### PR TITLE
Fix default penetrating radiation

### DIFF
--- a/src/Oceans/ocean_simulation.jl
+++ b/src/Oceans/ocean_simulation.jl
@@ -84,14 +84,16 @@ function default_ocean_closure(FT=Oceananigans.defaults.FloatType)
     return CATKEVerticalDiffusivity(VerticallyImplicitTimeDiscretization(), FT; mixing_length, turbulent_kinetic_energy_equation)
 end
 
+# Two-band shortwave penetration in the Paulson & Simpson (1977) form,
+# Defaults are Jerlov Type I (clearest open-ocean water)
 function default_radiative_forcing(grid)
-    ϵʳ = 0.6 # red fraction
-    λʳ = 1  # red decay scale
-    λᵇ = 16 # blue decay scale
+    surface_fraction = 0.58  # Paulson & Simpson 1977, Table 2, Type I
+    surface_scale    = 0.35  # [m]
+    deep_scale       = 23    # [m]
     forcing = TwoColorRadiation(grid;
-                                first_color_fraction = ϵʳ,
-                                first_absorption_coefficient = 1/λᵇ,
-                                second_absorption_coefficient = 1/λʳ)
+                                first_color_fraction          = surface_fraction,
+                                first_absorption_coefficient  = 1 / surface_scale,
+                                second_absorption_coefficient = 1 / deep_scale)
     return forcing
 end
 


### PR DESCRIPTION
The default radiation we have swaps the % of penetrating vs fast-absorbing radiation.
This PR aligns the default with Paulson (1977), the default for an OMIP simulation corresponding to the clearest possible water that has a 43% penetration.