### PR TITLE
Format NumericalEarth module docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ Since `ocean.model` is an `Oceananigans.HydrostaticFreeSurfaceModel`, we can lev
 ```julia
 u, v, w = ocean.model.velocities
 speed = Field(sqrt(u^2 + v^2))
-compute!(speed)
 
 using GLMakie
 heatmap(view(speed, :, :, ocean.model.grid.Nz), colorrange=(0, 0.5), colormap=:magma, nan_color=:lightgray)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -77,7 +77,6 @@ We can leverage `Oceananigans` features to plot the surface speed at the end of 
 ```julia
 u, v, w = ocean.model.velocities
 speed = Field(sqrt(u^2 + v^2))
-compute!(speed)
 
 using GLMakie
 heatmap(view(speed, :, :, ocean.model.grid.Nz), colorrange=(0, 0.5), colormap=:magma, nan_color=:lightgray)

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -1,10 +1,37 @@
 module NumericalEarth
 
+function readme_for_module_docs(path::AbstractString)
+    readme = read(path, String)
+
+    # Julia docstrings use Base.Markdown, which escapes raw HTML.
+    # Translate the HTML-heavy README sections to plain Markdown on the fly.
+    readme = replace(readme, r"<!--.*?-->"s => "")
+    readme = replace(readme,
+                     r"<a\s+href=\"([^\"]+)\"[^>]*>\s*<img\s+src=\"([^\"]+)\"[^>]*?(?:alt=\"([^\"]*)\")?[^>]*>\s*</a>"s =>
+                     s"[![\3](\2)](\1)")
+    readme = replace(readme,
+                     r"<a\s+href=\"([^\"]+)\"[^>]*>([^<]+)</a>"s =>
+                     s"[\2](\1)")
+    readme = replace(readme, r"<h1[^>]*>\s*([^<]+?)\s*</h1>"s => s"# \1\n")
+    readme = replace(readme, r"<pre>\s*<code>"s => "```bibtex\n")
+    readme = replace(readme, r"</code>\s*</pre>"s => "\n```")
+    readme = replace(readme, r"<code>\s*(.*?)\s*</code>"s => s"```\n\1\n```")
+    readme = replace(readme, r"</?p\b[^>]*>" => "")
+    readme = replace(readme, r"</?strong\b[^>]*>" => "")
+    readme = replace(readme,
+                     r"<details>\s*<summary>\s*([^<]+?)\s*</summary>"s =>
+                     s"### \1\n")
+    readme = replace(readme, "</details>" => "")
+    readme = replace(readme, r"\n{3,}" => "\n\n")
+
+    return strip(readme)
+end
+
 # Use the README as the module docs
 @doc let
     path = joinpath(dirname(@__DIR__), "README.md")
     include_dependency(path)
-    read(path, String)
+    readme_for_module_docs(path)
 end NumericalEarth
 
 export

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -1,34 +1,35 @@
 module NumericalEarth
 
-function readme_for_module_docs(path::AbstractString)
-    readme = read(path, String)
-
-    # Julia docstrings use Base.Markdown, which escapes raw HTML.
-    # Translate the HTML-heavy README sections to plain Markdown on the fly.
-    readme = replace(readme, r"<!--.*?-->"s => "")
-    readme = replace(readme,
-                     r"<a\s+href=\"([^\"]+)\"[^>]*>\s*<img\s+src=\"([^\"]+)\"[^>]*?(?:alt=\"([^\"]*)\")?[^>]*>\s*</a>"s =>
-                     s"[![\3](\2)](\1)")
-    readme = replace(readme,
-                     r"<a\s+href=\"([^\"]+)\"[^>]*>([^<]+)</a>"s =>
-                     s"[\2](\1)")
-    readme = replace(readme, r"<h1[^>]*>\s*([^<]+?)\s*</h1>"s => s"# \1\n")
-    readme = replace(readme, r"<pre>\s*<code>"s => "```bibtex\n")
-    readme = replace(readme, r"</code>\s*</pre>"s => "\n```")
-    readme = replace(readme, r"<code>\s*(.*?)\s*</code>"s => s"```\n\1\n```")
-    readme = replace(readme, r"</?p\b[^>]*>" => "")
-    readme = replace(readme, r"</?strong\b[^>]*>" => "")
-    readme = replace(readme,
-                     r"<details>\s*<summary>\s*([^<]+?)\s*</summary>"s =>
-                     s"### \1\n")
-    readme = replace(readme, "</details>" => "")
-    readme = replace(readme, r"\n{3,}" => "\n\n")
-
-    return strip(readme)
-end
-
 # Use the README as the module docs
 @doc let
+    """Helper function to read the README.md file and convert it to plain Markdown for use as module documentation."""
+    function readme_for_module_docs(path::AbstractString)
+        readme = read(path, String)
+
+        # Julia docstrings use Base.Markdown, which escapes raw HTML.
+        # Translate the HTML-heavy README sections to plain Markdown on the fly.
+        readme = replace(readme, r"<!--.*?-->"s => "")
+        readme = replace(readme,
+                        r"<a\s+href=\"([^\"]+)\"[^>]*>\s*<img\s+src=\"([^\"]+)\"[^>]*?(?:alt=\"([^\"]*)\")?[^>]*>\s*</a>"s =>
+                        s"[![\3](\2)](\1)")
+        readme = replace(readme,
+                        r"<a\s+href=\"([^\"]+)\"[^>]*>([^<]+)</a>"s =>
+                        s"[\2](\1)")
+        readme = replace(readme, r"<h1[^>]*>\s*([^<]+?)\s*</h1>"s => s"# \1\n")
+        readme = replace(readme, r"<pre>\s*<code>"s => "```bibtex\n")
+        readme = replace(readme, r"</code>\s*</pre>"s => "\n```")
+        readme = replace(readme, r"<code>\s*(.*?)\s*</code>"s => s"```\n\1\n```")
+        readme = replace(readme, r"</?p\b[^>]*>" => "")
+        readme = replace(readme, r"</?strong\b[^>]*>" => "")
+        readme = replace(readme,
+                        r"<details>\s*<summary>\s*([^<]+?)\s*</summary>"s =>
+                        s"### \1\n")
+        readme = replace(readme, "</details>" => "")
+        readme = replace(readme, r"\n{3,}" => "\n\n")
+
+        return strip(readme)
+    end
+
     path = joinpath(dirname(@__DIR__), "README.md")
     include_dependency(path)
     readme_for_module_docs(path)


### PR DESCRIPTION
The docstring for the top-level module is the README. But Documenter.jl uses markdown so before this PR there are some glitches in the formatting because the README uses html; see, e.g.:

<img width="700" alt="Screenshot 2026-05-16 at 4 17 31 pm" src="https://github.com/user-attachments/assets/09141e9f-8103-49bc-82e2-4eeb8c445934" />

This PR deals with these:

<img width="700" alt="Screenshot 2026-05-16 at 4 17 41 pm" src="https://github.com/user-attachments/assets/fe338771-abe7-4927-bbf8-582b1c913ecf" />
