### PR TITLE
Add meridional heat transport diagnostic using `v * T` method

### DIFF
--- a/examples/meridional_heat_transport_ecco.jl
+++ b/examples/meridional_heat_transport_ecco.jl
@@ -77,10 +77,9 @@ end
 # And add it as a callback to the simulation.
 add_callback!(simulation, progress, IterationInterval(200))
 
-mht_OHC = Field(meridional_heat_transport(esm, OceanHeatContentTendencyMethod()))
-mht_vT = Field(meridional_heat_transport(esm, MeridionalHeatFluxMethod()))
+mht = Field(meridional_heat_transport(esm))
 
-ocean.output_writers[:mth] = JLD2Writer(ocean.model, (; mht_vT, mht_OHC);
+ocean.output_writers[:mth] = JLD2Writer(ocean.model, (; mht);
                                         schedule = TimeInterval(3hours),
                                         filename = "ocean_one_degree_mht",
                                         overwrite_existing = true)
@@ -91,26 +90,22 @@ run!(simulation)
 
 using Oceananigans
 
-mht_OHC = FieldTimeSeries("ocean_one_degree_mht.jld2", "mht_OHC"; backend = OnDisk())
-mht_vT  = FieldTimeSeries("ocean_one_degree_mht.jld2", "mht_vT"; backend = OnDisk())
+mht  = FieldTimeSeries("ocean_one_degree_mht.jld2", "mht"; backend = OnDisk())
 
-times = mht_OHC.times
+times = mht.times
 Nt = length(times)
 
-grid = mht_OHC.grid
-Ny = size(mht_OHC.grid, 2)
+grid = mht.grid
+Ny = size(mht.grid, 2)
 
-mht_OHC_mean = deepcopy(mht_OHC[1][1, :, 1])
-mht_vT_mean  = deepcopy(mht_vT[1][1, :, 1])
+mht_mean  = deepcopy(mht[1][1, :, 1])
 
 for iter in 1:Nt
     @info "iteration $iter out of $Nt"
-    mht_OHC_mean += mht_OHC[iter][1, :, 1]
-    mht_vT_mean  +=  mht_vT[iter][1, :, 1]
+    mht_mean  +=  mht[iter][1, :, 1]
 end
 
-@. mht_OHC_mean = mht_OHC_mean / Nt
-@. mht_vT_mean = mht_vT_mean / Nt
+@. mht_mean = mht_mean / Nt
 
 using CairoMakie
 
@@ -119,7 +114,6 @@ ax = Axis(fig[1, 1], xlabel="latitude (deg)", ylabel="MHT (PW)")
 
 φ = φnodes(grid, Face())
 
-lines!(ax, φ, mht_OHC_mean[1:Ny+1] / 1e15, linewidth=4)
-lines!(ax, φ, mht_vT_mean[1:Ny+1]  / 1e15, linewidth=4)
+lines!(ax, φ, mht_mean[1:Ny+1]  / 1e15, linewidth=4)
 
 save("mht.png", fig)

--- a/examples/meridional_heat_transport_ecco.jl
+++ b/examples/meridional_heat_transport_ecco.jl
@@ -1,0 +1,125 @@
+using NumericalEarth
+using Oceananigans
+using Oceananigans.Units
+using Dates
+using Statistics
+using Printf
+
+using CUDA; CUDA.device!(3)
+
+arch = GPU()
+Nx = 360
+Ny = 180
+Nz = 50
+
+depth = 5000meters
+z = ExponentialDiscretization(Nz, -depth, 0; scale = depth/4)
+
+underlying_grid = TripolarGrid(arch; size = (Nx, Ny, Nz), halo = (5, 5, 4), z)
+underlying_grid = LatitudeLongitudeGrid(arch; size = (Nx, Ny, Nz), halo = (5, 5, 4), z, longitude = (0, 360), latitude = (-80, 80))
+bottom_height = regrid_bathymetry(underlying_grid;
+                                  minimum_depth = 10,
+                                  interpolation_passes = 10,
+                                  major_basins = 2)
+grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(bottom_height);
+                            active_cells_map=true)
+
+free_surface       = SplitExplicitFreeSurface(grid; substeps=70)
+momentum_advection = WENOVectorInvariant(order=5)
+tracer_advection   = WENO(order=5)
+vertical_mixing = NumericalEarth.Oceans.default_ocean_closure()
+ocean = ocean_simulation(grid; momentum_advection, tracer_advection, free_surface,
+                         closure=(vertical_mixing,))
+sea_ice = sea_ice_simulation(grid, ocean; advection=tracer_advection)
+
+date = DateTime(1993, 1, 1)
+dataset = ECCO4Monthly()
+ecco_temperature           = Metadatum(:temperature; date, dataset)
+ecco_salinity              = Metadatum(:salinity; date, dataset)
+ecco_sea_ice_thickness     = Metadatum(:sea_ice_thickness; date, dataset)
+ecco_sea_ice_concentration = Metadatum(:sea_ice_concentration; date, dataset)
+
+set!(ocean.model, T=ecco_temperature, S=ecco_salinity)
+set!(sea_ice.model, h=ecco_sea_ice_thickness, ℵ=ecco_sea_ice_concentration)
+
+radiation  = Radiation(arch)
+atmosphere = JRA55PrescribedAtmosphere(arch; backend=JRA55NetCDFBackend(80),
+                                       include_rivers_and_icebergs = false)
+esm = OceanSeaIceModel(ocean, sea_ice; atmosphere, radiation)
+
+simulation = Simulation(esm; Δt=20minutes, stop_time=5*365days)
+
+wall_time = Ref(time_ns())
+
+function progress(sim)
+    ocean = sim.model.ocean
+    u, v, w = ocean.model.velocities
+    T = ocean.model.tracers.T
+    e = ocean.model.tracers.e
+    Tmin, Tmax, Tavg = minimum(T), maximum(T), mean(view(T, :, :, ocean.model.grid.Nz))
+    emax = maximum(e)
+    umax = (maximum(abs, u), maximum(abs, v), maximum(abs, w))
+
+    step_time = 1e-9 * (time_ns() - wall_time[])
+
+    msg1 = @sprintf("time: %s, iter: %d", prettytime(sim), iteration(sim))
+    msg2 = @sprintf(", max|uo|: (%.1e, %.1e, %.1e) m s⁻¹", umax...)
+    msg3 = @sprintf(", max(e): %.2f m² s⁻²", emax)
+    msg4 = @sprintf(", wall time: %s \n", prettytime(step_time))
+
+    @info msg1 * msg2 * msg3 * msg4
+
+    wall_time[] = time_ns()
+
+     return nothing
+end
+
+# And add it as a callback to the simulation.
+add_callback!(simulation, progress, IterationInterval(200))
+
+mht_OHC = Field(meridional_heat_transport(esm, OceanHeatContentTendencyMethod()))
+mht_vT = Field(meridional_heat_transport(esm, MeridionalHeatFluxMethod()))
+
+ocean.output_writers[:mth] = JLD2Writer(ocean.model, (; mht_vT, mht_OHC);
+                                        schedule = TimeInterval(3hours),
+                                        filename = "ocean_one_degree_mht",
+                                        overwrite_existing = true)
+
+run!(simulation)
+
+##
+
+using Oceananigans
+
+mht_OHC = FieldTimeSeries("ocean_one_degree_mht.jld2", "mht_OHC"; backend = OnDisk())
+mht_vT  = FieldTimeSeries("ocean_one_degree_mht.jld2", "mht_vT"; backend = OnDisk())
+
+times = mht_OHC.times
+Nt = length(times)
+
+grid = mht_OHC.grid
+Ny = size(mht_OHC.grid, 2)
+
+mht_OHC_mean = deepcopy(mht_OHC[1][1, :, 1])
+mht_vT_mean  = deepcopy(mht_vT[1][1, :, 1])
+
+for iter in 1:Nt
+    @info "iteration $iter out of $Nt"
+    mht_OHC_mean += mht_OHC[iter][1, :, 1]
+    mht_vT_mean  +=  mht_vT[iter][1, :, 1]
+end
+
+@. mht_OHC_mean = mht_OHC_mean / Nt
+@. mht_vT_mean = mht_vT_mean / Nt
+
+using CairoMakie
+
+fig = Figure()
+ax = Axis(fig[1, 1], xlabel="latitude (deg)", ylabel="MHT (PW)")
+
+φ = φnodes(grid, Face())
+
+lines!(ax, φ, mht_OHC_mean[1:Ny+1] / 1e15, linewidth=4)
+lines!(ax, φ, mht_vT_mean[1:Ny+1]  / 1e15, linewidth=4)
+
+save("mht.png", fig)

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -1,6 +1,7 @@
 module Diagnostics
 
 export MixedLayerDepthField, MixedLayerDepthOperand
+export meridional_heat_transport
 export frazil_temperature_flux, net_ocean_temperature_flux, sea_ice_ocean_temperature_flux, atmosphere_ocean_temperature_flux,
        frazil_heat_flux, net_ocean_heat_flux, sea_ice_ocean_heat_flux, atmosphere_ocean_heat_flux,
        net_ocean_salinity_flux, sea_ice_ocean_salinity_flux, atmosphere_ocean_salinity_flux,
@@ -19,6 +20,7 @@ using NumericalEarth.EarthSystemModels: EarthSystemModel
 import Oceananigans.Fields: compute!
 
 include("mixed_layer_depth.jl")
+include("meridional_heat_transport.jl")
 include("interface_fluxes.jl")
 
 end # module

--- a/src/Diagnostics/meridional_heat_transport.jl
+++ b/src/Diagnostics/meridional_heat_transport.jl
@@ -1,0 +1,95 @@
+using ..EarthSystemModels: EarthSystemModel, reference_density, heat_capacity
+
+"""
+    meridional_heat_transport(esm::EarthSystemModel;
+                              reference_temperature = 0)
+
+Return the meridional heat transport for the coupled `esm::EarthSystemModel` by computing
+the meridional heat flux.
+
+The meridional heat transport is computed via:
+
+```math
+\\mathrm{MHT} ≡ ρᵒᶜ cᵒᶜ ∫  v (T - T_{\\rm ref}) \\, \\mathrm{d}x \\, \\mathrm{d}z
+```
+
+Above, ``T_{\\rm ref}`` is a reference temperature and ``ρᵒᶜ`` and ``cᵒᶜ`` are the
+ocean reference density and specific heat capacity respectively.
+
+!!! warning "Only works on LatitudeLongitudeGrid"
+
+    The `meridional_heat_transport` diagnostic currently is only supported only on
+    `LongitudeLatitudeGrid`s.
+
+Arguments
+=========
+
+* `esm`: An EarthSystemModel.
+
+
+Keyword Arguments
+=================
+
+* `reference_temperature`: The reference temperature (in ᵒC) used for the calculation; default: 0 ᵒC.
+
+  !!! info "Reference temperature"
+
+      The reference temperature is only relevant when we compute the meridional heat transport over a section
+      where there is a net volume transport. If we are computing the diagnostic globally, i.e., around a whole
+      latitude circle, then by necessity there is no net volume transport and thus the reference temperature
+      value is irrelevant. Section-averaged transport could also be considered as a reference temperature to
+      remove residual barotropic volume fluxes in basin-scale/regional analyses where a net volume transport
+      is present.
+
+Example
+=======
+
+```jldoctest
+using NumericalEarth
+using Oceananigans
+
+grid = RectilinearGrid(size = (4, 5, 2), extent = (1, 1, 1),
+                       topology = (Periodic, Bounded, Bounded))
+
+ocean = ocean_simulation(grid;
+                         momentum_advection = nothing,
+                         tracer_advection = nothing,
+                         closure = nothing,
+                         coriolis = nothing)
+
+sea_ice = sea_ice_simulation(grid, ocean)
+
+atmosphere = PrescribedAtmosphere(grid, [0.0])
+
+esm = OceanSeaIceModel(ocean, sea_ice; atmosphere, radiation = Radiation())
+
+mht = meridional_heat_transport(esm)
+
+# output
+
+Integral of BinaryOperation at (Center, Face, Center) over dims (1, 3)
+└── operand: BinaryOperation at (Center, Face, Center)
+    └── grid: 4×5×2 RectilinearGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×2 halo
+```
+"""
+function meridional_heat_transport(esm::EarthSystemModel; reference_temperature=0)
+
+    grid = esm.ocean.model.grid
+
+    validation_grid = grid isa ImmersedBoundaryGrid ? grid.underlying_grid : grid
+
+    grid isa OrthogonalSphericalShellGrid &&
+        throw(ArgumentError("meridional_heat_transport diagnostic does not work on OrthogonalSphericalShellGrid at the moment; use LatitudeLongitudeGrid."))
+
+    FT = eltype(esm)
+    reference_temperature = convert(FT, reference_temperature)
+
+    ρᵒᶜ = reference_density(esm.ocean)
+    cᵒᶜ = heat_capacity(esm.ocean)
+
+    T = esm.ocean.model.tracers.T
+    v = esm.ocean.model.velocities.v
+
+    MHT = Integral(ρᵒᶜ * cᵒᶜ * v * (T - reference_temperature), dims=(1, 3))
+    return MHT
+end

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -55,7 +55,8 @@ export
     frazil_temperature_flux, net_ocean_temperature_flux, sea_ice_ocean_temperature_flux, atmosphere_ocean_temperature_flux,
     frazil_heat_flux, net_ocean_heat_flux, sea_ice_ocean_heat_flux, atmosphere_ocean_heat_flux,
     net_ocean_salinity_flux, sea_ice_ocean_salinity_flux, atmosphere_ocean_salinity_flux,
-    net_ocean_freshwater_flux, sea_ice_ocean_freshwater_flux, atmosphere_ocean_freshwater_flux
+    net_ocean_freshwater_flux, sea_ice_ocean_freshwater_flux, atmosphere_ocean_freshwater_flux,
+    meridional_heat_transport
 
 using Oceananigans
 using Oceananigans.Operators: ℑxyᶠᶜᵃ, ℑxyᶜᶠᵃ

--- a/test/test_diagnostics_2.jl
+++ b/test/test_diagnostics_2.jl
@@ -11,9 +11,9 @@ for arch in test_architectures
 
     @testset "InterfaceFluxOutputs on $A" begin
         grid = RectilinearGrid(arch;
-                               size = (4, 4, 2),
+                               size = (4, 5, 2),
                                extent = (1, 1, 1),
-                               topology = (Periodic, Periodic, Bounded))
+                               topology = (Periodic, Bounded, Bounded))
 
         ocean = ocean_simulation(grid;
                                  momentum_advection = nothing,


### PR DESCRIPTION
This is a spin off from https://github.com/NumericalEarth/NumericalEarth.jl/pull/89

I propose we add here the  method for which the budget closes, that is only the yellow one from the figure in https://github.com/NumericalEarth/NumericalEarth.jl/pull/89#issuecomment-4056734234

We can then leave the ocean heat content method for https://github.com/NumericalEarth/NumericalEarth.jl/pull/89.