### PR TITLE
Support LinearEquationOfState

### DIFF
--- a/src/Oceans/ocean_simulation.jl
+++ b/src/Oceans/ocean_simulation.jl
@@ -7,6 +7,7 @@ using Oceananigans.TurbulenceClosures: VerticallyImplicitTimeDiscretization
 using Oceananigans.TurbulenceClosures.TKEBasedVerticalDiffusivities: CATKEVerticalDiffusivity,
                                                                      CATKEMixingLength,
                                                                      CATKEEquation
+using Oceananigans.BuoyancyFormulations: LinearEquationOfState
 using SeawaterPolynomials.TEOS10: TEOS10EquationOfState
 using Statistics: mean
 
@@ -382,8 +383,10 @@ const OceananigansModelSimulations = Union{
 #####
 
 EarthSystemModels.reference_density(eos::TEOS10EquationOfState) = eos.reference_density
+EarthSystemModels.reference_density(eos::LinearEquationOfState) = 1026.0
 EarthSystemModels.reference_density(buoyancy_formulation::SeawaterBuoyancy) = EarthSystemModels.reference_density(buoyancy_formulation.equation_of_state)
 EarthSystemModels.reference_density(ocean::OceananigansModelSimulations) = EarthSystemModels.reference_density(ocean.model.buoyancy.formulation)
+
 
 EarthSystemModels.heat_capacity(ocean::OceananigansModelSimulations) = heat_capacity(ocean.model.buoyancy.formulation)
 EarthSystemModels.heat_capacity(buoyancy_formulation::SeawaterBuoyancy) = heat_capacity(buoyancy_formulation.equation_of_state)
@@ -392,3 +395,4 @@ function EarthSystemModels.heat_capacity(::TEOS10EquationOfState{FT}) where FT
     cₚ⁰ = SeawaterPolynomials.TEOS10.teos10_reference_heat_capacity
     return convert(FT, cₚ⁰)
 end
+EarthSystemModels.heat_capacity(::LinearEquationOfState{FT}) where FT = 3991.86795711963

--- a/src/SeaIces/sea_ice_simulation.jl
+++ b/src/SeaIces/sea_ice_simulation.jl
@@ -111,12 +111,13 @@ function sea_ice_dynamics(grid, ocean=nothing;
                           rheology = ElastoViscoPlasticRheology(),
                           coriolis = default_coriolis(ocean),
                           free_drift = nothing,
+                          ocean_reference_density = ocean_reference_density(ocean),
                           solver = default_solver(grid, ocean))
 
     SSU, SSV = ocean_surface_velocities(ocean)
     FT = eltype(grid)
     sea_ice_ocean_drag_coefficient = convert(FT, sea_ice_ocean_drag_coefficient)
-    ρₑ = ocean_reference_density(ocean, FT)
+    ρₑ = convert(FT, ocean_reference_density)
 
     τo  = SemiImplicitStress(uₑ=SSU, vₑ=SSV, Cᴰ=sea_ice_ocean_drag_coefficient, ρₑ=ρₑ)
     τua = Field{Face, Center, Nothing}(grid)

--- a/src/SeaIces/sea_ice_simulation.jl
+++ b/src/SeaIces/sea_ice_simulation.jl
@@ -12,8 +12,8 @@ using ..EarthSystemModels.InterfaceComputations: InterfaceComputations, SkinTemp
 
 default_rotation_rate = Oceananigans.defaults.planet_rotation_rate
 
-ocean_reference_density(ocean::Simulation, FT) = convert(FT, reference_density(ocean))
-ocean_reference_density(::Nothing, FT) = convert(FT, 1026.0)
+ocean_reference_density(ocean::Simulation) = reference_density(ocean)
+ocean_reference_density(::Nothing) = 1026.0
 
 function default_snow_thermodynamics(grid)
     FT = eltype(grid)


### PR DESCRIPTION
This PR adds support for users to use an ocean LinearEquationOfState. The changes to support this are:
 - Pass `ocean_reference_density` to `sea_ice_dynamics`.
 - Add methods in `EarthSystemModels.reference_density` and `EarthSystemModels.heat_capacity`.
 
Closes #270 