### PR TITLE
Allow longitudes "bounding boxes" of 360 degrees  

### DIFF
--- a/src/DataWrangling/metadata_field.jl
+++ b/src/DataWrangling/metadata_field.jl
@@ -60,9 +60,6 @@ function native_convention_longitude(bbox_longitude, native)
     return (λ⁻, λ⁻ + (bbox_longitude[2] - bbox_longitude[1]))
 end
 
-global_longitude(::Nothing) = true
-global_longitude(bbox::BoundingBox) = bbox_longitude[2] - bbox_longitude[1] == 360
-
 restrict_longitude(bbox_interfaces, interfaces, N) =
     restrict(bbox_interfaces, interfaces, N)
 
@@ -73,7 +70,7 @@ function restrict_longitude(bbox_interfaces, interfaces::NTuple{2,Any}, N)
     Δ = (right - left) / N
 
     if bbox_longitude[2] - bbox_longitude[1] == 360
-        return bbox_interfaces, N
+        return interfaces, N
     elseif bbox_interfaces[1] ≥ left && bbox_interfaces[2] > right
         i⁻ = max(floor(Int, (bbox_interfaces[1] - left) / Δ - 1/2), 0)
         i⁺ = ceil(Int, (bbox_interfaces[2] - left) / Δ + 1/2)

--- a/src/DataWrangling/metadata_field.jl
+++ b/src/DataWrangling/metadata_field.jl
@@ -69,7 +69,7 @@ function restrict_longitude(bbox_interfaces, interfaces::NTuple{2,Any}, N)
     left, right = interfaces
     Δ = (right - left) / N
 
-    if bbox_longitude[2] - bbox_longitude[1] == 360
+    if bbox_interfaces[2] - bbox_interfaces[1] == 360
         return interfaces, N
     elseif bbox_interfaces[1] ≥ left && bbox_interfaces[2] > right
         i⁻ = max(floor(Int, (bbox_interfaces[1] - left) / Δ - 1/2), 0)

--- a/src/DataWrangling/metadata_field.jl
+++ b/src/DataWrangling/metadata_field.jl
@@ -60,6 +60,9 @@ function native_convention_longitude(bbox_longitude, native)
     return (λ⁻, λ⁻ + (bbox_longitude[2] - bbox_longitude[1]))
 end
 
+global_longitude(::Nothing) = true
+global_longitude(bbox::BoundingBox) = bbox_longitude[2] - bbox_longitude[1] == 360
+
 restrict_longitude(bbox_interfaces, interfaces, N) =
     restrict(bbox_interfaces, interfaces, N)
 
@@ -69,12 +72,9 @@ function restrict_longitude(bbox_interfaces, interfaces::NTuple{2,Any}, N)
     left, right = interfaces
     Δ = (right - left) / N
 
-    # Longitude bounding boxes may cross the native periodic seam after being
-    # mapped into the dataset's longitude convention, for example -110°..30°
-    # on ERA5's 0°..360° grid becomes 249.875°..389.875°. Preserve that
-    # continuous span (center-bracketed, see `restrict`) instead of clamping to
-    # the native upper face.
-    if bbox_interfaces[1] ≥ left && bbox_interfaces[2] > right
+    if bbox_longitude[2] - bbox_longitude[1] == 360
+        return bbox_interfaces, N
+    elseif bbox_interfaces[1] ≥ left && bbox_interfaces[2] > right
         i⁻ = max(floor(Int, (bbox_interfaces[1] - left) / Δ - 1/2), 0)
         i⁺ = ceil(Int, (bbox_interfaces[2] - left) / Δ + 1/2)
         return (left + i⁻ * Δ, left + i⁺ * Δ), i⁺ - i⁻

--- a/test/test_metadata.jl
+++ b/test/test_metadata.jl
@@ -44,7 +44,7 @@ end
 
     # Restrict location with (0, 360) longitude
     bbox = BoundingBox(longitude=(0, 360), latitude=(0, 10))
-    @test restrict_longitude(bbox.longitude, (0, 360), Nx) == ((0, 360), Nx)
+    @test restrict_longitude(bbox.longitude, (0, 360), 10) == ((0, 360), 10)
 end
 
 @testset "dataset_location fallback" begin

--- a/test/test_metadata.jl
+++ b/test/test_metadata.jl
@@ -3,7 +3,7 @@ include("runtests_setup.jl")
 using NumericalEarth.DataWrangling: Column, Linear, Nearest,
                                     BoundingBox, dataset_location,
                                     restrict_location, native_grid
-using NumericalEarth.DataWrangling: restrict
+using NumericalEarth.DataWrangling: restrict, restrict_longitude
 using NumericalEarth.DataWrangling.ERA5: ERA5HourlySingleLevel
 
 using Oceananigans: location
@@ -41,6 +41,10 @@ end
     bbox = BoundingBox(longitude=(0, 10), latitude=(0, 10))
     @test restrict_location((Face, Center, Center), bbox) == (Face, Center, Center)
     @test restrict_location((Center, Center, Center), nothing) == (Center, Center, Center)
+
+    # Restrict location with (0, 360) longitude
+    bbox = BoundingBox(longitude=(0, 360), latitude=(0, 10))
+    @test restrict_longitude(bbox.longitude, (0, 360), Nx) == ((0, 360), Nx)
 end
 
 @testset "dataset_location fallback" begin


### PR DESCRIPTION
On main, if we use `bbox = BoundingBox(longitude = (0, 360))` the `native_grid` construction will fail with
```julia
ERROR: ArgumentError: Longitudinal extent cannot be greater than 360 degrees.
Stacktrace:
 [1] validate_lat_lon_grid_args(topology::Tuple{…}, size::Tuple{…}, halo::Tuple{…}, FT::Type{…}, latitude::Tuple{…}, longitude::Tuple{…}, z::Vector{…}, precompute_metrics::Bool)
   @ Oceananigans.Grids ~/.julia/packages/Oceananigans/eN7TM/src/Grids/latitude_longitude_grid.jl:295
 [2] LatitudeLongitudeGrid(architecture::CPU, FT::DataType; size::Tuple{…}, longitude::Tuple{…}, latitude::Tuple{…}, z::Vector{…}, radius::Float64, topology::Tuple{…}, precompute_metrics::Bool, halo::Tuple{…})
   @ Oceananigans.Grids ~/.julia/packages/Oceananigans/eN7TM/src/Grids/latitude_longitude_grid.jl:208
 [3] construct_native_grid(metadata::Metadata{…}, bbox::BoundingBox{…}, arch::CPU; halo::Tuple{…})
   @ NumericalEarth.DataWrangling ~/development/NumericalEarth.jl/src/DataWrangling/metadata_field.jl:0
 [4] construct_native_grid
   @ ~/development/NumericalEarth.jl/src/DataWrangling/metadata_field.jl:114 [inlined]
 [5] native_grid
   @ ~/development/NumericalEarth.jl/src/DataWrangling/metadata_field.jl:93 [inlined]
 [6] FieldTimeSeries(metadata::Metadata{…}, arch::CPU; kw::@Kwargs{…})
   @ NumericalEarth.DataWrangling ~/development/NumericalEarth.jl/src/DataWrangling/metadata_field_time_series.jl:34
 [7] top-level scope
   @ REPL[12]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

In theory, a longitude restriction of `longitude = (0, 360)` should be equal to passing `longitude = nothing` aka taking the whole grid.

This PR implements this fix