### PR TITLE
Update imports and figure size in simulation example

### DIFF
--- a/examples/veros_ocean_forced_simulation.jl
+++ b/examples/veros_ocean_forced_simulation.jl
@@ -8,7 +8,7 @@
 # CairoMakie to visualize the simulation.
 
 using NumericalEarth
-using PythonCall
+using CondaPkg, PythonCall
 using Oceananigans, Oceananigans.Units
 using CairoMakie
 using Printf
@@ -121,7 +121,7 @@ un = @lift(u[$n])
 vn = @lift(v[$n])
 Nt = length(u)
 
-fig = Figure(resolution = (1000, 700))
+fig = Figure(size = (1000, 700))
 ax1 = Axis(fig[1, 1]; title = "Surface zonal velocity (m/s)", xlabel = "", ylabel = "Latitude")
 ax2 = Axis(fig[2, 1]; title = "Surface meridional velocity (m/s)", xlabel = "", ylabel = "Latitude")
 hm1 = heatmap!(ax1, un, colormap = :bwr, colorrange = (-0.2, 0.2))


### PR DESCRIPTION
I'm not sure how the Veros extension was triggered without the CondaPkg.

It may be because of that that Veros was erroring in the docs build in #237?