### PR TITLE
Reinitialize download progress when dowloading a new file

### DIFF
--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -36,10 +36,12 @@ import Oceananigans.Fields: set!
 ##### Downloading utilities
 #####
 
-Base.@kwdef struct DownloadProgress
-    next_fraction :: Base.RefValue{Float64} = Ref(0.0)
-    download_start_time :: Base.RefValue{UInt64} = Ref(time_ns())
+mutable struct DownloadProgress
+    next_fraction :: Float64
+    download_start_time :: UInt64
 end
+
+DownloadProgress() = DownloadProgress(0.0, time_ns())
 
 """
     DownloadProgress(total, now; filename="")
@@ -50,24 +52,24 @@ function (d::DownloadProgress)(total, now; filename="")
     if total > 0
         fraction = now / total
 
-        if fraction < 1 / messages && d.next_fraction[] == 0
+        if fraction < 1 / messages && d.next_fraction == 0
             @info @sprintf("Downloading %s (size: %s)...", filename, pretty_filesize(total))
-            d.next_fraction[] = 1 / messages
-            d.download_start_time[] = time_ns()
+            d.next_fraction = 1 / messages
+            d.download_start_time = time_ns()
         end
 
-        if fraction > d.next_fraction[]
-            elapsed = 1e-9 * (time_ns() - d.download_start_time[])
+        if fraction > d.next_fraction
+            elapsed = 1e-9 * (time_ns() - d.download_start_time)
             msg = @sprintf(" ... downloaded %s (%d%% complete, %s)", pretty_filesize(now),
                            100fraction, prettytime(elapsed))
             @info msg
-            d.next_fraction[] = d.next_fraction[] + 1 / messages
+            d.next_fraction = d.next_fraction + 1 / messages
         end
     else
-        if now > 0 && d.next_fraction[] == 0
+        if now > 0 && d.next_fraction == 0
             @info "Downloading $filename..."
-            d.next_fraction[] = 1 / messages
-            d.download_start_time[] = time_ns()
+            d.next_fraction = 1 / messages
+            d.download_start_time = time_ns()
         end
     end
 

--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -36,36 +36,38 @@ import Oceananigans.Fields: set!
 ##### Downloading utilities
 #####
 
-next_fraction = Ref(0.0)
-download_start_time = Ref(time_ns())
+Base.@kwdef struct DownloadProgress
+    next_fraction :: Base.RefValue{Float64} = Ref(0.0)
+    download_start_time :: Base.RefValue{UInt64} = Ref(time_ns())
+end
 
 """
-    download_progress(total, now; filename="")
+    DownloadProgress(total, now; filename="")
 """
-function download_progress(total, now; filename="")
+function (d::DownloadProgress)(total, now; filename="")
     messages = 10
 
     if total > 0
         fraction = now / total
 
-        if fraction < 1 / messages && next_fraction[] == 0
+        if fraction < 1 / messages && d.next_fraction[] == 0
             @info @sprintf("Downloading %s (size: %s)...", filename, pretty_filesize(total))
-            next_fraction[] = 1 / messages
-            download_start_time[] = time_ns()
+            d.next_fraction[] = 1 / messages
+            d.download_start_time[] = time_ns()
         end
 
-        if fraction > next_fraction[]
-            elapsed = 1e-9 * (time_ns() - download_start_time[])
+        if fraction > d.next_fraction[]
+            elapsed = 1e-9 * (time_ns() - d.download_start_time[])
             msg = @sprintf(" ... downloaded %s (%d%% complete, %s)", pretty_filesize(now),
                            100fraction, prettytime(elapsed))
             @info msg
-            next_fraction[] = next_fraction[] + 1 / messages
+            d.next_fraction[] = d.next_fraction[] + 1 / messages
         end
     else
-        if now > 0 && next_fraction[] == 0
+        if now > 0 && d.next_fraction[] == 0
             @info "Downloading $filename..."
-            next_fraction[] = 1 / messages
-            download_start_time[] = time_ns()
+            d.next_fraction[] = 1 / messages
+            d.download_start_time[] = time_ns()
         end
     end
 

--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -36,7 +36,7 @@ import Oceananigans.Fields: set!
 ##### Downloading utilities
 #####
 
-mutable struct DownloadProgress
+mutable struct DownloadProgress <: Function
     next_fraction :: Float64
     download_start_time :: UInt64
 end

--- a/src/DataWrangling/ECCO/ECCO.jl
+++ b/src/DataWrangling/ECCO/ECCO.jl
@@ -27,7 +27,7 @@ using NumericalEarth.DataWrangling:
     MicromolePerLiter,
     Metadata,
     Metadatum,
-    download_progress,
+    DownloadProgress,
     InverseSign,
     native_grid,
     location,
@@ -337,7 +337,7 @@ function download_dataset(metadata::ECCOMetadata)
                     throw(ArgumentError(msg))
                 end
                 @info "Downloading ECCO data: $(metadatum.name) in $(metadatum.dir)..."
-                Downloads.download(fileurl, filepath; downloader, progress=download_progress)
+                Downloads.download(fileurl, filepath; downloader, progress=DownloadProgress())
             end
         end
     end

--- a/src/DataWrangling/EN4/EN4.jl
+++ b/src/DataWrangling/EN4/EN4.jl
@@ -17,7 +17,7 @@ using ..DataWrangling:
     BoundingBox,
     inpaint_mask!,
     NearestNeighborInpainting,
-    download_progress,
+    DownloadProgress,
     compute_native_date_range,
     Kelvin,
     Celsius
@@ -218,7 +218,7 @@ function download_dataset(metadata::Metadata{<:EN4Monthly})
             if !isfile(extracted_file) & !isfile(zippath)
                 push!(missingzips, zippath)
                 @info "Downloading EN4 data: $(metadatum.name) in $(metadatum.dir)..."
-                Downloads.download(fileurl, zippath; progress=download_progress)
+                Downloads.download(fileurl, zippath; progress=DownloadProgress())
             elseif !isfile(extracted_file) & isfile(zippath)
                 push!(missingzips, zippath)
             end

--- a/src/DataWrangling/ETOPO/ETOPO.jl
+++ b/src/DataWrangling/ETOPO/ETOPO.jl
@@ -7,7 +7,7 @@ using Oceananigans
 using Oceananigans.DistributedComputations: @root
 using Scratch
 
-using ..DataWrangling: download_progress, Metadatum, metadata_path, AbstractStaticBathymetry
+using ..DataWrangling: DownloadProgress, Metadatum, metadata_path, AbstractStaticBathymetry
 
 import NumericalEarth.DataWrangling:
     metadata_filename,
@@ -51,7 +51,7 @@ function download_dataset(metadatum::ETOPOMetadatum)
 
     @root if !isfile(filepath)
         @info "Downloading ETOPO data: $(metadatum.name) in $(metadatum.dir)..."
-        Downloads.download(fileurl, filepath; progress=download_progress)
+        Downloads.download(fileurl, filepath; progress=DownloadProgress())
     end
     return filepath
 end

--- a/src/DataWrangling/GEBCO/GEBCO.jl
+++ b/src/DataWrangling/GEBCO/GEBCO.jl
@@ -8,7 +8,7 @@ using Oceananigans
 using Oceananigans.DistributedComputations: @root
 using Scratch
 
-using ..DataWrangling: download_progress, Metadatum, metadata_path, AbstractStaticBathymetry
+using ..DataWrangling: DownloadProgress, Metadatum, metadata_path, AbstractStaticBathymetry
 
 import NumericalEarth.DataWrangling:
     metadata_filename,
@@ -79,7 +79,7 @@ function download_dataset(metadatum::GEBCOMetadatum)
 
         try
             @info "Downloading from BODC..."
-            Downloads.download(GEBCO_zip_url, zip_path; progress=download_progress)
+            Downloads.download(GEBCO_zip_url, zip_path; progress=DownloadProgress())
 
             # Extract the NetCDF file from the ZIP using ZipFile.jl
             @info "Extracting NetCDF from ZIP archive..."

--- a/src/DataWrangling/IBCAO/IBCAO.jl
+++ b/src/DataWrangling/IBCAO/IBCAO.jl
@@ -8,7 +8,7 @@ using Oceananigans.DistributedComputations: @root
 using Scratch
 using NCDatasets
 
-using ..DataWrangling: download_progress, Metadatum, metadata_path, AbstractStaticBathymetry
+using ..DataWrangling: DownloadProgress, Metadatum, metadata_path, AbstractStaticBathymetry
 
 import NumericalEarth.DataWrangling:
     metadata_filename,
@@ -84,7 +84,7 @@ function download_dataset(metadatum::IBCAOMetadatum)
     @root if !isfile(nc_path)
         if !isfile(tiff_path)
             @info "Downloading IBCAO V5.1 GeoTIFF (100m, with Greenland ice, ~25 GB)..."
-            Downloads.download(IBCAO_tiff_url, tiff_path; progress=download_progress)
+            Downloads.download(IBCAO_tiff_url, tiff_path; progress=DownloadProgress())
         end
 
         @info "Reprojecting IBCAO from Polar Stereographic (EPSG:3996) to WGS84 at 0.01°..."

--- a/src/DataWrangling/IBCSO/IBCSO.jl
+++ b/src/DataWrangling/IBCSO/IBCSO.jl
@@ -7,7 +7,7 @@ using Oceananigans
 using Oceananigans.DistributedComputations: @root
 using Scratch
 
-using ..DataWrangling: download_progress, Metadatum, metadata_path, AbstractStaticBathymetry
+using ..DataWrangling: DownloadProgress, Metadatum, metadata_path, AbstractStaticBathymetry
 
 import NumericalEarth.DataWrangling:
     metadata_filename,
@@ -78,7 +78,7 @@ function download_dataset(metadatum::IBCSOMetadatum)
 
     @root if !isfile(filepath)
         @info "Downloading IBCSO data: $(metadatum.name) to $download_dir..."
-        Downloads.download(IBCSO_pangaea_url, filepath; progress=download_progress)
+        Downloads.download(IBCSO_pangaea_url, filepath; progress=DownloadProgress())
     end
 
     return filepath

--- a/src/DataWrangling/JRA55/JRA55_metadata.jl
+++ b/src/DataWrangling/JRA55/JRA55_metadata.jl
@@ -5,7 +5,7 @@ using Downloads
 using Oceananigans.DistributedComputations
 
 using NumericalEarth.DataWrangling
-using NumericalEarth.DataWrangling: Metadata, metadata_path, download_progress, AnyDateTime
+using NumericalEarth.DataWrangling: Metadata, metadata_path, DownloadProgress, AnyDateTime
 
 import Dates: year, month, day
 import Oceananigans.Fields: set!
@@ -197,7 +197,7 @@ function download_dataset(metadata::JRA55Metadata)
         filepath = metadata_path(metadatum)
 
         if !isfile(filepath)
-            Downloads.download(fileurl, filepath; progress=download_progress)
+            Downloads.download(fileurl, filepath; progress=DownloadProgress())
         end
     end
 

--- a/src/DataWrangling/ORCA/ORCA.jl
+++ b/src/DataWrangling/ORCA/ORCA.jl
@@ -7,7 +7,7 @@ using Oceananigans
 using Oceananigans.DistributedComputations: @root
 using Scratch
 
-using ..DataWrangling: download_progress, Metadatum, metadata_path
+using ..DataWrangling: DownloadProgress, Metadatum, metadata_path
 
 import NumericalEarth.DataWrangling:
     metadata_filename,
@@ -114,7 +114,7 @@ function download_dataset(metadatum::ORCAMetadatum)
     @root if !isfile(filepath)
         dataset_name = nameof(typeof(metadatum.dataset))
         @info "Downloading $(dataset_name) data: $(metadatum.name) to $(metadatum.dir)..."
-        Downloads.download(fileurl, filepath; progress=download_progress)
+        Downloads.download(fileurl, filepath; progress=DownloadProgress())
     end
 
     return filepath

--- a/src/DataWrangling/OSPapa/OSPapa.jl
+++ b/src/DataWrangling/OSPapa/OSPapa.jl
@@ -14,7 +14,7 @@ using Scratch
 using Downloads
 using Thermodynamics: q_vap_from_RH, Liquid
 
-using NumericalEarth.DataWrangling: download_progress
+using NumericalEarth.DataWrangling: DownloadProgress
 using NumericalEarth.Atmospheres: PrescribedAtmosphere, PrescribedPrecipitationFlux, AtmosphereThermodynamicsParameters
 using NumericalEarth.Oceans: reference_density, heat_capacity
 
@@ -73,7 +73,7 @@ function download_ospapa_file(dir=download_OSPapa_cache)
     if !isfile(filepath)
         url = OSPAPA_S3_URL * OSPAPA_FILENAME
         @info "Downloading Ocean Station Papa data from AWS S3..."
-        Downloads.download(url, filepath; progress=download_progress)
+        Downloads.download(url, filepath; progress=DownloadProgress())
     end
     return filepath
 end

--- a/src/DataWrangling/OSPapa/OSPapa_flux_observations.jl
+++ b/src/DataWrangling/OSPapa/OSPapa_flux_observations.jl
@@ -81,7 +81,7 @@ function download_ospapa_flux(; start_date, end_date, dir=download_OSPapa_cache)
         t1 = Dates.format(end_date, "yyyy-mm-ddTHH:MM:SSZ")
         url = "$(ERDDAP_BASE)/ocs_papa_flux.nc?$(ERDDAP_FLUX_VARS)&time>=$(t0)&time<=$(t1)"
         @info "Downloading OS Papa flux data from ERDDAP..."
-        Downloads.download(url, filepath; progress=download_progress)
+        Downloads.download(url, filepath; progress=DownloadProgress())
     end
     return filepath
 end

--- a/src/DataWrangling/WOA/WOA.jl
+++ b/src/DataWrangling/WOA/WOA.jl
@@ -16,7 +16,7 @@ using ..DataWrangling:
     BoundingBox,
     inpaint_mask!,
     NearestNeighborInpainting,
-    download_progress
+    DownloadProgress
 
 using Oceananigans.DistributedComputations: @root
 


### PR DESCRIPTION
At the moment, the download_progress uses global variables 
```
next_fraction = Ref(0.0)
download_start_time = Ref(time_ns())
```
that persist during downloads in the same session such that we loose the download_progress information after downloading the first file. This PR wraps them in a `DownloadProgress` struct that gets correctly reinitialized at each download