### PR TITLE
[CI] Delete all CUDA toolkits on the host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           echo " --> df -a /"
           df -a /
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -124,10 +124,10 @@ jobs:
       - name: df before cleanup
         run: |
           df -hT
-      - name: Clean up old CUDA toolkits
-        # Save storage by deleting old CUDA toolkits, we'll use v13
+      - name: Clean up CUDA toolkits
+        # Save storage by deleting CUDA toolkits
         run: |
-          rm -rf /host-usr-local/cuda-12.*
+          rm -rf /host-usr-local/cuda-*
       - name: df after cleanup
         run: |
           df -hT


### PR DESCRIPTION
Ref: https://github.com/NumericalEarth/NumericalEarth.jl/issues/265#issuecomment-4513006126. I suspect we don't need any CUDA toolkit on the host, so we can delete all of them.