### PR TITLE
Fix README: NumericalEarth is a registered package

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,14 +126,12 @@ which produces
 
 ## Installation
 
-NumericalEarth is not yet a registered package (we are working on it). To install from a Julia REPL:
+NumericalEarth is a [registered Julia package](https://julialang.org/packages/). To install from a Julia REPL:
 
 ```julia
 julia> using Pkg
 
-julia> Pkg.add("https://github.com/NumericalEarth/NumericalEarth.jl/")
-
-julia> Pkg.instantiate()
+julia> Pkg.add("NumericalEarth")
 ```
 
 Use `Pkg.add(url="https://github.com/NumericalEarth/NumericalEarth.jl.git", rev="main")` to install the latest development version.


### PR DESCRIPTION
## Summary
- The second "Installation" section (near the bottom of the README) incorrectly stated that NumericalEarth is not yet registered and directed users to install via the GitHub URL
- NumericalEarth is registered in the [General registry](https://github.com/JuliaRegistries/General/tree/master/N/NumericalEarth), so the instructions now match the first installation section: `Pkg.add("NumericalEarth")`
- Kept the `rev="main"` tip for installing the dev version

## Test plan
- [x] Verified NumericalEarth exists in the General registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)