### PR TITLE
Bump version from 0.5.4 to 0.5.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NumericalEarth"
 uuid = "904d977b-046a-4731-8b86-9235c0d1ef02"
 license = "MIT"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["NumericalEarth contributors"]
 
 [deps]


### PR DESCRIPTION
To capture #321 which are needed for ClimaOcean and ClimaCoupler