### PR TITLE
Support Breeze 0.6 alongside 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NumericalEarth"
 uuid = "904d977b-046a-4731-8b86-9235c0d1ef02"
 license = "MIT"
-version = "0.5.5"
+version = "0.5.6"
 authors = ["NumericalEarth contributors"]
 
 [deps]
@@ -61,7 +61,7 @@ NumericalEarthWOAExt = "WorldOceanAtlasTools"
 Accessors = "0.1.44"
 Adapt = "4"
 ArchGDAL = "0.10"
-Breeze = "0.5.3"
+Breeze = "0.5.3, 0.6"
 CDSAPI = "2.2.1"
 CFTime = "0.1, 0.2"
 ClimaSeaIce = "0.5.6"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -28,7 +28,7 @@ Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 NumericalEarth = {path = ".."}
 
 [compat]
-Breeze = "0.5.3"
+Breeze = "0.5.3, 0.6"
 CUDA = "~6.0"
 CairoMakie = "0.15"
 ConservativeRegridding = "0.2"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -36,7 +36,7 @@ NumericalEarth = {path = ".."}
 
 [compat]
 ArchGDAL = "0.10"
-Breeze = "0.5.3"
+Breeze = "0.5.3, 0.6"
 CDSAPI = "2.2.2"
 CFTime = "0.1, 0.2"
 CUDA = "5.9.5"


### PR DESCRIPTION
## Summary

Widens the `Breeze` compat bound to `"0.5.3, 0.6"` in the root, `test/`, and `docs/` `Project.toml` so NumericalEarth supports **both** Breeze 0.5.x and 0.6.x. Bumps the package version `0.5.5` → `0.5.6` (patch — no change to NumericalEarth's own public API).

## Why this is sufficient

Breeze 0.6.0's two breaking changes are:
1. The terrain-following API rewrite (`follow_terrain!` → `TerrainFollowingVerticalDiscretization` + `materialize_terrain!`).
2. `OpenBoundaryCondition` → `NormalFlowBoundaryCondition`, which requires Oceananigans 0.110.

Neither affects us:
- `ext/NumericalEarthBreezeExt/`, the Breeze examples (`breeze_over_four_oceans.jl`, `breeze_over_slab_land.jl`), and `test/test_breeze_coupling.jl` use only `AtmosphereModel`, `RadiativeTransferModel`, `thermodynamic_density`, `radiation_flux_divergence`, and `update_radiation!` — none of which changed.
- Our Oceananigans compat is already `0.110.1, 0.111`, satisfying Breeze 0.6.0.

## Test plan
- [ ] CI resolves and loads the env against both Breeze 0.5.x and 0.6.x
- [ ] Breeze coupling tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)