### PR TITLE
Improve test robustness

### DIFF
--- a/ext/NumericalEarthWOAExt.jl
+++ b/ext/NumericalEarthWOAExt.jl
@@ -15,9 +15,9 @@ const fallback_product_years = (2023, 2018, 2013)
 function woa_filepath(woa_tracer, product_year, period)
     # Try user-specified product year first
     try
-        return WorldOceanAtlasTools.WOAfile(woa_tracer;
-                                            product_year, period, resolution=1)
-    catch
+        return WorldOceanAtlasTools.WOAfile(woa_tracer; product_year, period, resolution=1)
+    catch e
+        @warn "Errored with exception $(e)"
     end
 
     # Fall back to other product years
@@ -25,9 +25,9 @@ function woa_filepath(woa_tracer, product_year, period)
         py == product_year && continue
         try
             @info "WOA product year $product_year unavailable for tracer \"$woa_tracer\", trying $py..."
-            return WorldOceanAtlasTools.WOAfile(woa_tracer;
-                                                product_year=py, period, resolution=1)
-        catch
+            return WorldOceanAtlasTools.WOAfile(woa_tracer; product_year=py, period, resolution=1)
+        catch e
+            @warn "Errored with exception $(e)"
         end
     end
 
@@ -50,9 +50,8 @@ function download_dataset(metadata::Metadata{<:WOAClimatology}; skip_existing=tr
         # Trigger DataDeps download and get the path to the original WOA file
         source = woa_filepath(woa_tracer, product_year, period)
 
-        # Symlink to avoid duplicating the data
         rm(linkpath; force=true)
-        symlink(source, linkpath)
+        cp(source, linkpath)
     end
 
     return nothing

--- a/test/test_bathymetry.jl
+++ b/test/test_bathymetry.jl
@@ -1,4 +1,5 @@
 include("runtests_setup.jl")
+include("download_utils.jl")
 
 using JLD2
 using NumericalEarth.Bathymetry: remove_minor_basins!,
@@ -13,10 +14,13 @@ using Statistics
     @info "Testing Bathymetry construction and smoothing..."
     for arch in test_architectures
         ETOPOmetadata = Metadatum(:bottom_height, dataset=ETOPO2022())
+        filepath = metadata_path(ETOPOmetadata)
 
         # Testing downloading
-        NumericalEarth.DataWrangling.download_dataset(ETOPOmetadata)
-        @test isfile(metadata_path(ETOPOmetadata))
+        download_dataset_with_fallback(filepath; dataset_name="ETOPO2022") do
+            NumericalEarth.DataWrangling.download_dataset(ETOPOmetadata)
+        end
+        @test isfile(filepath)
 
         grid = LatitudeLongitudeGrid(arch;
                                      size = (100, 100, 10),

--- a/test/test_cds_downloading.jl
+++ b/test/test_cds_downloading.jl
@@ -1,4 +1,5 @@
 include("runtests_setup.jl")
+include("download_utils.jl")
 
 using CDSAPI
 using Dates
@@ -27,8 +28,10 @@ start_date = DateTime(2005, 2, 16, 12)
         filepath = metadata_path(metadatum)
         isfile(filepath) && rm(filepath; force=true)
 
-        # Download the data
-        download_dataset(metadatum)
+        # Download the data (falls back to NumericalEarthArtifacts if CDS is unreachable)
+        download_dataset_with_fallback(filepath; dataset_name="ERA5Hourly $variable") do
+            download_dataset(metadatum)
+        end
         @test isfile(filepath)
 
         # Verify the NetCDF file structure
@@ -140,9 +143,11 @@ start_date = DateTime(2005, 2, 16, 12)
             variable = :temperature
             metadatum = Metadatum(variable; dataset, bounding_box, date=start_date)
 
-            # Download if not present
+            # Download if not present (falls back to NumericalEarthArtifacts if CDS is unreachable)
             filepath = metadata_path(metadatum)
-            isfile(filepath) || download_dataset(metadatum)
+            isfile(filepath) || download_dataset_with_fallback(filepath; dataset_name="ERA5Hourly $variable") do
+                download_dataset(metadatum)
+            end
 
             # Create a Field from the downloaded data
             ψ = Field(metadatum, arch)
@@ -167,9 +172,11 @@ start_date = DateTime(2005, 2, 16, 12)
             variable = :temperature
             metadatum = Metadatum(variable; dataset, bounding_box, date=start_date)
 
-            # Download if not present
+            # Download if not present (falls back to NumericalEarthArtifacts if CDS is unreachable)
             filepath = metadata_path(metadatum)
-            isfile(filepath) || download_dataset(metadatum)
+            isfile(filepath) || download_dataset_with_fallback(filepath; dataset_name="ERA5Hourly $variable") do
+                download_dataset(metadatum)
+            end
 
             # Create a target grid matching the bounding box region
             grid = LatitudeLongitudeGrid(arch;

--- a/test/test_ecco2_daily.jl
+++ b/test/test_ecco2_daily.jl
@@ -1,4 +1,5 @@
 include("runtests_setup.jl")
+include("download_utils.jl")
 
 using NumericalEarth
 using NumericalEarth.DataWrangling: NearestNeighborInpainting, metadata_path, native_times, download_dataset
@@ -31,7 +32,12 @@ for arch in test_architectures
             for name in (:temperature, :salinity)
                 metadata = Metadata(name; dates, dataset)
 
-                download_dataset(metadata) # just in case is not downloaded
+                # just in case is not downloaded; fall back to NumericalEarthArtifacts
+                # if the primary source is unreachable
+                filepaths = [metadata_path(datum) for datum in metadata]
+                download_dataset_with_fallback(filepaths; dataset_name="$D $name") do
+                    download_dataset(metadata)
+                end
                 for datum in metadata
                     @test isfile(metadata_path(datum))
                 end

--- a/test/test_ecco2_monthly.jl
+++ b/test/test_ecco2_monthly.jl
@@ -1,4 +1,5 @@
 include("runtests_setup.jl")
+include("download_utils.jl")
 
 using NumericalEarth
 using NumericalEarth.ECCO
@@ -37,7 +38,12 @@ for arch in test_architectures, dataset in test_ecco_datasets
                 for name in test_names[dataset]
                     metadata = Metadata(name; dates, dataset)
 
-                    download_dataset(metadata) # just in case is not downloaded
+                    # just in case is not downloaded; fall back to NumericalEarthArtifacts
+                    # if the primary source is unreachable
+                    filepaths = [metadata_path(datum) for datum in metadata]
+                    download_dataset_with_fallback(filepaths; dataset_name="$D $name") do
+                        download_dataset(metadata)
+                    end
                     for datum in metadata
                         @test isfile(metadata_path(datum))
                     end

--- a/test/test_ecco4_en4.jl
+++ b/test/test_ecco4_en4.jl
@@ -1,4 +1,5 @@
 include("runtests_setup.jl")
+include("download_utils.jl")
 
 using NumericalEarth
 using NumericalEarth.ECCO
@@ -34,7 +35,12 @@ for arch in test_architectures, dataset in test_ecco_en4_datasets
             for name in test_names[dataset]
                 metadata = Metadata(name; dates, dataset)
 
-                download_dataset(metadata) # just in case is not downloaded
+                # just in case is not downloaded; fall back to NumericalEarthArtifacts
+                # if the primary source is unreachable
+                filepaths = [metadata_path(datum) for datum in metadata]
+                download_dataset_with_fallback(filepaths; dataset_name="$D $name") do
+                    download_dataset(metadata)
+                end
                 for datum in metadata
                     @test isfile(metadata_path(datum))
                 end

--- a/test/test_glorys_downloading.jl
+++ b/test/test_glorys_downloading.jl
@@ -1,4 +1,5 @@
 include("runtests_setup.jl")
+include("download_utils.jl")
 
 using CopernicusMarine
 
@@ -10,6 +11,8 @@ using CopernicusMarine
         metadatum = Metadatum(variable; dataset, bounding_box)
         filepath = NumericalEarth.DataWrangling.metadata_path(metadatum)
         isfile(filepath) && rm(filepath; force=true)
-        NumericalEarth.DataWrangling.download_dataset(metadatum)
+        download_dataset_with_fallback(filepath; dataset_name="GLORYSDaily $variable") do
+            NumericalEarth.DataWrangling.download_dataset(metadatum)
+        end
     end
 end

--- a/test/test_woa.jl
+++ b/test/test_woa.jl
@@ -11,11 +11,8 @@ using WorldOceanAtlasTools
 
 inpainting = NearestNeighborInpainting(10)
 
-# Ensure a WOA Metadatum file is on disk, trying NOAA first and falling back
-# to the NumericalEarthArtifacts mirror. Field(...) and set!(...) rely on the
-# file already being present — see metadata_field.jl for the internal download
-# path — so this helper is called before any Field / set! that references the
-# same metadatum.
+# Ensure a WOA Metadatum file is on disk, trying NOAA first 
+# and falling back to the NumericalEarthArtifacts mirror.
 function ensure_woa_file(metadatum; label)
     filepath = metadata_path(metadatum)
     download_dataset_with_fallback(filepath; dataset_name=label) do

--- a/test/test_woa.jl
+++ b/test/test_woa.jl
@@ -1,4 +1,5 @@
 include("runtests_setup.jl")
+include("download_utils.jl")
 
 ENV["DATADEPS_ALWAYS_ACCEPT"] = "true"
 
@@ -10,6 +11,19 @@ using WorldOceanAtlasTools
 
 inpainting = NearestNeighborInpainting(10)
 
+# Ensure a WOA Metadatum file is on disk, trying NOAA first and falling back
+# to the NumericalEarthArtifacts mirror. Field(...) and set!(...) rely on the
+# file already being present — see metadata_field.jl for the internal download
+# path — so this helper is called before any Field / set! that references the
+# same metadatum.
+function ensure_woa_file(metadatum; label)
+    filepath = metadata_path(metadatum)
+    download_dataset_with_fallback(filepath; dataset_name=label) do
+        download_dataset(metadatum)
+    end
+    return filepath
+end
+
 for arch in test_architectures
     A = typeof(arch)
 
@@ -19,8 +33,8 @@ for arch in test_architectures
         @testset "WOA Annual download and Field creation" begin
             for name in (:temperature, :salinity)
                 metadata = Metadatum(name; dataset=WOAAnnual())
-                download_dataset(metadata)
-                @test isfile(metadata_path(metadata))
+                filepath = ensure_woa_file(metadata; label="WOA Annual $name")
+                @test isfile(filepath)
 
                 field = Field(metadata, arch; inpainting=NearestNeighborInpainting(2))
                 @test field isa Field
@@ -40,8 +54,10 @@ for arch in test_architectures
             field = CenterField(grid)
 
             for name in (:temperature, :salinity)
+                metadatum = Metadatum(name; dataset=WOAAnnual())
+                ensure_woa_file(metadatum; label="WOA Annual $name")
                 @test begin
-                    set!(field, Metadatum(name; dataset=WOAAnnual()); inpainting)
+                    set!(field, metadatum; inpainting)
                     true
                 end
             end
@@ -50,6 +66,7 @@ for arch in test_architectures
         @testset "WOA Annual inpainting" begin
             for name in (:temperature, :salinity)
                 metadatum = Metadatum(name; dataset=WOAAnnual())
+                ensure_woa_file(metadatum; label="WOA Annual $name")
 
                 grid = LatitudeLongitudeGrid(arch,
                                              size = (20, 20, 10),
@@ -79,8 +96,8 @@ for arch in test_architectures
         @testset "WOA Monthly download and Field creation" begin
             for name in (:temperature, :salinity)
                 metadata = Metadatum(name; dataset=WOAMonthly())
-                download_dataset(metadata)
-                @test isfile(metadata_path(metadata))
+                filepath = ensure_woa_file(metadata; label="WOA Monthly $name")
+                @test isfile(filepath)
 
                 field = Field(metadata, arch; inpainting=NearestNeighborInpainting(2))
                 @test field isa Field
@@ -96,8 +113,10 @@ for arch in test_architectures
             field = CenterField(grid)
 
             for name in (:temperature, :salinity)
+                metadatum = Metadatum(name; dataset=WOAMonthly())
+                ensure_woa_file(metadatum; label="WOA Monthly $name")
                 @test begin
-                    set!(field, Metadatum(name; dataset=WOAMonthly()); inpainting)
+                    set!(field, metadatum; inpainting)
                     true
                 end
             end


### PR DESCRIPTION
I have uploaded all the data used for tests at https://github.com/NumericalEarth/NumericalEarthArtifacts/. In this way, if a test fails because a source is unreachable, the testset will not be broken. 

This PR updates all the data locations to use the fallback in case of failure.

Closes #183 