### PR TITLE
Fix to the WindDependentWaveFormulation of the gravity_wave_parameter

### DIFF
--- a/src/EarthSystemModels/InterfaceComputations/roughness_lengths.jl
+++ b/src/EarthSystemModels/InterfaceComputations/roughness_lengths.jl
@@ -37,7 +37,7 @@ WindDependentWaveFormulation(FT=Oceananigans.defaults.FloatType; Umax = 19, ℂ�
                                  convert(FT, ℂ₂))
 
 gravity_wave_parameter(α::Number, args...) = α
-gravity_wave_parameter(α::WindDependentWaveFormulation, ΔU) = α.ℂ₁ * min(ΔU, α.Umax) + α.ℂ₂
+gravity_wave_parameter(α::WindDependentWaveFormulation, ΔU) = max(zero(ΔU), α.ℂ₁ * min(ΔU, α.Umax) + α.ℂ₂)
 
 """
     ScalarRoughnessLength(FT = Float64;


### PR DESCRIPTION
with these defaults, the `gravity_wave_parameter` becomes negative for `ΔU < 2.94` m/s.
The correct approach is to limit the "turbulent" gravity wave parameter to zero for low wind limits