### PR TITLE
Revert CATKE mixing length to calibrated default

### DIFF
--- a/src/Oceans/ocean_simulation.jl
+++ b/src/Oceans/ocean_simulation.jl
@@ -79,9 +79,8 @@ function default_free_surface(grid::DistributedGrid;
 end
 
 function default_ocean_closure(FT=Oceananigans.defaults.FloatType)
-    mixing_length = CATKEMixingLength(Cᵇ=0.01)
     turbulent_kinetic_energy_equation = CATKEEquation(Cᵂϵ=1.0)
-    return CATKEVerticalDiffusivity(VerticallyImplicitTimeDiscretization(), FT; mixing_length, turbulent_kinetic_energy_equation)
+    return CATKEVerticalDiffusivity(VerticallyImplicitTimeDiscretization(), FT; turbulent_kinetic_energy_equation)
 end
 
 function default_radiative_forcing(grid)


### PR DESCRIPTION
## Summary

- Remove the ad-hoc override `CATKEMixingLength(Cᵇ=0.01)` in `default_ocean_closure()` and use the published calibrated default (`Cᵇ=0.28`, Wagner et al. 2025).

## Motivation

The parameter `Cᵇ` controls the bottom-distance constraint on the CATKE stable mixing length:

```
ℓ = min(Cˢ × d_surface, Cᵇ × d_bottom, w★/√N²)
```

With `Cᵇ = 0.01` (28× smaller than the calibrated value of 0.28), the bottom term becomes the **tightest constraint** for nearly all depths below ~50 m, regardless of ocean depth. In a 5 km deep ocean:

| Depth | `Cˢ × d_up` | `Cᵇ × d_down` (0.01) | `Cᵇ × d_down` (0.28) |
|---|---|---|---|
| 50 m  | 56 m  | **49 m** | 1386 m |
| 100 m | 113 m | **49 m** | 1372 m |
| 500 m | 565 m | **45 m** | 1260 m |

This artificially caps the mixing length at ~50 m everywhere, directly suppressing the vertical diffusivity `κ = ℓ × √e` and producing unrealistically shallow mixed layer depths globally.

Below are the MLD diagnostics from an 8-year OMIP run on the `ss/omip-prototype` branch (two configurations: half-degree TripolarGrid and ORCA-NCAR). Both cases show winter MLD barely reaching 50–100 m, far shallower than observed values (500–2000 m in the Labrador Sea, 200–500 m in the Southern Ocean):

<img width="3200" height="1800" alt="fig04_mld" src="https://github.com/user-attachments/assets/41a0eb96-be08-4b19-b8ba-76d7cd879947" />

> **Note**: the figure above corresponds to runs performed from the `ss/omip-prototype` branch using `CATKEMixingLength(Cᵇ=0.01)`.

## Test plan

- [ ] CI passes (the change is a parameter default, no API change)
- [ ] Re-run OMIP simulation and verify deeper MLD in key convection regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)