### PR TITLE
Bump Breeze compat to 0.4, 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -57,7 +57,7 @@ NumericalEarthWOAExt = "WorldOceanAtlasTools"
 [compat]
 Adapt = "4"
 ArchGDAL = "0.10"
-Breeze = "0.4"
+Breeze = "0.4, 0.5"
 CDSAPI = "2.2.1"
 CFTime = "0.1, 0.2"
 ClimaSeaIce = "0.5"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -35,7 +35,7 @@ ConservativeRegridding = {url = "https://github.com/JuliaGeo/ConservativeRegridd
 
 [compat]
 ArchGDAL = "0.10"
-Breeze = "0.4"
+Breeze = "0.4, 0.5"
 CDSAPI = "2.2.2"
 CFTime = "0.1, 0.2"
 CUDA = "5.9.5"


### PR DESCRIPTION
## Summary
- Widen `Breeze` compat from `"0.4"` to `"0.4, 0.5"` in both `Project.toml` and `test/Project.toml` to allow the newly released Breeze 0.5.0 while keeping 0.4 supported.
- No source changes required in `ext/NumericalEarthBreezeExt/` — the existing extension code works against Breeze 0.5 unmodified.
- NumericalEarth version stays at `0.4.1` (patch-level compat widening, non-breaking for downstream).

## Test plan
- [x] `Pkg.resolve()` in `test/` picks up Breeze v0.5.0
- [x] `NumericalEarthBreezeExt` precompiles against Breeze 0.5
- [x] `test/test_breeze_coupling.jl` passes locally (12/12 — construction, atmosphere_simulation, time stepping, SST flux response)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)