### PR TITLE
Filter set!(model, ::MetadataSet) by per-model accepted kwargs

### DIFF
--- a/src/DataWrangling/metadata.jl
+++ b/src/DataWrangling/metadata.jl
@@ -499,14 +499,16 @@ end
 """
     set!(model, mset::MetadataSet)
 
-Set fields of `model` from the variables in `mset`, auto-routing verbose
-dataset variable names to short model field-names via the global
-[`variable_glossary`](@ref) registry.
+Generic fallback: route every glossary-mapped variable in `mset` to
+`set!(model; kwargs...)`. Variables not in [`variable_glossary`](@ref) are
+silently skipped.
 
-Variables in `mset` that the target `model` does not consume are silently
-skipped — this lets partial application across coupled-model components work
-naturally. For example, a single 4-variable set can drive both an ocean and a
-sea-ice model:
+This fallback works for permissive models that accept arbitrary kwargs but
+will fail on models (e.g. `HydrostaticFreeSurfaceModel`, `SeaIceModel`) that
+throw `ArgumentError` on unknown kwargs. Those models override this method to
+filter the routed kwargs to those they actually consume — see the methods
+below. The overrides let a single multi-component MetadataSet drive both an
+ocean and a sea-ice model:
 
 ```julia
 mset = MetadataSet(:temperature, :salinity,
@@ -515,44 +517,41 @@ mset = MetadataSet(:temperature, :salinity,
 set!(ocean.model,   mset)   # consumes :temperature, :salinity  → T, S
 set!(sea_ice.model, mset)   # consumes :sea_ice_thickness, :sea_ice_concentration → h, ℵ
 ```
-
-The per-model filter is controlled by [`accepted_metadata_names`](@ref). The
-fallback accepts every key in `variable_glossary` (preserving prior behavior
-for stub/ad-hoc models in tests).
 """
 function Fields.set!(model, mset::MetadataSet)
-    accepted = accepted_metadata_names(model)
-    names = filter(n -> n in accepted, getfield(mset, :names))
+    names = filter(n -> haskey(variable_glossary, n), getfield(mset, :names))
+    return _set_glossary!(model, mset, names)
+end
+
+# Build kwargs from `mset` restricted to verbose `names` and forward to
+# `set!(model; kwargs...)`. Internal helper for the per-model overrides.
+function _set_glossary!(model, mset::MetadataSet, names)
     isempty(names) && return model
     kwargs = NamedTuple{Tuple(variable_glossary[n] for n in names)}(Tuple(mset[n] for n in names))
     return set!(model; kwargs...)
 end
 
-"""
-    accepted_metadata_names(model) -> Tuple{Symbol,...}
-
-Return the verbose `MetadataSet` variable names that `set!(model, mset)` is
-allowed to route to `model`. Defaults to every key in `variable_glossary`;
-model-specific methods narrow this to the subset that the underlying
-`set!(model; kwargs...)` actually accepts (otherwise an unrelated variable in
-a shared `MetadataSet` would trigger an `ArgumentError` from the unknown kwarg).
-"""
-accepted_metadata_names(model) = Tuple(keys(variable_glossary))
-
-# Ocean: route any glossary key whose short name matches a property of
-# velocities, tracers, or free_surface (the three places HydrostaticFreeSurfaceModel's
-# `set!` looks up kwargs).
+# Ocean: route only variables whose short name appears in velocities,
+# tracers, or free_surface — the three places HydrostaticFreeSurfaceModel's
+# `set!` looks up kwargs.
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceModel
-function accepted_metadata_names(model::HydrostaticFreeSurfaceModel)
+function Fields.set!(model::HydrostaticFreeSurfaceModel, mset::MetadataSet)
     short = (propertynames(model.velocities)...,
              propertynames(model.tracers)...,
              propertynames(model.free_surface)...)
-    return Tuple(n for (n, s) in variable_glossary if s in short)
+    names = filter(getfield(mset, :names)) do n
+        haskey(variable_glossary, n) && variable_glossary[n] in short
+    end
+    return _set_glossary!(model, mset, names)
 end
 
-# Sea ice: ClimaSeaIce's `set!(::SeaIceModel; h, ℵ)` only knows these two.
+# Sea ice: ClimaSeaIce's `set!(::SeaIceModel; h, ℵ)` only accepts these two.
 using ClimaSeaIce: SeaIceModel
-accepted_metadata_names(::SeaIceModel) = (:sea_ice_thickness, :sea_ice_concentration)
+function Fields.set!(model::SeaIceModel, mset::MetadataSet)
+    sea_ice_names = (:sea_ice_thickness, :sea_ice_concentration)
+    names = filter(in(sea_ice_names), getfield(mset, :names))
+    return _set_glossary!(model, mset, names)
+end
 
 """
     download(mset::MetadataSet; kwargs...)

--- a/src/DataWrangling/metadata.jl
+++ b/src/DataWrangling/metadata.jl
@@ -497,18 +497,16 @@ function Fields.set!(fields::NamedTuple, mset::MetadataSet)
 end
 
 """
-    set!(model, mset::MetadataSet)
+    set!(model, mset::MetadataSet, names=keys(variable_glossary))
 
-Generic fallback: route every glossary-mapped variable in `mset` to
-`set!(model; kwargs...)`. Variables not in [`variable_glossary`](@ref) are
-silently skipped.
+Route variables from `mset` to `set!(model; kwargs...)`, translating verbose
+dataset names to short model field-names via [`variable_glossary`](@ref).
+Only the intersection of `names` and `mset.names` is forwarded.
 
-This fallback works for permissive models that accept arbitrary kwargs but
-will fail on models (e.g. `HydrostaticFreeSurfaceModel`, `SeaIceModel`) that
-throw `ArgumentError` on unknown kwargs. Those models override this method to
-filter the routed kwargs to those they actually consume — see the methods
-below. The overrides let a single multi-component MetadataSet drive both an
-ocean and a sea-ice model:
+The default `names` is every glossary key — fine for permissive models. Models
+that throw on unknown kwargs (`HydrostaticFreeSurfaceModel`, `SeaIceModel`)
+override the 2-argument form to pass a narrower `names`, letting a single
+multi-component MetadataSet drive both an ocean and a sea-ice model:
 
 ```julia
 mset = MetadataSet(:temperature, :salinity,
@@ -518,16 +516,10 @@ set!(ocean.model,   mset)   # consumes :temperature, :salinity  → T, S
 set!(sea_ice.model, mset)   # consumes :sea_ice_thickness, :sea_ice_concentration → h, ℵ
 ```
 """
-function Fields.set!(model, mset::MetadataSet)
-    names = filter(n -> haskey(variable_glossary, n), getfield(mset, :names))
-    return _set_glossary!(model, mset, names)
-end
-
-# Build kwargs from `mset` restricted to verbose `names` and forward to
-# `set!(model; kwargs...)`. Internal helper for the per-model overrides.
-function _set_glossary!(model, mset::MetadataSet, names)
-    isempty(names) && return model
-    kwargs = NamedTuple{Tuple(variable_glossary[n] for n in names)}(Tuple(mset[n] for n in names))
+function Fields.set!(model, mset::MetadataSet, names=keys(variable_glossary))
+    routed = filter(in(names), getfield(mset, :names))
+    isempty(routed) && return model
+    kwargs = NamedTuple{Tuple(variable_glossary[n] for n in routed)}(Tuple(mset[n] for n in routed))
     return set!(model; kwargs...)
 end
 
@@ -539,18 +531,14 @@ function Fields.set!(model::HydrostaticFreeSurfaceModel, mset::MetadataSet)
     short = (propertynames(model.velocities)...,
              propertynames(model.tracers)...,
              propertynames(model.free_surface)...)
-    names = filter(getfield(mset, :names)) do n
-        haskey(variable_glossary, n) && variable_glossary[n] in short
-    end
-    return _set_glossary!(model, mset, names)
+    names = Tuple(n for (n, s) in variable_glossary if s in short)
+    return set!(model, mset, names)
 end
 
 # Sea ice: ClimaSeaIce's `set!(::SeaIceModel; h, ℵ)` only accepts these two.
 using ClimaSeaIce: SeaIceModel
 function Fields.set!(model::SeaIceModel, mset::MetadataSet)
-    sea_ice_names = (:sea_ice_thickness, :sea_ice_concentration)
-    names = filter(in(sea_ice_names), getfield(mset, :names))
-    return _set_glossary!(model, mset, names)
+    return set!(model, mset, (:sea_ice_thickness, :sea_ice_concentration))
 end
 
 """

--- a/src/DataWrangling/metadata.jl
+++ b/src/DataWrangling/metadata.jl
@@ -503,7 +503,7 @@ Set fields of `model` from the variables in `mset`, auto-routing verbose
 dataset variable names to short model field-names via the global
 [`variable_glossary`](@ref) registry.
 
-Variables in `mset` that have no entry in `variable_glossary` are silently
+Variables in `mset` that the target `model` does not consume are silently
 skipped — this lets partial application across coupled-model components work
 naturally. For example, a single 4-variable set can drive both an ocean and a
 sea-ice model:
@@ -515,13 +515,44 @@ mset = MetadataSet(:temperature, :salinity,
 set!(ocean.model,   mset)   # consumes :temperature, :salinity  → T, S
 set!(sea_ice.model, mset)   # consumes :sea_ice_thickness, :sea_ice_concentration → h, ℵ
 ```
+
+The per-model filter is controlled by [`accepted_metadata_names`](@ref). The
+fallback accepts every key in `variable_glossary` (preserving prior behavior
+for stub/ad-hoc models in tests).
 """
 function Fields.set!(model, mset::MetadataSet)
-    names = getfield(mset, :names)
-    known = filter(n -> haskey(variable_glossary, n), names)
-    kwargs = NamedTuple{Tuple(variable_glossary[n] for n in known)}(Tuple(mset[n] for n in known))
+    accepted = accepted_metadata_names(model)
+    names = filter(n -> n in accepted, getfield(mset, :names))
+    isempty(names) && return model
+    kwargs = NamedTuple{Tuple(variable_glossary[n] for n in names)}(Tuple(mset[n] for n in names))
     return set!(model; kwargs...)
 end
+
+"""
+    accepted_metadata_names(model) -> Tuple{Symbol,...}
+
+Return the verbose `MetadataSet` variable names that `set!(model, mset)` is
+allowed to route to `model`. Defaults to every key in `variable_glossary`;
+model-specific methods narrow this to the subset that the underlying
+`set!(model; kwargs...)` actually accepts (otherwise an unrelated variable in
+a shared `MetadataSet` would trigger an `ArgumentError` from the unknown kwarg).
+"""
+accepted_metadata_names(model) = Tuple(keys(variable_glossary))
+
+# Ocean: route any glossary key whose short name matches a property of
+# velocities, tracers, or free_surface (the three places HydrostaticFreeSurfaceModel's
+# `set!` looks up kwargs).
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceModel
+function accepted_metadata_names(model::HydrostaticFreeSurfaceModel)
+    short = (propertynames(model.velocities)...,
+             propertynames(model.tracers)...,
+             propertynames(model.free_surface)...)
+    return Tuple(n for (n, s) in variable_glossary if s in short)
+end
+
+# Sea ice: ClimaSeaIce's `set!(::SeaIceModel; h, ℵ)` only knows these two.
+using ClimaSeaIce: SeaIceModel
+accepted_metadata_names(::SeaIceModel) = (:sea_ice_thickness, :sea_ice_concentration)
 
 """
     download(mset::MetadataSet; kwargs...)

--- a/test/test_metadata_set.jl
+++ b/test/test_metadata_set.jl
@@ -234,15 +234,12 @@ function NumericalEarth.DataWrangling.set!(m::RestrictiveStubModel; kw...)
     return m
 end
 
-# Override the dispatch to filter to `m.accepts` — same shape as the real
-# HydrostaticFreeSurfaceModel/SeaIceModel methods.
+# Override the 2-arg dispatch to pass a narrowed `names` to the generic
+# 3-arg form — same shape as the real HydrostaticFreeSurfaceModel/SeaIceModel
+# methods.
 function Oceananigans.Fields.set!(m::RestrictiveStubModel, mset::MetadataSet)
-    names = filter(getfield(mset, :names)) do n
-        haskey(variable_glossary, n) && variable_glossary[n] in m.accepts
-    end
-    isempty(names) && return m
-    kwargs = NamedTuple{Tuple(variable_glossary[n] for n in names)}(Tuple(mset[n] for n in names))
-    return set!(m; kwargs...)
+    names = Tuple(n for (n, s) in variable_glossary if s in m.accepts)
+    return set!(m, mset, names)
 end
 
 @testset "set!(model, mset) — per-model overrides filter a shared MetadataSet" begin

--- a/test/test_metadata_set.jl
+++ b/test/test_metadata_set.jl
@@ -1,7 +1,8 @@
 include("runtests_setup.jl")
 
 using NumericalEarth.DataWrangling: MetadataSet, Metadata, Metadatum,
-                                    BoundingBox, variable_glossary, metadata_path
+                                    BoundingBox, variable_glossary, metadata_path,
+                                    accepted_metadata_names
 
 # `MetadataSet` is a pure DataWrangling concept: no downloads, no field
 # construction. These tests exercise construction, accessors, iteration,
@@ -209,6 +210,73 @@ end
     # (it just doesn't appear). Simulate this by pretending we're routing to a
     # model that ignores unknown variables.
     @test issubset(received_keys, values(NumericalEarth.DataWrangling.variable_glossary))
+end
+
+#####
+##### Per-model accepted_metadata_names filter
+#####
+##### A real Oceananigans/ClimaSeaIce model throws ArgumentError on unknown
+##### kwargs, so the generic dispatch must filter glossary keys down to those
+##### the target model can consume. This stub mimics that strict behavior.
+
+mutable struct RestrictiveStubModel
+    accepts  :: Tuple{Vararg{Symbol}}        # short field names this model accepts
+    received :: Vector{Pair{Symbol, Any}}
+    RestrictiveStubModel(accepts...) = new(accepts, Pair{Symbol, Any}[])
+end
+
+function NumericalEarth.DataWrangling.set!(m::RestrictiveStubModel; kw...)
+    for (k, v) in kw
+        k in m.accepts || throw(ArgumentError("name $k not accepted by RestrictiveStubModel"))
+        push!(m.received, k => v)
+    end
+    return m
+end
+
+# Narrow the verbose-name filter so only variables routable to `m.accepts` are
+# delivered — same pattern as the HydrostaticFreeSurfaceModel/SeaIceModel
+# methods.
+function NumericalEarth.DataWrangling.accepted_metadata_names(m::RestrictiveStubModel)
+    return Tuple(n for (n, s) in variable_glossary if s in m.accepts)
+end
+
+@testset "set!(model, mset) — per-model filter (regression for issue with 4-var sets)" begin
+    mset = MetadataSet(:temperature, :salinity,
+                       :sea_ice_thickness, :sea_ice_concentration;
+                       dataset = ECCO4Monthly(),
+                       date    = snapshot_date)
+
+    # Ocean-like model: only :T, :S
+    ocean_like = RestrictiveStubModel(:T, :S)
+    set!(ocean_like, mset)
+    ocean_keys = first.(ocean_like.received)
+    @test :T in ocean_keys
+    @test :S in ocean_keys
+    @test !(:h in ocean_keys)
+    @test !(:ℵ in ocean_keys)
+    @test length(ocean_keys) == 2
+
+    # Sea-ice-like model: only :h, :ℵ
+    sea_ice_like = RestrictiveStubModel(:h, :ℵ)
+    set!(sea_ice_like, mset)
+    ice_keys = first.(sea_ice_like.received)
+    @test :h in ice_keys
+    @test :ℵ in ice_keys
+    @test !(:T in ice_keys)
+    @test !(:S in ice_keys)
+    @test length(ice_keys) == 2
+
+    # Model that accepts nothing relevant — call is a no-op, no error.
+    empty_model = RestrictiveStubModel(:foo)
+    set!(empty_model, mset)
+    @test isempty(empty_model.received)
+end
+
+@testset "accepted_metadata_names — fallback covers all glossary keys" begin
+    # The fallback (used by ad-hoc/stub models) is every glossary key, so a
+    # bare StubModel sees every routed kwarg. Real-model methods narrow this
+    # — exercised end-to-end in test_ocean_sea_ice_model.jl.
+    @test Set(accepted_metadata_names(StubModel())) == Set(keys(variable_glossary))
 end
 
 @testset "set!(::NamedTuple, mset) — explicit per-variable" begin

--- a/test/test_metadata_set.jl
+++ b/test/test_metadata_set.jl
@@ -1,8 +1,7 @@
 include("runtests_setup.jl")
 
 using NumericalEarth.DataWrangling: MetadataSet, Metadata, Metadatum,
-                                    BoundingBox, variable_glossary, metadata_path,
-                                    accepted_metadata_names
+                                    BoundingBox, variable_glossary, metadata_path
 
 # `MetadataSet` is a pure DataWrangling concept: no downloads, no field
 # construction. These tests exercise construction, accessors, iteration,
@@ -213,11 +212,13 @@ end
 end
 
 #####
-##### Per-model accepted_metadata_names filter
+##### Per-model overrides (regression for issue with shared multi-component sets)
 #####
-##### A real Oceananigans/ClimaSeaIce model throws ArgumentError on unknown
-##### kwargs, so the generic dispatch must filter glossary keys down to those
-##### the target model can consume. This stub mimics that strict behavior.
+##### Real Oceananigans/ClimaSeaIce models throw ArgumentError on unknown
+##### kwargs, so they override `set!(model, ::MetadataSet)` to filter down to
+##### the variables they consume. This RestrictiveStubModel mimics that
+##### strictness and demonstrates the override pattern used by the real
+##### dispatches in src/DataWrangling/metadata.jl.
 
 mutable struct RestrictiveStubModel
     accepts  :: Tuple{Vararg{Symbol}}        # short field names this model accepts
@@ -233,20 +234,24 @@ function NumericalEarth.DataWrangling.set!(m::RestrictiveStubModel; kw...)
     return m
 end
 
-# Narrow the verbose-name filter so only variables routable to `m.accepts` are
-# delivered — same pattern as the HydrostaticFreeSurfaceModel/SeaIceModel
-# methods.
-function NumericalEarth.DataWrangling.accepted_metadata_names(m::RestrictiveStubModel)
-    return Tuple(n for (n, s) in variable_glossary if s in m.accepts)
+# Override the dispatch to filter to `m.accepts` — same shape as the real
+# HydrostaticFreeSurfaceModel/SeaIceModel methods.
+function Oceananigans.Fields.set!(m::RestrictiveStubModel, mset::MetadataSet)
+    names = filter(getfield(mset, :names)) do n
+        haskey(variable_glossary, n) && variable_glossary[n] in m.accepts
+    end
+    isempty(names) && return m
+    kwargs = NamedTuple{Tuple(variable_glossary[n] for n in names)}(Tuple(mset[n] for n in names))
+    return set!(m; kwargs...)
 end
 
-@testset "set!(model, mset) — per-model filter (regression for issue with 4-var sets)" begin
+@testset "set!(model, mset) — per-model overrides filter a shared MetadataSet" begin
     mset = MetadataSet(:temperature, :salinity,
                        :sea_ice_thickness, :sea_ice_concentration;
                        dataset = ECCO4Monthly(),
                        date    = snapshot_date)
 
-    # Ocean-like model: only :T, :S
+    # Ocean-like model: override filters to (:T, :S).
     ocean_like = RestrictiveStubModel(:T, :S)
     set!(ocean_like, mset)
     ocean_keys = first.(ocean_like.received)
@@ -256,7 +261,7 @@ end
     @test !(:ℵ in ocean_keys)
     @test length(ocean_keys) == 2
 
-    # Sea-ice-like model: only :h, :ℵ
+    # Sea-ice-like model: override filters to (:h, :ℵ).
     sea_ice_like = RestrictiveStubModel(:h, :ℵ)
     set!(sea_ice_like, mset)
     ice_keys = first.(sea_ice_like.received)
@@ -266,17 +271,10 @@ end
     @test !(:S in ice_keys)
     @test length(ice_keys) == 2
 
-    # Model that accepts nothing relevant — call is a no-op, no error.
+    # No matching variables → no-op, no error.
     empty_model = RestrictiveStubModel(:foo)
     set!(empty_model, mset)
     @test isempty(empty_model.received)
-end
-
-@testset "accepted_metadata_names — fallback covers all glossary keys" begin
-    # The fallback (used by ad-hoc/stub models) is every glossary key, so a
-    # bare StubModel sees every routed kwarg. Real-model methods narrow this
-    # — exercised end-to-end in test_ocean_sea_ice_model.jl.
-    @test Set(accepted_metadata_names(StubModel())) == Set(keys(variable_glossary))
 end
 
 @testset "set!(::NamedTuple, mset) — explicit per-variable" begin


### PR DESCRIPTION
## Summary
- Fixes the docs-build failure introduced by #259 in `examples/one_degree_simulation.jl`: `set!(ocean.model, ecco_set)` and `set!(sea_ice.model, ecco_set)` both threw `ArgumentError: name h not found in model.velocities, model.tracers, or model.free_surface` because the generic `set!(model, ::MetadataSet)` forwarded *every* glossary-mapped variable to the model, but real `HydrostaticFreeSurfaceModel`/`SeaIceModel` throw on unknown kwargs.
- Add direct dispatches `set!(::HydrostaticFreeSurfaceModel, ::MetadataSet)` and `set!(::SeaIceModel, ::MetadataSet)` that filter the routed kwargs to those the model actually consumes.
- Keep the generic `set!(model, ::MetadataSet)` fallback simple: deliver every glossary-mapped variable. Permissive stub/ad-hoc models continue to work; strict models override to filter.

## Design
Plain multiple dispatch — no `accepted_metadata_names` hook in between. Per-model logic lives next to its dispatch, and a future model can do more than just filter (transform, validate, multi-pass) without having to extend a second function. A small `_set_glossary!` helper keeps the kwargs-construction code DRY across the two dispatches.

## Why this got through CI
The existing `set!(model, mset)` tests in `test/test_metadata_set.jl` use a permissive `StubModel` whose `set!` accepts arbitrary kwargs, so the dispatch's failure to filter wasn't exercised. Docs build *did* fail on the #259 merge commit but the run shows as `cancelled`, so it wasn't a hard block.

## Test plan
- [x] `julia --project=. test/test_metadata_set.jl` passes locally, including a new `RestrictiveStubModel` regression test that mimics the real models' kwarg-strictness with a shared 4-variable MetadataSet and demonstrates the override pattern.
- [x] Smoke test against real models confirms `which(set!, (HydrostaticFreeSurfaceModel, MetadataSet))` and `which(set!, (SeaIceModel, MetadataSet))` route to the specialised methods, not the fallback.
- [ ] CI docs build passes (this is the failing case from main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)