### PR TITLE
Allow using the internal model's diffusivity in the `SkinTemperature`

### DIFF
--- a/src/EarthSystemModels/EarthSystemModels.jl
+++ b/src/EarthSystemModels/EarthSystemModels.jl
@@ -21,6 +21,8 @@ export
     FreezingLimitedOceanTemperature,
     SkinTemperature,
     BulkTemperature,
+    DiffusiveFlux,
+    InteriorDiffusivity,
     compute_atmosphere_ocean_fluxes!,
     compute_atmosphere_sea_ice_fluxes!,
     compute_sea_ice_ocean_fluxes!,

--- a/src/EarthSystemModels/InterfaceComputations/InterfaceComputations.jl
+++ b/src/EarthSystemModels/InterfaceComputations/InterfaceComputations.jl
@@ -20,6 +20,8 @@ export
     LinearStableStabilityFunction,
     SkinTemperature,
     BulkTemperature,
+    DiffusiveFlux,
+    InteriorDiffusivity,
     atmosphere_ocean_stability_functions,
     atmosphere_land_stability_functions,
     atmosphere_sea_ice_stability_functions,

--- a/src/EarthSystemModels/InterfaceComputations/atmosphere_ocean_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/atmosphere_ocean_fluxes.jl
@@ -29,11 +29,7 @@ function compute_atmosphere_ocean_fluxes!(coupled_model)
     interface_properties = coupled_model.interfaces.atmosphere_ocean_interface.properties
     ocean_properties = coupled_model.interfaces.ocean_properties
     atmosphere_properties = atmosphere_ocean_properties(coupled_model)
-
-    # The diffusivity operation enters the kernel parameter space only when
-    # the temperature formulation consumes it (see issue #116).
-    ocean_state = assemble_interior_fields(exchanger.ocean.state,
-                                           interface_properties.temperature_formulation)
+    ocean_state = assemble_interior_fields(exchanger.ocean.state, interface_properties.temperature_formulation)
 
     # Radiation state for the interface solve (used by SkinTemperature).
     # When `radiation === nothing` these are `nothing`s and the getter

--- a/src/EarthSystemModels/InterfaceComputations/atmosphere_ocean_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/atmosphere_ocean_fluxes.jl
@@ -59,6 +59,23 @@ function compute_atmosphere_ocean_fluxes!(coupled_model)
     return nothing
 end
 
+@inline function assemble_interior_state(i, j, kᴺ, grid, interior_state, ocean_properties, temperature_formulation)
+    @inbounds begin
+        uᵒᶜ = ℑxᶜᵃᵃ(i, j, kᴺ, grid, interior_state.u)
+        vᵒᶜ = ℑyᵃᶜᵃ(i, j, kᴺ, grid, interior_state.v)
+        Tᵒᶜ = interior_state.T[i, j, kᴺ]
+        Tᵒᶜ = convert_to_kelvin(ocean_properties.temperature_units, Tᵒᶜ)
+        Sᵒᶜ = interior_state.S[i, j, kᴺ]
+    end
+    return (u=uᵒᶜ, v=vᵒᶜ, T=Tᵒᶜ, S=Sᵒᶜ)
+end
+
+@inline function assemble_interior_state(i, j, kᴺ, grid, interior_state, ocean_properties, ::SkinTemperature{<:DiffusiveFlux{<:Any, <:InteriorDiffusivity}})
+    Ψᵢ = assemble_interior_state(i, j, kᴺ, grid, interior_state, ocean_properties, nothing)
+    κ  = @inbounds interior_state.κ[i, j, 1]
+    return merge(Ψᵢ, (; κ))
+end
+
 """ Compute turbulent fluxes between an atmosphere and an interface state using similarity theory """
 @kernel function _compute_atmosphere_ocean_interface_state!(interface_fluxes,
                                                             interface_temperature,
@@ -83,13 +100,6 @@ end
         Tᵃᵗ = atmosphere_state.T[i, j, 1]
         pᵃᵗ = atmosphere_state.p[i, j, 1]
         qᵃᵗ = atmosphere_state.q[i, j, 1]
-
-        # Ocean state at cell centers
-        uᵒᶜ = ℑxᶜᵃᵃ(i, j, kᴺ, grid, interior_state.u)
-        vᵒᶜ = ℑyᵃᶜᵃ(i, j, kᴺ, grid, interior_state.v)
-        Tᵒᶜ = interior_state.T[i, j, kᴺ]
-        Tᵒᶜ = convert_to_kelvin(ocean_properties.temperature_units, Tᵒᶜ)
-        Sᵒᶜ = interior_state.S[i, j, kᴺ]
     end
 
     # Build thermodynamic and dynamic states in the atmosphere and interface.
@@ -104,7 +114,12 @@ end
                               q = qᵃᵗ,
                               h_bℓ = atmosphere_state.h_bℓ)
 
-    local_interior_state = (u=uᵒᶜ, v=vᵒᶜ, T=Tᵒᶜ, S=Sᵒᶜ)
+    local_interior_state = assemble_interior_state(i, j, kᴺ, grid, interior_state, ocean_properties, interface_properties.temperature_formulation)
+
+    uᵒᶜ = local_interior_state.u
+    vᵒᶜ = local_interior_state.v
+    Tᵒᶜ = local_interior_state.T
+    Sᵒᶜ = local_interior_state.S
 
     # Local radiative state at this cell. Returns zero-valued state when
     # radiation is off.

--- a/src/EarthSystemModels/InterfaceComputations/atmosphere_ocean_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/atmosphere_ocean_fluxes.jl
@@ -19,7 +19,6 @@ function compute_atmosphere_ocean_fluxes!(coupled_model)
     grid = exchanger.grid
     arch = architecture(grid)
     clock = coupled_model.clock
-    ocean_state = exchanger.ocean.state
     # Simplify NamedTuple to reduce parameter space consumption.
     # See https://github.com/CliMA/NumericalEarth.jl/issues/116.
     atmosphere_data = atmosphere_ocean_data(coupled_model)
@@ -30,6 +29,11 @@ function compute_atmosphere_ocean_fluxes!(coupled_model)
     interface_properties = coupled_model.interfaces.atmosphere_ocean_interface.properties
     ocean_properties = coupled_model.interfaces.ocean_properties
     atmosphere_properties = atmosphere_ocean_properties(coupled_model)
+
+    # The diffusivity operation enters the kernel parameter space only when
+    # the temperature formulation consumes it (see issue #116).
+    ocean_state = assemble_interior_fields(exchanger.ocean.state,
+                                           interface_properties.temperature_formulation)
 
     # Radiation state for the interface solve (used by SkinTemperature).
     # When `radiation === nothing` these are `nothing`s and the getter
@@ -70,7 +74,7 @@ end
     return (u=uᵒᶜ, v=vᵒᶜ, T=Tᵒᶜ, S=Sᵒᶜ)
 end
 
-@inline function assemble_interior_state(i, j, kᴺ, grid, interior_state, ocean_properties, ::SkinTemperature{<:DiffusiveFlux{<:Any, <:InteriorDiffusivity}})
+@inline function assemble_interior_state(i, j, kᴺ, grid, interior_state, ocean_properties, ::IDST)
     Ψᵢ = assemble_interior_state(i, j, kᴺ, grid, interior_state, ocean_properties, nothing)
     κ  = @inbounds interior_state.κ[i, j, 1]
     return merge(Ψᵢ, (; κ))

--- a/src/EarthSystemModels/InterfaceComputations/component_interfaces.jl
+++ b/src/EarthSystemModels/InterfaceComputations/component_interfaces.jl
@@ -449,8 +449,6 @@ function ComponentInterfaces(atmosphere, ocean, sea_ice=nothing;
     exchanger = StateExchanger(exchange_grid, radiation, atmosphere, land, ocean, sea_ice;
                                atmosphere_correction = exchanger_correction)
 
-    validate_interior_fields(atmosphere_ocean_interface_temperature, exchanger.ocean)
-
     properties = (; gravitational_acceleration)
 
     return ComponentInterfaces(ao_interface,

--- a/src/EarthSystemModels/InterfaceComputations/component_interfaces.jl
+++ b/src/EarthSystemModels/InterfaceComputations/component_interfaces.jl
@@ -347,7 +347,10 @@ Keyword Arguments
 - `freshwater_density`: reference density of freshwater. Default: `default_freshwater_density`.
 - `atmosphere_ocean_fluxes`: flux formulation for atmosphere-ocean interface. Default: `SimilarityTheoryFluxes()`.
 - `atmosphere_sea_ice_fluxes`: flux formulation for atmosphere-sea ice interface. Default: `SimilarityTheoryFluxes()`.
-- `atmosphere_ocean_interface_temperature`: temperature formulation for atmosphere-ocean interface. Default: `BulkTemperature()`.
+- `atmosphere_ocean_interface_temperature`: temperature formulation for atmosphere-ocean interface.
+   Options are `BulkTemperature()` (default) and `SkinTemperature(internal_flux)`, where for the ocean
+   `internal_flux` is a `DiffusiveFlux(δ, κ)` with either a prescribed diffusivity `κ` or an
+   `InteriorDiffusivity()` assessed from the ocean turbulence closure.
 - `atmosphere_ocean_interface_specific_humidity`: specific humidity formulation. Default: `default_ao_specific_humidity(ocean)`.
 - `atmosphere_sea_ice_interface_temperature`: temperature formulation for atmosphere-sea ice interface. Default: `default_ai_temperature(sea_ice)`.
 - `ocean_reference_density`: reference density for the ocean. Default: `reference_density(ocean)`.
@@ -445,6 +448,8 @@ function ComponentInterfaces(atmosphere, ocean, sea_ice=nothing;
 
     exchanger = StateExchanger(exchange_grid, radiation, atmosphere, land, ocean, sea_ice;
                                atmosphere_correction = exchanger_correction)
+
+    validate_interior_fields(atmosphere_ocean_interface_temperature, exchanger.ocean)
 
     properties = (; gravitational_acceleration)
 

--- a/src/EarthSystemModels/InterfaceComputations/component_interfaces.jl
+++ b/src/EarthSystemModels/InterfaceComputations/component_interfaces.jl
@@ -349,7 +349,7 @@ Keyword Arguments
 - `atmosphere_sea_ice_fluxes`: flux formulation for atmosphere-sea ice interface. Default: `SimilarityTheoryFluxes()`.
 - `atmosphere_ocean_interface_temperature`: temperature formulation for atmosphere-ocean interface.
    Options are `BulkTemperature()` (default) and `SkinTemperature(internal_flux)`, where for the ocean
-   `internal_flux` is a `DiffusiveFlux(δ, κ)` with either a prescribed diffusivity `κ` or an
+   `internal_flux` is a `DiffusiveFlux(κ, δ)` with either a prescribed diffusivity `κ` or an
    `InteriorDiffusivity()` assessed from the ocean turbulence closure.
 - `atmosphere_ocean_interface_specific_humidity`: specific humidity formulation. Default: `default_ao_specific_humidity(ocean)`.
 - `atmosphere_sea_ice_interface_temperature`: temperature formulation for atmosphere-sea ice interface. Default: `default_ai_temperature(sea_ice)`.

--- a/src/EarthSystemModels/InterfaceComputations/interface_states.jl
+++ b/src/EarthSystemModels/InterfaceComputations/interface_states.jl
@@ -348,9 +348,51 @@ end
 
 SkinTemperature(internal_flux; max_ΔT=5) = SkinTemperature(internal_flux, max_ΔT)
 
+"""
+    DiffusiveFlux(δ, κ)
+
+Internal flux ``J = - κ (Tₛ - Tᵢ) / δ`` between the interior temperature ``Tᵢ``,
+located a distance ``δ`` below the interface (typically half the spacing of the topmost
+interior cell), and the interface temperature ``Tₛ``. The diffusivity `κ` (m² s⁻¹) is
+either a prescribed constant or an [`InteriorDiffusivity`](@ref) assessed from the
+interior model.
+"""
 struct DiffusiveFlux{Z, K}
     δ :: Z # Boundary layer thickness, as a first guess we will use half the grid spacing
     κ :: K # diffusivity in m² s⁻¹
+end
+
+"""
+    InteriorDiffusivity(FT = Oceananigans.defaults.FloatType; minimum_diffusivity = 1.4e-7)
+
+Diffusivity for a [`DiffusiveFlux`](@ref) that is assessed from the interior model (for example the near-surface 
+vertical diffusivity predicted by the ocean turbulence closure) instead of being prescribed. The assessed value is floored by
+`minimum_diffusivity`, which defaults to the molecular thermal diffusivity of seawater, guarding stably-stratified conditions 
+in which modeled diffusivities vanish.
+"""
+struct InteriorDiffusivity{FT}
+    minimum_diffusivity :: FT
+end
+
+InteriorDiffusivity(FT::DataType = Oceananigans.defaults.FloatType; minimum_diffusivity = 1.4e-7) =
+    InteriorDiffusivity(convert(FT, minimum_diffusivity))
+
+@inline internal_diffusivity(κ::Number, Ψᵢ) = κ
+@inline internal_diffusivity(d::InteriorDiffusivity, Ψᵢ) = max(Ψᵢ.κ, d.minimum_diffusivity)
+
+@inline requires_interior_diffusivity(temperature_formulation) = false
+@inline requires_interior_diffusivity(st::SkinTemperature) = requires_interior_diffusivity(st.internal_flux)
+@inline requires_interior_diffusivity(flux::DiffusiveFlux) = flux.κ isa InteriorDiffusivity
+
+function validate_interior_fields(temperature_formulation, ocean_exchanger)
+    requires_interior_diffusivity(temperature_formulation) || return nothing
+    state = isnothing(ocean_exchanger) ? NamedTuple() : ocean_exchanger.state
+    haskey(state, :κ) ||
+        throw(ArgumentError("$(summary(temperature_formulation)) uses an InteriorDiffusivity, \
+                             which requires an ocean component that exposes its near-surface \
+                             vertical diffusivity. Either use such an ocean component or \
+                             prescribe the diffusivity with SkinTemperature(DiffusiveFlux(δ, κ))."))
+    return nothing
 end
 
 # The flux balance is solved by computing
@@ -388,11 +430,11 @@ end
 #
 # corresponding to a linearization of the outgoing longwave radiation term.
 @inline function flux_balance_temperature(st::SkinTemperature{<:DiffusiveFlux}, Ψₛ, ℙₛ, 𝒬ᵀ, 𝒬ᵛ, ℐꜛˡʷ, Qd, Ψᵢ, ℙᵢ, Ψₐ, ℙₐ)
-    Qa = 𝒬ᵛ + ℐꜛˡʷ + Qd # Net flux (positive out of the ocean)
     F  = st.internal_flux
+    κ  = internal_diffusivity(F.κ, Ψᵢ)
     ρ  = ℙᵢ.reference_density
     c  = ℙᵢ.heat_capacity
-    Qa = (𝒬ᵛ + ℐꜛˡʷ + Qd) # Net flux excluding sensible heat (positive out of the ocean)
+    Qa = 𝒬ᵛ + ℐꜛˡʷ + Qd # Net flux excluding sensible heat (positive out of the ocean)
     λ  = 1 / (ρ * c) # m³ K J⁻¹
     Jᵀ = Qa * λ
 
@@ -403,10 +445,11 @@ end
     # Flux balance: T★ = (Tᵢ κ - (Jᵀ + Ωc Tᵃᵗ) δ) / (κ - Ωc δ)
     # where Ωc = 𝒬ᵀ λ / ΔT. Multiply through by ΔT to avoid Inf when ΔT → 0.
     Ωᵀ = 𝒬ᵀ * λ  # unnormalized sensible heat coefficient (= Ωc * ΔT)
-    D  = F.κ * ΔT - Ωᵀ * F.δ
-    T★ = (Ψᵢ.T * F.κ * ΔT - (Jᵀ * ΔT + Ωᵀ * Tᵃᵗ) * F.δ) / D
-
-    return ifelse(D == 0, Ψₛ.temperature, T★)
+    D  = κ * ΔT - Ωᵀ * F.δ
+    T★ = (Ψᵢ.T * κ * ΔT - (Jᵀ * ΔT + Ωᵀ * Tᵃᵗ) * F.δ) / D
+    T★ = ifelse(D == 0, Ψₛ.temperature, T★)
+    max_ΔT = convert(typeof(T★), st.max_ΔT)
+    return Ψᵢ.T + clamp(T★ - Ψᵢ.T, -max_ΔT, max_ΔT)
 end
 
 # Solve the surface flux balance equation:

--- a/src/EarthSystemModels/InterfaceComputations/interface_states.jl
+++ b/src/EarthSystemModels/InterfaceComputations/interface_states.jl
@@ -386,18 +386,6 @@ const IDST = SkinTemperature{<:DiffusiveFlux{<:InteriorDiffusivity}}
 assemble_interior_fields(state, temperature_formulation) = Base.structdiff(state, NamedTuple{(:κ,)})
 assemble_interior_fields(state, temperature_formulation::IDST) = state
 
-validate_interior_fields(temperature_formulation, ocean_exchanger) = nothing
-
-function validate_interior_fields(temperature_formulation::IDST, ocean_exchanger)
-    state = isnothing(ocean_exchanger) ? NamedTuple() : ocean_exchanger.state
-    haskey(state, :κ) ||
-        throw(ArgumentError("$(summary(temperature_formulation)) uses an InteriorDiffusivity, \
-                             which requires an ocean component that exposes its near-surface \
-                             vertical diffusivity. Either use such an ocean component or \
-                             prescribe the diffusivity with SkinTemperature(DiffusiveFlux(κ, δ))."))
-    return nothing
-end
-
 # The flux balance is solved by computing
 #
 #            κ

--- a/src/EarthSystemModels/InterfaceComputations/interface_states.jl
+++ b/src/EarthSystemModels/InterfaceComputations/interface_states.jl
@@ -30,7 +30,6 @@ function Base.summary(q★::ImpureSaturationSpecificHumidity)
         "Liquid"
     end
 
-
     return string("ImpureSaturationSpecificHumidity{$phase_str}(water_mole_fraction=",
                   prettysummary(q★.water_mole_fraction), ")")
 end
@@ -365,9 +364,9 @@ end
 """
     InteriorDiffusivity(FT = Oceananigans.defaults.FloatType; minimum_diffusivity = 1.4e-7)
 
-Diffusivity for a [`DiffusiveFlux`](@ref) that is assessed from the interior model (for example the near-surface 
+Diffusivity for a [`DiffusiveFlux`](@ref) that is assessed from the interior model (for example the near-surface
 vertical diffusivity predicted by the ocean turbulence closure) instead of being prescribed. The assessed value is floored by
-`minimum_diffusivity`, which defaults to the molecular thermal diffusivity of seawater, guarding stably-stratified conditions 
+`minimum_diffusivity`, which defaults to the molecular thermal diffusivity of seawater, guarding stably-stratified conditions
 in which modeled diffusivities vanish.
 """
 struct InteriorDiffusivity{FT}
@@ -421,8 +420,10 @@ assemble_interior_fields(state, temperature_formulation::IDST) = state
 #
 # corresponding to a linearization of the outgoing longwave radiation term.
 @inline function flux_balance_temperature(st::SkinTemperature{<:DiffusiveFlux}, Ψₛ, ℙₛ, 𝒬ᵀ, 𝒬ᵛ, ℐꜛˡʷ, Qd, Ψᵢ, ℙᵢ, Ψₐ, ℙₐ)
+    FT = typeof(Ψₛ.temperature)
     F  = st.internal_flux
-    κ  = internal_diffusivity(F.κ, Ψᵢ)
+    κ  = convert(FT, internal_diffusivity(F.κ, Ψᵢ))
+    δ  = convert(FT, F.δ)
     ρ  = ℙᵢ.reference_density
     c  = ℙᵢ.heat_capacity
     Qa = 𝒬ᵛ + ℐꜛˡʷ + Qd # Net flux excluding sensible heat (positive out of the ocean)
@@ -436,10 +437,10 @@ assemble_interior_fields(state, temperature_formulation::IDST) = state
     # Flux balance: T★ = (Tᵢ κ - (Jᵀ + Ωc Tᵃᵗ) δ) / (κ - Ωc δ)
     # where Ωc = 𝒬ᵀ λ / ΔT. Multiply through by ΔT to avoid Inf when ΔT → 0.
     Ωᵀ = 𝒬ᵀ * λ  # unnormalized sensible heat coefficient (= Ωc * ΔT)
-    D  = κ * ΔT - Ωᵀ * F.δ
-    T★ = (Ψᵢ.T * κ * ΔT - (Jᵀ * ΔT + Ωᵀ * Tᵃᵗ) * F.δ) / D
+    D  = κ * ΔT - Ωᵀ * δ
+    T★ = (Ψᵢ.T * κ * ΔT - (Jᵀ * ΔT + Ωᵀ * Tᵃᵗ) * δ) / D
     T★ = ifelse(D == 0, Ψₛ.temperature, T★)
-    max_ΔT = convert(typeof(T★), st.max_ΔT)
+    max_ΔT = convert(FT, st.max_ΔT)
     return Ψᵢ.T + clamp(T★ - Ψᵢ.T, -max_ΔT, max_ΔT)
 end
 

--- a/src/EarthSystemModels/InterfaceComputations/interface_states.jl
+++ b/src/EarthSystemModels/InterfaceComputations/interface_states.jl
@@ -349,7 +349,7 @@ end
 SkinTemperature(internal_flux; max_ΔT=5) = SkinTemperature(internal_flux, max_ΔT)
 
 """
-    DiffusiveFlux(δ, κ)
+    DiffusiveFlux(κ, δ)
 
 Internal flux ``J = - κ (Tₛ - Tᵢ) / δ`` between the interior temperature ``Tᵢ``,
 located a distance ``δ`` below the interface (typically half the spacing of the topmost
@@ -357,9 +357,9 @@ interior cell), and the interface temperature ``Tₛ``. The diffusivity `κ` (m�
 either a prescribed constant or an [`InteriorDiffusivity`](@ref) assessed from the
 interior model.
 """
-struct DiffusiveFlux{Z, K}
-    δ :: Z # Boundary layer thickness, as a first guess we will use half the grid spacing
+struct DiffusiveFlux{K, Z}
     κ :: K # diffusivity in m² s⁻¹
+    δ :: Z # Boundary layer thickness, as a first guess we will use half the grid spacing
 end
 
 """
@@ -374,24 +374,27 @@ struct InteriorDiffusivity{FT}
     minimum_diffusivity :: FT
 end
 
-InteriorDiffusivity(FT::DataType = Oceananigans.defaults.FloatType; minimum_diffusivity = 1.4e-7) =
-    InteriorDiffusivity(convert(FT, minimum_diffusivity))
+InteriorDiffusivity(FT::DataType = Oceananigans.defaults.FloatType; minimum_diffusivity = 1.4e-7) =  InteriorDiffusivity(convert(FT, minimum_diffusivity))
 
 @inline internal_diffusivity(κ::Number, Ψᵢ) = κ
 @inline internal_diffusivity(d::InteriorDiffusivity, Ψᵢ) = max(Ψᵢ.κ, d.minimum_diffusivity)
 
-@inline requires_interior_diffusivity(temperature_formulation) = false
-@inline requires_interior_diffusivity(st::SkinTemperature) = requires_interior_diffusivity(st.internal_flux)
-@inline requires_interior_diffusivity(flux::DiffusiveFlux) = flux.κ isa InteriorDiffusivity
+# A skin temperature whose internal flux uses the interior model's diffusivity
+const IDST = SkinTemperature{<:DiffusiveFlux{<:InteriorDiffusivity}}
 
-function validate_interior_fields(temperature_formulation, ocean_exchanger)
-    requires_interior_diffusivity(temperature_formulation) || return nothing
+# We try to keep the parameter space clean. If we do not need the diffusivity we remove it.
+assemble_interior_fields(state, temperature_formulation) = Base.structdiff(state, NamedTuple{(:κ,)})
+assemble_interior_fields(state, temperature_formulation::IDST) = state
+
+validate_interior_fields(temperature_formulation, ocean_exchanger) = nothing
+
+function validate_interior_fields(temperature_formulation::IDST, ocean_exchanger)
     state = isnothing(ocean_exchanger) ? NamedTuple() : ocean_exchanger.state
     haskey(state, :κ) ||
         throw(ArgumentError("$(summary(temperature_formulation)) uses an InteriorDiffusivity, \
                              which requires an ocean component that exposes its near-surface \
                              vertical diffusivity. Either use such an ocean component or \
-                             prescribe the diffusivity with SkinTemperature(DiffusiveFlux(δ, κ))."))
+                             prescribe the diffusivity with SkinTemperature(DiffusiveFlux(κ, δ))."))
     return nothing
 end
 

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -76,6 +76,8 @@ export
     ComponentInterfaces,
     SkinTemperature,
     BulkTemperature,
+    DiffusiveFlux,
+    InteriorDiffusivity,
     # Land (prognostic SlabLand + closures)
     SlabLand,
     SlabEnergy,

--- a/src/Oceans/Oceans.jl
+++ b/src/Oceans/Oceans.jl
@@ -5,6 +5,7 @@ export ocean_simulation, SlabOcean, PrescribedOcean
 using Adapt: Adapt, adapt
 using KernelAbstractions: @kernel, @index
 using Oceananigans: Oceananigans
+using Oceananigans.AbstractOperations: KernelFunctionOperation
 using Oceananigans.Advection: WENO, WENOVectorInvariant
 using Oceananigans.BoundaryConditions: DefaultBoundaryCondition, DiscreteBoundaryFunction,
                                        FieldBoundaryConditions, FluxBoundaryCondition, getbc
@@ -20,6 +21,7 @@ using Oceananigans.Models.NonhydrostaticModels: NonhydrostaticModel
 using Oceananigans.OrthogonalSphericalShellGrids: OrthogonalSphericalShellGrids, TripolarGrid
 using Oceananigans.Operators: ℑxyᶠᶜᵃ, ℑxyᶜᶠᵃ, ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ∂xᶠᶜᶜ, ∂yᶜᶠᶜ
 using Oceananigans.Simulations: Simulation
+using Oceananigans.TurbulenceClosures: κzᶜᶜᶠ
 using Oceananigans.TurbulenceClosures.TKEBasedVerticalDiffusivities: CATKEVerticalDiffusivity,
                                                                      CATKEMixingLength,
                                                                      CATKEEquation
@@ -110,7 +112,42 @@ function EarthSystemModels.InterfaceComputations.ComponentExchanger(ocean::Ocean
         S = Field{Center, Center, Nothing}(grid)
     end
 
-    return ComponentExchanger((; u, v, T, S), nothing)
+    # Near-surface vertical tracer diffusivity, evaluated lazily inside the
+    # interface flux kernel by formulations that consume it (`InteriorDiffusivity`).
+    model = ocean.model
+    temperature_index = findfirst(name -> name === :T, collect(keys(model.tracers)))
+    κ = KernelFunctionOperation{Center, Center, Nothing}(Σκzᴺ,
+                                                         ocean_grid,
+                                                         model.closure,
+                                                         model.closure_fields,
+                                                         Val(temperature_index),
+                                                         model.clock,
+                                                         Oceananigans.fields(model))
+
+    return ComponentExchanger((; u, v, T, S, κ), nothing)
+end
+
+#####
+##### Near-surface vertical diffusivity assessment
+#####
+
+# Total vertical tracer diffusivity at (Center, Center, Face), summed over the
+# closures of a closure tuple. `κzᶜᶜᶠ` falls back to zero for closures without
+# an explicit vertical diffusivity (e.g. purely horizontal ones).
+@inline Σκzᶜᶜᶠ(i, j, k, grid, closure, K, id, clock, model_fields) =
+    κzᶜᶜᶠ(i, j, k, grid, closure, K, id, clock, model_fields)
+
+@inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple, K::Tuple, id, clock, model_fields) =
+    κzᶜᶜᶠ(i, j, k, grid, first(closure), first(K), id, clock, model_fields) +
+    Σκzᶜᶜᶠ(i, j, k, grid, Base.tail(closure), Base.tail(K), id, clock, model_fields)
+
+@inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple{}, K::Tuple{}, id, clock, model_fields) = zero(grid)
+
+# Evaluated at the topmost interior face: boundary-layer closures (e.g. CATKE)
+# have a vanishing mixing length, and thus vanishing diffusivity, at the surface face.
+@inline function Σκzᴺ(i, j, k, grid, closure, K, id, clock, model_fields)
+    Nz = size(grid, 3)
+    return Σκzᶜᶜᶠ(i, j, Nz, grid, closure, K, id, clock, model_fields)
 end
 
 @inline net_flux(condition) = condition

--- a/src/Oceans/Oceans.jl
+++ b/src/Oceans/Oceans.jl
@@ -152,8 +152,8 @@ end
     κzᶜᶜᶠ(i, j, k, grid, closure[4], K[4], id, clock, model_fields) 
 
 @inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple, K::Tuple, id, clock, model_fields) =
-    κzᶜᶜᶠ(i, j, k, grid,  closure[1],     K[1],    id, clock, model_fields) +
-    Σκzᶜᶜᶠ(i, j, k, grid, closure[2:end], K[2:end] id, clock, model_fields)
+    κzᶜᶜᶠ(i, j, k, grid,  closure[1],     K[1],     id, clock, model_fields) +
+    Σκzᶜᶜᶠ(i, j, k, grid, closure[2:end], K[2:end], id, clock, model_fields)
 
 # Evaluated at the topmost interior face: boundary-layer closures (e.g. CATKE)
 # have a vanishing mixing length, and thus vanishing diffusivity, at the surface face.

--- a/src/Oceans/Oceans.jl
+++ b/src/Oceans/Oceans.jl
@@ -131,7 +131,7 @@ end
 ##### Near-surface vertical diffusivity assessment
 #####
 
-# Total vertical tracer diffusivity at the surface. Salls back to zero for closures without vertical diffusivity
+# Total vertical tracer diffusivity at the surface. Falls back to zero for closures without vertical diffusivity
 @inline Σκzᶜᶜᶠ(i, j, k, grid, closure, K, id, clock, model_fields) = κzᶜᶜᶠ(i, j, k, grid, closure, K, id, clock, model_fields)
 
 @inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple{}, K::Tuple{}, id, clock, model_fields) = zero(grid)

--- a/src/Oceans/Oceans.jl
+++ b/src/Oceans/Oceans.jl
@@ -137,15 +137,18 @@ end
 @inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple{}, K::Tuple{}, id, clock, model_fields) = zero(grid)
 
 @inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple{<:Any}, K::Tuple{<:Any}, id, clock, model_fields) =
+    κzᶜᶜᶠ(i, j, k, grid, closure[1], K[1], id, clock, model_fields) 
+
+@inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple{<:Any, <:Any}, K::Tuple{<:Any, <:Any}, id, clock, model_fields) =
     κzᶜᶜᶠ(i, j, k, grid, closure[1], K[1], id, clock, model_fields) +
     κzᶜᶜᶠ(i, j, k, grid, closure[2], K[2], id, clock, model_fields) 
 
-@inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple{<:Any, <:Any}, K::Tuple{<:Any, <:Any}, id, clock, model_fields) =
+@inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple{<:Any, <:Any, <:Any}, K::Tuple{<:Any, <:Any, <:Any}, id, clock, model_fields) =
     κzᶜᶜᶠ(i, j, k, grid, closure[1], K[1], id, clock, model_fields) +
     κzᶜᶜᶠ(i, j, k, grid, closure[2], K[2], id, clock, model_fields) +
     κzᶜᶜᶠ(i, j, k, grid, closure[3], K[3], id, clock, model_fields) 
 
-@inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple{<:Any, <:Any, <:Any}, K::Tuple{<:Any, <:Any, <:Any}, id, clock, model_fields) =
+@inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple{<:Any, <:Any, <:Any, <:Any}, K::Tuple{<:Any, <:Any, <:Any, <:Any}, id, clock, model_fields) =
     κzᶜᶜᶠ(i, j, k, grid, closure[1], K[1], id, clock, model_fields) +
     κzᶜᶜᶠ(i, j, k, grid, closure[2], K[2], id, clock, model_fields) +
     κzᶜᶜᶠ(i, j, k, grid, closure[3], K[3], id, clock, model_fields) +

--- a/src/Oceans/Oceans.jl
+++ b/src/Oceans/Oceans.jl
@@ -158,8 +158,6 @@ end
     κzᶜᶜᶠ(i, j, k, grid,  closure[1],     K[1],     id, clock, model_fields) +
     Σκzᶜᶜᶠ(i, j, k, grid, closure[2:end], K[2:end], id, clock, model_fields)
 
-# Evaluated at the topmost interior face: boundary-layer closures (e.g. CATKE)
-# have a vanishing mixing length, and thus vanishing diffusivity, at the surface face.
 @inline function Σκzᴺ(i, j, k, grid, closure, K, id, clock, model_fields)
     Nz = size(grid, 3)
     return Σκzᶜᶜᶠ(i, j, Nz, grid, closure, K, id, clock, model_fields)

--- a/src/Oceans/Oceans.jl
+++ b/src/Oceans/Oceans.jl
@@ -131,17 +131,29 @@ end
 ##### Near-surface vertical diffusivity assessment
 #####
 
-# Total vertical tracer diffusivity at (Center, Center, Face), summed over the
-# closures of a closure tuple. `κzᶜᶜᶠ` falls back to zero for closures without
-# an explicit vertical diffusivity (e.g. purely horizontal ones).
-@inline Σκzᶜᶜᶠ(i, j, k, grid, closure, K, id, clock, model_fields) =
-    κzᶜᶜᶠ(i, j, k, grid, closure, K, id, clock, model_fields)
-
-@inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple, K::Tuple, id, clock, model_fields) =
-    κzᶜᶜᶠ(i, j, k, grid, first(closure), first(K), id, clock, model_fields) +
-    Σκzᶜᶜᶠ(i, j, k, grid, Base.tail(closure), Base.tail(K), id, clock, model_fields)
+# Total vertical tracer diffusivity at the surface. Salls back to zero for closures without vertical diffusivity
+@inline Σκzᶜᶜᶠ(i, j, k, grid, closure, K, id, clock, model_fields) = κzᶜᶜᶠ(i, j, k, grid, closure, K, id, clock, model_fields)
 
 @inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple{}, K::Tuple{}, id, clock, model_fields) = zero(grid)
+
+@inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple{<:Any}, K::Tuple{<:Any}, id, clock, model_fields) =
+    κzᶜᶜᶠ(i, j, k, grid, closure[1], K[1], id, clock, model_fields) +
+    κzᶜᶜᶠ(i, j, k, grid, closure[2], K[2], id, clock, model_fields) 
+
+@inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple{<:Any, <:Any}, K::Tuple{<:Any, <:Any}, id, clock, model_fields) =
+    κzᶜᶜᶠ(i, j, k, grid, closure[1], K[1], id, clock, model_fields) +
+    κzᶜᶜᶠ(i, j, k, grid, closure[2], K[2], id, clock, model_fields) +
+    κzᶜᶜᶠ(i, j, k, grid, closure[3], K[3], id, clock, model_fields) 
+
+@inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple{<:Any, <:Any, <:Any}, K::Tuple{<:Any, <:Any, <:Any}, id, clock, model_fields) =
+    κzᶜᶜᶠ(i, j, k, grid, closure[1], K[1], id, clock, model_fields) +
+    κzᶜᶜᶠ(i, j, k, grid, closure[2], K[2], id, clock, model_fields) +
+    κzᶜᶜᶠ(i, j, k, grid, closure[3], K[3], id, clock, model_fields) +
+    κzᶜᶜᶠ(i, j, k, grid, closure[4], K[4], id, clock, model_fields) 
+
+@inline Σκzᶜᶜᶠ(i, j, k, grid, closure::Tuple, K::Tuple, id, clock, model_fields) =
+    κzᶜᶜᶠ(i, j, k, grid,  closure[1],     K[1],    id, clock, model_fields) +
+    Σκzᶜᶜᶠ(i, j, k, grid, closure[2:end], K[2:end] id, clock, model_fields)
 
 # Evaluated at the topmost interior face: boundary-layer closures (e.g. CATKE)
 # have a vanishing mixing length, and thus vanishing diffusivity, at the surface face.

--- a/test/test_surface_fluxes.jl
+++ b/test/test_surface_fluxes.jl
@@ -12,6 +12,7 @@ using NumericalEarth.EarthSystemModels.InterfaceComputations: ComponentInterface
                                                               SkinTemperature,
                                                               BulkTemperature,
                                                               DiffusiveFlux,
+                                                              InteriorDiffusivity,
                                                               SkinHumidity,
                                                               FractionalHumidity,
                                                               CriticalSaturation,
@@ -76,7 +77,9 @@ end
 
             # No radiation: pass `radiation = nothing` to disable radiative
             # contributions wholesale.
-            for atmosphere_ocean_interface_temperature in (BulkTemperature(), SkinTemperature(DiffusiveFlux(1, 1e-2)))
+            for atmosphere_ocean_interface_temperature in (BulkTemperature(),
+                                                           SkinTemperature(DiffusiveFlux(1, 1e-2)),
+                                                           SkinTemperature(DiffusiveFlux(1, InteriorDiffusivity())))
                 @info " Testing zero fluxes with $(atmosphere_ocean_interface_temperature)..."
 
                 interfaces = ComponentInterfaces(atmosphere, ocean;
@@ -104,6 +107,31 @@ end
                 @test turbulent_fluxes.latent_heat[1, 1, 1]   < eps(eltype(grid))
                 @test turbulent_fluxes.water_vapor[1, 1, 1]   < eps(eltype(grid))
             end
+
+            @info " Testing interior diffusivity assessment..."
+
+            # The assessed diffusivity is the total vertical tracer diffusivity
+            # at the topmost interior face, summed over the closure tuple.
+            closure = (VerticalScalarDiffusivity(κ=1e-3), VerticalScalarDiffusivity(κ=2e-3))
+            diffusive_ocean = ocean_simulation(grid;
+                                               momentum_advection = nothing,
+                                               tracer_advection = nothing,
+                                               closure,
+                                               bottom_drag_coefficient = 0)
+
+            set!(diffusive_ocean.model, T = 15, S = 30)
+
+            skin_temperature = SkinTemperature(DiffusiveFlux(0.5, InteriorDiffusivity()))
+            interfaces = ComponentInterfaces(atmosphere, diffusive_ocean;
+                                             atmosphere_ocean_interface_temperature = skin_temperature)
+
+            coupled_model = OceanOnlyModel(diffusive_ocean; atmosphere, interfaces)
+            assessed_diffusivity = compute!(Field(interfaces.exchanger.ocean.state.κ))
+            @test all(Array(interior(assessed_diffusivity)) .≈ 3e-3)
+
+            # The skin temperature solve runs with the assessed diffusivity
+            Tₛ = interfaces.atmosphere_ocean_interface.temperature
+            @test all(isfinite, Array(interior(Tₛ)))
 
             @info " Testing neutral fluxes..."
 

--- a/test/test_surface_fluxes.jl
+++ b/test/test_surface_fluxes.jl
@@ -111,10 +111,15 @@ end
 
             @info " Testing interior diffusivity assessment..."
 
-            # The assessed diffusivity is the total vertical tracer diffusivity
-            # at the topmost interior face, summed over the closure tuple.
+            column_grid = RectilinearGrid(arch, Float32;
+                                          size = 1,
+                                          x = 10,
+                                          y = 10,
+                                          z = (-1, 0),
+                                          topology = (Flat, Flat, Bounded))
+
             closure = (VerticalScalarDiffusivity(κ=1e-3), VerticalScalarDiffusivity(κ=2e-3))
-            diffusive_ocean = ocean_simulation(grid;
+            diffusive_ocean = ocean_simulation(column_grid;
                                                momentum_advection = nothing,
                                                tracer_advection = nothing,
                                                closure,

--- a/test/test_surface_fluxes.jl
+++ b/test/test_surface_fluxes.jl
@@ -13,6 +13,7 @@ using NumericalEarth.EarthSystemModels.InterfaceComputations: ComponentInterface
                                                               BulkTemperature,
                                                               DiffusiveFlux,
                                                               InteriorDiffusivity,
+                                                              assemble_interior_fields,
                                                               SkinHumidity,
                                                               FractionalHumidity,
                                                               CriticalSaturation,
@@ -78,8 +79,8 @@ end
             # No radiation: pass `radiation = nothing` to disable radiative
             # contributions wholesale.
             for atmosphere_ocean_interface_temperature in (BulkTemperature(),
-                                                           SkinTemperature(DiffusiveFlux(1, 1e-2)),
-                                                           SkinTemperature(DiffusiveFlux(1, InteriorDiffusivity())))
+                                                           SkinTemperature(DiffusiveFlux(1e-2, 1)),
+                                                           SkinTemperature(DiffusiveFlux(InteriorDiffusivity(), 1)))
                 @info " Testing zero fluxes with $(atmosphere_ocean_interface_temperature)..."
 
                 interfaces = ComponentInterfaces(atmosphere, ocean;
@@ -121,7 +122,7 @@ end
 
             set!(diffusive_ocean.model, T = 15, S = 30)
 
-            skin_temperature = SkinTemperature(DiffusiveFlux(0.5, InteriorDiffusivity()))
+            skin_temperature = SkinTemperature(DiffusiveFlux(InteriorDiffusivity(), 0.5))
             interfaces = ComponentInterfaces(atmosphere, diffusive_ocean;
                                              atmosphere_ocean_interface_temperature = skin_temperature)
 
@@ -132,6 +133,12 @@ end
             # The skin temperature solve runs with the assessed diffusivity
             Tₛ = interfaces.atmosphere_ocean_interface.temperature
             @test all(isfinite, Array(interior(Tₛ)))
+
+            # The diffusivity operation is stripped from the kernel arguments
+            # unless the temperature formulation needs it
+            exchanged_state = interfaces.exchanger.ocean.state
+            @test !haskey(assemble_interior_fields(exchanged_state, BulkTemperature()), :κ)
+            @test haskey(assemble_interior_fields(exchanged_state, skin_temperature), :κ)
 
             @info " Testing neutral fluxes..."
 


### PR DESCRIPTION
This allows us to assess the skin temperature consistently with what the ocean does in the interior. In this case it will be something like:
```julia
ocean = ocean_simulation(grid; ...)
interior_flux = DiffusiveFlux(InteriorDiffusivity(), Δzᶜᶜᶠ(i, j, k, grid) / 2))
interfaces = ComponentInterfaces(atmosphere, ocean; atmosphere_ocean_interface_temperature = SkinTemperature(interior_flux))
```

