### PR TITLE
Couple a compressible (terrain-following) Breeze atmosphere

### DIFF
--- a/ext/NumericalEarthBreezeExt/breeze_atmosphere_interface.jl
+++ b/ext/NumericalEarthBreezeExt/breeze_atmosphere_interface.jl
@@ -1,4 +1,5 @@
 using Oceananigans.Grids: Center
+using GPUArraysCore: @allowscalar
 using Breeze.AtmosphereModels: thermodynamic_density
 using NumericalEarth.Atmospheres: AtmosphereThermodynamicsParameters
 using NumericalEarth.EarthSystemModels: component_model
@@ -26,10 +27,12 @@ NumericalEarth.EarthSystemModels.thermodynamics_parameters(atmos::BreezeAtmosphe
 #####
 
 # Height of the lowest atmospheric cell center (the "surface layer").
-# Note: for stretched grids on GPU, this may require allowscalar.
+# `zspacing` of the lowest cell reads a single device-array element on stretched or
+# terrain-following grids (GPU); `@allowscalar` permits that one scalar read.
 function NumericalEarth.EarthSystemModels.surface_layer_height(atmosphere::BreezeAtmosphere)
     grid = atmosphere.grid
-    return Oceananigans.zspacing(1, 1, 1, grid, Center(), Center(), Center()) / 2
+    Δz = @allowscalar Oceananigans.zspacing(1, 1, 1, grid, Center(), Center(), Center())
+    return Δz / 2
 end
 
 NumericalEarth.EarthSystemModels.surface_layer_height(atmos::BreezeAtmosphereSim) =
@@ -87,10 +90,19 @@ function NumericalEarth.EarthSystemModels.interpolate_state!(exchanger, exchange
     T = atmosphere.temperature
     ρqᵛᵉ = atmosphere.moisture_density
 
-    # Reference state (anelastic dynamics)
+    # Surface air density ρ₀ and pressure p₀. Anelastic dynamics expose a hydrostatic
+    # `reference_state` carrying both. Compressible (terrain-following) dynamics have
+    # `reference_state === nothing`; they instead carry a 3-D `terrain_reference_density`
+    # (whose surface level `[i, j, 1]` is what the interpolation kernel reads) and a scalar
+    # `surface_pressure`. Fall back to those so either atmosphere couples.
     ref = atmosphere.dynamics.reference_state
-    ρ₀ = ref.density
-    p₀ = ref.surface_pressure
+    if isnothing(ref)
+        ρ₀ = atmosphere.dynamics.terrain_reference_density
+        p₀ = atmosphere.dynamics.surface_pressure
+    else
+        ρ₀ = ref.density
+        p₀ = ref.surface_pressure
+    end
 
     arch = architecture(exchange_grid)
     kernel_parameters = interface_kernel_parameters(exchange_grid)


### PR DESCRIPTION
## Summary

`AtmosphereOceanModel` could not couple a `CompressibleDynamics` (terrain-following)
Breeze atmosphere — the air–sea coupler's Breeze interface assumed anelastic dynamics in
two spots and errored before the first step. Both are fixed in
`ext/NumericalEarthBreezeExt/breeze_atmosphere_interface.jl`:

1. **`interpolate_state!`** read `atmosphere.dynamics.reference_state.density` /
   `.surface_pressure`. Compressible dynamics have `reference_state === nothing`, giving
   `FieldError: type Nothing has no field density`. Now falls back to the 3-D
   `terrain_reference_density` (surface level `[i,j,1]` is exactly what the interpolation
   kernel indexes) and the scalar `surface_pressure`.
2. **`surface_layer_height`** reads the lowest cell's `zspacing`, which indexes a device
   array on a terrain-following GPU grid → `Scalar indexing is disallowed`. The single
   scalar read is now wrapped in `@allowscalar` (GPUArraysCore), as the prior comment hinted.

The anelastic path is unchanged (the new branch only triggers when `reference_state === nothing`).

## Testing

Verified on an NVIDIA GH200: a terrain-following compressible Breeze atmosphere over real
fjord terrain (Nærøyfjord) coupled to a hydrostatic + CATKE immersed-boundary ocean now
steps stably, with air–sea sensible/latent/momentum fluxes computed at the interface and
the ocean responding to the coupled wind stress. Before this change both a full
hydrostatic ocean and a `SlabOcean` failed identically (so it was the atmosphere side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)