### PR TITLE
Fix veros' docs fragility

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
       - ".github/workflows/docs.yml"
       - "docs/**"
       - "examples/**"
+      - "ext/**"
       - "src/**"
       - "Project.toml"
   push:

--- a/ext/NumericalEarthVerosExt/NumericalEarthVerosExt.jl
+++ b/ext/NumericalEarthVerosExt/NumericalEarthVerosExt.jl
@@ -1,6 +1,7 @@
 module NumericalEarthVerosExt
 
 using CondaPkg: CondaPkg
+using Downloads: Downloads
 using Oceananigans: Oceananigans
 using Oceananigans.Architectures: CPU
 using Oceananigans.Fields: Field

--- a/ext/NumericalEarthVerosExt/veros_ocean_simulation.jl
+++ b/ext/NumericalEarthVerosExt/veros_ocean_simulation.jl
@@ -3,6 +3,9 @@ using Oceananigans.Fields: set!
 using NumericalEarth: NumericalEarth
 using NumericalEarth.EarthSystemModels: EarthSystemModel, ocean_salinity
 
+const veros_version = "1.6.2"
+const veros_requirements_url = "https://raw.githubusercontent.com/team-ocean/veros/v$(veros_version)/requirements.txt"
+
 """
     install_veros()
 
@@ -11,17 +14,23 @@ Returns a NamedTuple containing package information if successful.
 Also patches Veros's signal handling to work with PythonCall.
 """
 function install_veros()
-    # Veros uses hdf5 < 2. The shenanigans in the following two lines
-    # are necessary to allow loading compatible hdf5 and h5py.
-    CondaPkg.add("hdf5"; version="<2", channel="conda-forge")
-    CondaPkg.add("h5py"; version=">=3.0,<3.13", channel="conda-forge")
-    # veros main pins requests==2.34.0; drop once team-ocean/veros#829 merges
-    CondaPkg.add("requests"; version="==2.34.0", channel="conda-forge")
-    CondaPkg.add_pip("veros", version="@ https://github.com/team-ocean/veros/archive/refs/heads/main.zip")
+    # Veros' setup.py rewrites every `==` pin in its requirements.txt into a `<=` cap,
+    # and pixi treats conda-installed packages as hard pins during the pip solve, so any
+    # conda-forge release newer than a veros cap makes the environment unsatisfiable.
+    # Mirroring the caps as conda pins keeps the conda solve within what veros accepts.
+    requirements = Downloads.download(veros_requirements_url, IOBuffer())
+    for line in eachline(seekstart(requirements))
+        # skip requirements with environment markers (`pkg==1.0; python_version < ...`)
+        pinned_requirement = match(r"^([A-Za-z0-9._-]+)==([^;\s]+)$", strip(line))
+        isnothing(pinned_requirement) && continue
+        package_name, pinned_version = pinned_requirement.captures
+        CondaPkg.add(package_name; version="<=" * pinned_version, channel="conda-forge", resolve=false)
+    end
+
+    CondaPkg.add_pip("veros", version="==" * veros_version)
     cli = CondaPkg.which("veros")
 
     # Patch signal handling as early as possible
-    # This ensures it's patched before any Veros modules are used
     patch_veros_signal_handling()
 
     @info "... the veros CLI has been installed at $(cli)."


### PR DESCRIPTION
Every time the python ecosystem is updated, the veros simulation breaks.
In this PR I am fixing the version of veros to 1.6.2 and making sure we install the correct requirements for the package.
This should solve the fragility issue