### PR TITLE
Mask out immersed cells in flux computations

### DIFF
--- a/src/Oceans/assemble_net_ocean_fluxes.jl
+++ b/src/Oceans/assemble_net_ocean_fluxes.jl
@@ -1,4 +1,5 @@
 using Printf
+using Oceananigans.Grids: inactive_node
 using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ
 using Oceananigans.Forcings: MultipleForcings
 using NumericalEarth.EarthSystemModels: EarthSystemModel, NoOceanInterfaceModel, NoInterfaceModel


### PR DESCRIPTION
in the ocean, to avoid having fluxes populated on land