### PR TITLE
Fix surface variables' range for Oceananigans' oceans

### DIFF
--- a/src/Oceans/Oceans.jl
+++ b/src/Oceans/Oceans.jl
@@ -74,12 +74,12 @@ ocean_temperature(ocean::Simulation{<:HydrostaticFreeSurfaceModel}) = ocean.mode
 
 function ocean_surface_salinity(ocean::Simulation{<:HydrostaticFreeSurfaceModel})
     kᴺ = size(ocean.model.grid, 3)
-    return interior(ocean.model.tracers.S, :, :, kᴺ:kᴺ)
+    return view(ocean.model.tracers.S.data, :, :, kᴺ:kᴺ)
 end
 
 function ocean_surface_temperature(ocean::Simulation{<:HydrostaticFreeSurfaceModel})
     kᴺ = size(ocean.model.grid, 3)
-    return interior(ocean.model.tracers.T, :, :, kᴺ:kᴺ)
+    return view(ocean.model.tracers.T.data, :, :, kᴺ:kᴺ)
 end
 
 function ocean_surface_velocities(ocean::Simulation{<:HydrostaticFreeSurfaceModel})


### PR DESCRIPTION
After https://github.com/CliMA/Oceananigans.jl/pull/5408, we have switched `:xy` to mean `Nx, Ny+1, Nz` for a `RIghtFaceFolded` tripolar grid. For this reason, the `_assemble_net_ocean_fluxes!` which needs access to surface salinity fails because we pass the `interior` of the tracers.

This PR changes the surface variables to include the halos, so we are always safe.