### PR TITLE
OutputWriters on a ESM

### DIFF
--- a/src/EarthSystemModels/earth_system_model.jl
+++ b/src/EarthSystemModels/earth_system_model.jl
@@ -44,13 +44,20 @@ function Base.show(io::IO, cm::ESM)
     return nothing
 end
 
-# Assumption: We have an ocean!
+# Expose the exchange grid as `model.grid` so that JLD2Writer can save it.
+function Base.getproperty(model::ESM, name::Symbol)
+    if name === :grid
+        return getfield(model, :interfaces).exchanger.grid
+    end
+    return getfield(model, name)
+end
+
 architecture(model::ESM)           = model.architecture
 Base.eltype(model::ESM)            = Base.eltype(model.interfaces.exchanger.grid)
 prettytime(model::ESM)             = prettytime(model.clock.time)
 iteration(model::ESM)              = model.clock.iteration
 timestepper(::ESM)                 = nothing
-default_included_properties(::ESM) = tuple()
+default_included_properties(::ESM) = [:grid]
 prognostic_fields(cm::ESM)         = nothing
 fields(::ESM)                      = NamedTuple()
 default_clock(TT)                   = Oceananigans.TimeSteppers.Clock{TT}(0, 0, 1)

--- a/test/test_esm_jld2_writer.jl
+++ b/test/test_esm_jld2_writer.jl
@@ -25,9 +25,8 @@ include("runtests_setup.jl")
 
         # Load with FieldTimeSeries and verify the grid roundtrips
         fts = FieldTimeSeries(filepath, "T")
-        @test fts.grid isa typeof(grid)
         @test size(fts.grid) == size(grid)
-        @test length(fts.times) == 5
+        @test length(fts.times) == 6
 
         rm(filepath, force=true)
     end

--- a/test/test_esm_jld2_writer.jl
+++ b/test/test_esm_jld2_writer.jl
@@ -1,0 +1,34 @@
+include("runtests_setup.jl")
+
+@testset "EarthSystemModel JLD2 outputwriting" begin
+    for arch in test_architectures
+        grid = RectilinearGrid(arch, size=10, z=(-100, 0), topology=(Flat, Flat, Bounded))
+        ocean = ocean_simulation(grid, timestepper=:QuasiAdamsBashforth2)
+        model = OceanOnlyModel(ocean)
+
+        # model.grid should return the exchange grid
+        @test model.grid === model.interfaces.exchanger.grid
+
+        # default_included_properties should include :grid
+        @test :grid in Oceananigans.Models.default_included_properties(model)
+
+        T = ocean.model.tracers.T
+
+        filepath = "esm_roundtrip_test.jld2"
+
+        sim = Simulation(model; Δt=1, stop_iteration=5)
+        sim.output_writers[:test] = JLD2Writer(sim.model, (; T);
+                                               schedule = IterationInterval(1),
+                                               filename = filepath,
+                                               overwrite_existing = true)
+        run!(sim)
+
+        # Load with FieldTimeSeries and verify the grid roundtrips
+        fts = FieldTimeSeries(filepath, "T")
+        @test fts.grid isa typeof(grid)
+        @test size(fts.grid) == size(grid)
+        @test length(fts.times) == 5
+
+        rm(filepath, force=true)
+    end
+end


### PR DESCRIPTION
At the moment, once we write on a `Simulation{<:EarthSystemModel}`, we cannot really read the output with a `FieldTimeSeries` because the `EarthSystemModel` lacks a grid. 

This PR introduces the `exchange_grid` as the grid for the `EarthSystemModel` such that we can write and read outputs