### PR TITLE
Revert build status for one-degree ocean simulation to `false`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -30,7 +30,7 @@ mkpath(OUTPUT_DIR)
 # on pushes to `main`/tags, or when the `build all examples` label is added to a PR.
 examples = [
     Example("Single-column ocean simulation", "single_column_os_papa_simulation", true),
-    Example("One-degree ocean--sea ice simulation", "one_degree_simulation", true), # true for the moment, then revert
+    Example("One-degree ocean--sea ice simulation", "one_degree_simulation", false),
     Example("Near-global ocean simulation", "near_global_ocean_simulation", false),
     Example("Global climate simulation", "global_climate_simulation", false),
     Example("Veros ocean simulation", "veros_ocean_forced_simulation", false),


### PR DESCRIPTION
This was set to true for debugging in #91. Changed the build status of the one-degree ocean-sea ice simulation example to false.
