### PR TITLE
Pass clocks in simulations

### DIFF
--- a/src/Oceans/nonhydrostatic_ocean_simulation.jl
+++ b/src/Oceans/nonhydrostatic_ocean_simulation.jl
@@ -12,6 +12,7 @@ using SeawaterPolynomials.TEOS10: TEOS10EquationOfState
                                     advection = WENO(order=9),
                                     forcing = NamedTuple(),
                                     boundary_conditions::NamedTuple = NamedTuple(),
+                                    clock = nothing,
                                     verbose = false)
 
 Construct and return a nonhydrostatic ocean simulation suitable for Large Eddy
@@ -33,6 +34,7 @@ timestepping is needed.
 - `advection`: Advection scheme. Defaults to `WENO(order=9)`.
 - `forcing`: Named tuple of additional forcing(s).
 - `boundary_conditions`: User-supplied boundary conditions; merged with defaults.
+- `clock`: Clock for the underlying model. Defaults to `nothing` (model builds its own).
 - `verbose`: If `true`, prints additional setup information.
 """
 function nonhydrostatic_ocean_simulation(grid;
@@ -67,6 +69,9 @@ function nonhydrostatic_ocean_simulation(grid;
     boundary_conditions = merge(default_boundary_conditions, boundary_conditions)
     buoyancy = SeawaterBuoyancy(; gravitational_acceleration, equation_of_state)
 
+    # Only forward `clock` when supplied so the model keeps its own default otherwise.
+    clock_kw = isnothing(clock) ? NamedTuple() : (; clock)
+
     ocean_model = NonhydrostaticModel(grid;
                                       buoyancy,
                                       closure,
@@ -74,7 +79,8 @@ function nonhydrostatic_ocean_simulation(grid;
                                       tracers,
                                       coriolis,
                                       forcing,
-                                      boundary_conditions)
+                                      boundary_conditions,
+                                      clock_kw...)
 
     ocean = Simulation(ocean_model; Δt, verbose)
 

--- a/src/Oceans/ocean_simulation.jl
+++ b/src/Oceans/ocean_simulation.jl
@@ -187,6 +187,7 @@ end
                                  equation_of_state = TEOS10EquationOfState(; reference_density),
                                  boundary_conditions::NamedTuple = NamedTuple(),
                                  radiative_forcing = default_radiative_forcing(grid),
+                                 clock = nothing,
                                  warn = true,
                                  verbose = false)
 
@@ -251,6 +252,9 @@ defaults on a per-field basis.
 - `equation_of_state`: Equation of state object. Defaults to TEOS-10 (`TEOS10EquationOfState`).
 - `boundary_conditions`: User-supplied boundary conditions; merged with defaults.
 - `radiative_forcing`: Additional temperature forcing; merged into `forcing`.
+- `clock`: Clock for the underlying model. Defaults to `nothing`, in which case the
+  model builds its own default clock. Pass a `Clock` (e.g. `Clock{Float64}(time=0)` or
+  a `DateTime`-based clock) to control the time type, for instance when coupling.
 - `warn`: If `true`, warnings are emitted for potentially unintended setups.
 - `verbose`: If `true`, prints additional setup information.
 """
@@ -273,6 +277,7 @@ function hydrostatic_ocean_simulation(grid;
                                       equation_of_state = TEOS10EquationOfState(; reference_density),
                                       boundary_conditions::NamedTuple = NamedTuple(),
                                       radiative_forcing = default_radiative_forcing(grid),
+                                      clock = nothing,
                                       warn = true,
                                       verbose = false)
 
@@ -381,6 +386,9 @@ function hydrostatic_ocean_simulation(grid;
         tracer_advection = merge(tracer_advection, tke_advection)
     end
 
+    # Only forward `clock` when supplied so the model keeps its own default otherwise.
+    clock_kw = isnothing(clock) ? NamedTuple() : (; clock)
+
     ocean_model = HydrostaticFreeSurfaceModel(grid;
                                               buoyancy,
                                               closure,
@@ -392,7 +400,8 @@ function hydrostatic_ocean_simulation(grid;
                                               free_surface,
                                               coriolis,
                                               forcing,
-                                              boundary_conditions)
+                                              boundary_conditions,
+                                              clock_kw...)
 
     ocean = Simulation(ocean_model; Δt, verbose)
 

--- a/src/SeaIces/sea_ice_simulation.jl
+++ b/src/SeaIces/sea_ice_simulation.jl
@@ -42,7 +42,8 @@ end
                                                             density=sea_ice_density),
                        conductivity = 2, # W m⁻¹ K⁻¹
                        internal_heat_flux = ConductiveFlux(; conductivity),
-                       snow_thermodynamics = default_snow_thermodynamics(grid))
+                       snow_thermodynamics = default_snow_thermodynamics(grid),
+                       clock = nothing)
 
 Construct a sea ice simulation with the given grid and optional ocean simulation.
 The sea ice model is configured with a slab thermodynamics, Elasto-Visco-Plastic rheology,
@@ -80,6 +81,8 @@ Keyword Arguments
                         `ConductiveFlux` with specified conductivity)
 - `snow_thermodynamics`: thermodynamics for the snow layer (default is a slab thermodynamics with
                          specified conductivity and prescribed temperature)
+- `clock`: clock for the sea ice model. Defaults to `nothing`, in which case the model builds its
+           own default clock; pass a `Clock` to control the time type (e.g. when coupling)
 """
 function sea_ice_simulation(grid, ocean=nothing;
                             Δt = 5minutes,
@@ -99,7 +102,8 @@ function sea_ice_simulation(grid, ocean=nothing;
                                                                  density=sea_ice_density),
                             conductivity = 2, # W m⁻¹ K⁻¹
                             internal_heat_flux = ConductiveFlux(; conductivity),
-                            snow_thermodynamics = default_snow_thermodynamics(grid))
+                            snow_thermodynamics = default_snow_thermodynamics(grid),
+                            clock = nothing)
 
     # Build consistent boundary conditions for the ice model:
     # - bottom -> flux boundary condition
@@ -128,6 +132,9 @@ function sea_ice_simulation(grid, ocean=nothing;
     top_heat_flux    = Field{Center, Center, Nothing}(grid)
     snowfall         = Field{Center, Center, Nothing}(grid)
 
+    # Only forward `clock` when supplied so the model keeps its own default otherwise.
+    clock_kw = isnothing(clock) ? NamedTuple() : (; clock)
+
     # Build the sea ice model
     sea_ice_model = SeaIceModel(grid;
                                 ice_salinity,
@@ -143,7 +150,8 @@ function sea_ice_simulation(grid, ocean=nothing;
                                 dynamics,
                                 timestepper,
                                 bottom_heat_flux,
-                                top_heat_flux)
+                                top_heat_flux,
+                                clock_kw...)
 
     verbose = false
     sea_ice = Simulation(sea_ice_model; Δt, verbose)


### PR DESCRIPTION
This is an initial PR that allows passing clocks to simulations. So we can do something like
```julia
start_date = DateTime(1958, 1, 1)
ocean = ocean_simulation(grid, clock = Clock(time=start_date))
sea_ice = sea_ice_simulation(grid, clock = Clock(time=start_date))
atmos = JRA55PrescribedAtmosphere(; start_date)
```