### PR TITLE
Reduce burden on the CPU testing suite

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ if filter_tests!(testsuite, args)
         delete!(testsuite, "test_ocean_sea_ice_model")
         delete!(testsuite, "test_diagnostics_1")
         delete!(testsuite, "test_ecco2_daily")
+        delete!(testsuite, "test_orca_grid")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,11 +29,17 @@ if filter_tests!(testsuite, args)
     delete!(testsuite, "test_distributed_utils")
     delete!(testsuite, "test_reactant")
 
-    # Remove CPU-only tests when
-    # testing on GPUs
     if gpu_test
+        # Remove CPU-only tests when testing on GPUs
         delete!(testsuite, "test_veros")
         delete!(testsuite, "test_speedy_coupling")
+    else
+        # Remove the slowest tests from CPU CI to keep total runtime
+        # manageable; GPU CI still runs them. See issue #193.
+        delete!(testsuite, "test_ocean_only_model")
+        delete!(testsuite, "test_ocean_sea_ice_model")
+        delete!(testsuite, "test_diagnostics_1")
+        delete!(testsuite, "test_ecco2_daily")
     end
 end
 


### PR DESCRIPTION
The heaviest tests blow up the testing time on the CPU job.
These tests, however are also repeated on (faster) GPU workers. To speed up the testing infrastructure we keep the heaviest tests only on the GPU which is a more stringent testing hardware