### PR TITLE
Add hdf5 version constraint in `install_veros` function

### DIFF
--- a/ext/NumericalEarthVerosExt/veros_ocean_simulation.jl
+++ b/ext/NumericalEarthVerosExt/veros_ocean_simulation.jl
@@ -29,6 +29,7 @@ Returns a NamedTuple containing package information if successful.
 Also patches Veros's signal handling to work with PythonCall.
 """
 function install_veros()
+    CondaPkg.add("hdf5"; version="<2", channel="conda-forge") # Veros uses hdf5 version < 2. Therefore we pin it to prevent dependency issues
     CondaPkg.add_pip("veros", version="@ https://github.com/team-ocean/veros/archive/refs/heads/main.zip")
     cli = CondaPkg.which("veros")
     


### PR DESCRIPTION
Pin hdf5 version to prevent dependency issues. Apparently new versions of hdf5 are incompatible with veros. Sometimes th e tests pick up hdf5 v>=2 leading to test flakyness. Hopefully pinning to a version < 2 will solve test flakyness.


