### PR TITLE
Add Copernicus DEM GLO-30 / GLO-90 topography via Zarr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ env:
   COPERNICUS_PASSWORD: ${{ secrets.COPERNICUSMARINE_SERVICE_PASSWORD }}
   CDSAPI_URL: "https://cds.climate.copernicus.eu/api"
   CDSAPI_KEY: ${{ secrets.CDSAPI_KEY }}
+  DESTINE_ACCESS_TOKEN: ${{ secrets.DESTINE_ACCESS_TOKEN }}
   DATADEPS_ALWAYS_ACCEPT: true
   JULIA_PKG_SERVER_REGISTRY_PREFERENCE: 'eager'
 
@@ -235,7 +236,7 @@ jobs:
               using Pkg;
               Pkg.test(; coverage=true,
                         julia_args=["--check-bounds=yes", "--compiled-modules=yes", "-O0"],
-                        test_args=["--verbose", "test_cds_downloading", "test_jra55_ecco_en4_etopo_downloading", "test_glorys_downloading"])
+                        test_args=["--verbose", "test_cds_downloading", "test_jra55_ecco_en4_etopo_downloading", "test_glorys_downloading", "test_copernicus_dem_downloading"])
           '
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5

--- a/Project.toml
+++ b/Project.toml
@@ -46,6 +46,7 @@ RRTMGP = "a01a1ee8-cea4-48fc-987c-fc7878d79da1"
 Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 SpeedyWeather = "9e226e20-d153-4fed-8a5b-493def4f21a9"
 WorldOceanAtlasTools = "04f20302-f1b9-11e8-29d9-7d841cb0a64a"
+Zarr = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 
 [extensions]
 NumericalEarthArchGDALExt = "ArchGDAL"
@@ -56,6 +57,7 @@ NumericalEarthReactantExt = "Reactant"
 NumericalEarthSpeedyWeatherExt = ["SpeedyWeather", "ConservativeRegridding"]
 NumericalEarthVerosExt = ["PythonCall", "CondaPkg"]
 NumericalEarthWOAExt = "WorldOceanAtlasTools"
+NumericalEarthZarrExt = "Zarr"
 
 [compat]
 Accessors = "0.1.44"
@@ -95,5 +97,6 @@ StaticArrays = "1"
 Statistics = "<0.0.1, 1"
 Thermodynamics = "0.15.3, 1"
 WorldOceanAtlasTools = "0.6"
+Zarr = "0.10"
 ZipFile = "0.10"
 julia = "1.10"

--- a/docs/src/Metadata/supported_variables.md
+++ b/docs/src/Metadata/supported_variables.md
@@ -44,13 +44,13 @@ NumericalEarth currently ships connectors for the following data products:
 ## [Supported variables for GLO30](@id dataset-glo30-vars)
 
 - `:bottom_height` - Surface elevation (Digital Surface Model) on a global 30 m
-  (1 arc-second) grid. Read in regional windows only; requires a DestinE access
-  token and `using Zarr`. See [`GLO30`](@ref).
+  (1 arc-second) grid from the `GLO30` dataset. Read in regional windows only;
+  requires a DestinE access token and `using Zarr`.
 
 ## [Supported variables for GLO90](@id dataset-glo90-vars)
 
 - `:bottom_height` - Surface elevation (Digital Surface Model) on a global 90 m
-  (3 arc-second) grid; the coarser sibling of GLO-30. See [`GLO90`](@ref).
+  (3 arc-second) grid from the `GLO90` dataset; the coarser sibling of GLO-30.
 
 ## [Supported variables for ECCO2Monthly](@id dataset-ecco2monthly-vars)
 

--- a/docs/src/Metadata/supported_variables.md
+++ b/docs/src/Metadata/supported_variables.md
@@ -9,6 +9,8 @@ NumericalEarth currently ships connectors for the following data products:
 | `GEBCO2024`        | [Supported variables](@ref dataset-gebco2024-vars)        | [GEBCO 2024 overview](https://www.gebco.net/data-products/gridded-bathymetry-data)                 |
 | `IBCSOv2`          | [Supported variables](@ref dataset-ibcsov2-vars)          | [IBCSO overview](https://ibcso.org/ibcso-2024-annual-release/)                                     |
 | `IBCAOv5`          | [Supported variables](@ref dataset-ibcaov5-vars)          | [IBCAO overview](https://www.gebco.net/data-products/gridded-bathymetry-data/arctic-ocean)         |
+| `GLO30`            | [Supported variables](@ref dataset-glo30-vars)            | [Copernicus DEM GLO-30 (Earth Data Hub)](https://earthdatahub.destine.eu/collections/copernicus-dem/datasets/GLO-30) |
+| `GLO90`            | [Supported variables](@ref dataset-glo90-vars)            | [Copernicus DEM GLO-90 (Earth Data Hub)](https://earthdatahub.destine.eu/collections/copernicus-dem/datasets/GLO-90) |
 | `ORCA1`            | `:bottom_height`, `:mesh_mask`                            | [ORCA1 mesh and bathymetry (Zenodo)](https://zenodo.org/records/4436658)                           |
 | `ORCA12`           | `:bottom_height`, `:mesh_mask`                            | [ORCA12 mesh and bathymetry (Zenodo)](https://zenodo.org/records/15495870)                         |
 | `GLORYSStatic`     | `:depth`                                                  | [Copernicus GLORYS static product](https://data.marine.copernicus.eu/product/GLOBAL_MULTIYEAR_PHY_001_030/description) |
@@ -38,6 +40,17 @@ NumericalEarth currently ships connectors for the following data products:
 ## [Supported variables for ETOPO2022](@id dataset-etopo2022-vars)
 
 - `:bottom_height` - Global bathymetry/topography on a 1 arc-minute grid.
+
+## [Supported variables for GLO30](@id dataset-glo30-vars)
+
+- `:bottom_height` - Surface elevation (Digital Surface Model) on a global 30 m
+  (1 arc-second) grid. Read in regional windows only; requires a DestinE access
+  token and `using Zarr`. See [`GLO30`](@ref).
+
+## [Supported variables for GLO90](@id dataset-glo90-vars)
+
+- `:bottom_height` - Surface elevation (Digital Surface Model) on a global 90 m
+  (3 arc-second) grid; the coarser sibling of GLO-30. See [`GLO90`](@ref).
 
 ## [Supported variables for ECCO2Monthly](@id dataset-ecco2monthly-vars)
 

--- a/ext/NumericalEarthZarrExt.jl
+++ b/ext/NumericalEarthZarrExt.jl
@@ -8,10 +8,34 @@ using NumericalEarth.DataWrangling: native_grid
 
 const CopernicusDEM = NumericalEarth.DataWrangling.CopernicusDEM
 
-# NOTE (verify on first live run): this assumes the Earth Data Hub Copernicus DEM
-# store names its coordinates "lon"/"lat" and stores `dsm` as (lat, lon). Ascending vs
-# descending order is detected and handled below; if the coordinate names or the
-# dimension order differ, adjust here.
+#####
+##### bitround filter
+#####
+
+# The GLO-90 store applies the numcodecs `bitround` filter (lossy mantissa
+# rounding done at write time). Decoding is a passthrough: the stored values are
+# already the rounded floats, so no inverse is needed. Zarr.jl has no built-in
+# bitround filter, so we register a minimal one in its global `filterdict`.
+struct BitRoundFilter{T, Tenc} <: Zarr.Filter{T, Tenc}
+    keepbits::Int32
+end
+
+BitRoundFilter(; keepbits = 14, T = Float32, Tenc = T) = BitRoundFilter{T, Tenc}(Int32(keepbits))
+
+Zarr.zencode(data::AbstractArray, ::BitRoundFilter) = data
+Zarr.zdecode(data::AbstractArray, ::BitRoundFilter) = data
+Zarr.JSON.lower(filter::BitRoundFilter) = Dict("id" => "bitround", "keepbits" => filter.keepbits)
+Zarr.getfilter(::Type{<:BitRoundFilter}, d) = BitRoundFilter(; keepbits = d["keepbits"])
+Zarr.filterdict["bitround"] = BitRoundFilter
+
+#####
+##### Copernicus DEM Zarr → regional NetCDF
+#####
+
+# The Earth Data Hub Copernicus DEM stores name their coordinates "lon"/"lat" and
+# store `dsm` as (lon, lat); both coordinates are ascending. Ascending vs descending
+# is detected and handled regardless, so only the coordinate names and dimension
+# order are assumed here.
 function CopernicusDEM.zarr_to_netcdf(metadatum::CopernicusDEM.CopernicusDEMMetadatum, nc_path)
     token = get(ENV, "DESTINE_ACCESS_TOKEN", nothing)
     isnothing(token) && error(
@@ -39,8 +63,7 @@ function CopernicusDEM.zarr_to_netcdf(metadatum::CopernicusDEM.CopernicusDEMMeta
     latitude_range,  latitude_ascending  = ascending_window(latitude,  first_latitude,  Ny)
 
     variable_name = CopernicusDEM.dataset_zarr_variable_name
-    slab = store[variable_name][latitude_range, longitude_range]  # (lat, lon)
-    elevation = permutedims(Float32.(slab), (2, 1))               # → (lon, lat)
+    elevation = Float32.(store[variable_name][longitude_range, latitude_range])  # (lon, lat)
 
     # The native LatitudeLongitudeGrid is ascending in both lon and lat.
     longitude_ascending || (elevation = reverse(elevation, dims = 1))

--- a/ext/NumericalEarthZarrExt.jl
+++ b/ext/NumericalEarthZarrExt.jl
@@ -26,7 +26,13 @@ Zarr.zencode(data::AbstractArray, ::BitRoundFilter) = data
 Zarr.zdecode(data::AbstractArray, ::BitRoundFilter) = data
 Zarr.JSON.lower(filter::BitRoundFilter) = Dict("id" => "bitround", "keepbits" => filter.keepbits)
 Zarr.getfilter(::Type{<:BitRoundFilter}, d) = BitRoundFilter(; keepbits = d["keepbits"])
-Zarr.filterdict["bitround"] = BitRoundFilter
+
+# Register at load time, not precompile time: mutating Zarr's global `filterdict`
+# from module top-level runs during precompilation and is discarded, so the entry
+# would be missing at runtime.
+function __init__()
+    Zarr.filterdict["bitround"] = BitRoundFilter
+end
 
 #####
 ##### Copernicus DEM Zarr → regional NetCDF

--- a/ext/NumericalEarthZarrExt.jl
+++ b/ext/NumericalEarthZarrExt.jl
@@ -1,0 +1,97 @@
+module NumericalEarthZarrExt
+
+using Zarr: Zarr, zopen
+using NCDatasets: NCDataset, defDim, defVar
+using Oceananigans.Grids: x_domain, y_domain
+using NumericalEarth: NumericalEarth
+using NumericalEarth.DataWrangling: native_grid
+
+const CopernicusDEM = NumericalEarth.DataWrangling.CopernicusDEM
+
+# NOTE (verify on first live run): this assumes the Earth Data Hub Copernicus DEM
+# store names its coordinates "lon"/"lat" and stores `dsm` as (lat, lon). Ascending vs
+# descending order is detected and handled below; if the coordinate names or the
+# dimension order differ, adjust here.
+function CopernicusDEM.zarr_to_netcdf(metadatum::CopernicusDEM.CopernicusDEMMetadatum, nc_path)
+    token = get(ENV, "DESTINE_ACCESS_TOKEN", nothing)
+    isnothing(token) && error(
+        "Set the DESTINE_ACCESS_TOKEN environment variable to read Copernicus DEM. " *
+        "Register at https://platform.destine.eu/ and create a token at " *
+        "https://earthdatahub.destine.eu/account-settings#my-personal-access-tokens.")
+
+    url = string("https://edh:", token, "@", CopernicusDEM.zarr_host_path(metadatum.dataset))
+    store = zopen(url; consolidated = true)
+
+    grid = native_grid(metadatum)
+    λ₁, λ₂ = x_domain(grid)
+    φ₁, φ₂ = y_domain(grid)
+    Nx, Ny, _ = size(grid)
+
+    Δλ = (λ₂ - λ₁) / Nx
+    Δφ = (φ₂ - φ₁) / Ny
+    first_longitude = λ₁ + Δλ / 2
+    first_latitude  = φ₁ + Δφ / 2
+
+    longitude = store["lon"][:]
+    latitude  = store["lat"][:]
+
+    longitude_range, longitude_ascending = ascending_window(longitude, first_longitude, Nx)
+    latitude_range,  latitude_ascending  = ascending_window(latitude,  first_latitude,  Ny)
+
+    variable_name = CopernicusDEM.dataset_zarr_variable_name
+    slab = store[variable_name][latitude_range, longitude_range]  # (lat, lon)
+    elevation = permutedims(Float32.(slab), (2, 1))               # → (lon, lat)
+
+    # The native LatitudeLongitudeGrid is ascending in both lon and lat.
+    longitude_ascending || (elevation = reverse(elevation, dims = 1))
+    latitude_ascending  || (elevation = reverse(elevation, dims = 2))
+
+    window_longitude = longitude_ascending ? longitude[longitude_range] : reverse(longitude[longitude_range])
+    window_latitude  = latitude_ascending  ? latitude[latitude_range]   : reverse(latitude[latitude_range])
+
+    NCDataset(nc_path, "c") do dataset
+        defDim(dataset, "lon", length(window_longitude))
+        defDim(dataset, "lat", length(window_latitude))
+
+        longitude_variable = defVar(dataset, "lon", Float64, ("lon",);
+                                    attrib = ["units" => "degrees_east", "long_name" => "longitude"])
+        latitude_variable  = defVar(dataset, "lat", Float64, ("lat",);
+                                    attrib = ["units" => "degrees_north", "long_name" => "latitude"])
+        elevation_variable = defVar(dataset, "z", Float32, ("lon", "lat");
+                                    attrib = ["units" => "m", "long_name" => "surface elevation"])
+
+        longitude_variable[:] = window_longitude
+        latitude_variable[:]  = window_latitude
+        elevation_variable[:, :] = elevation
+    end
+
+    return nothing
+end
+
+# A contiguous block of `count` storage indices into `coordinate` whose values
+# bracket the window starting near `target_first`, returned in storage order
+# together with whether `coordinate` is ascending. Assumes the store resolution
+# matches the native grid, so a contiguous block of length `count` is exact.
+function ascending_window(coordinate, target_first, count)
+    n = length(coordinate)
+    ascending = coordinate[1] < coordinate[end]
+    ascending_coordinate = ascending ? coordinate : reverse(coordinate)
+
+    start = searchsortednearest(ascending_coordinate, target_first)
+    start = clamp(start, 1, n - count + 1)
+    ascending_range = start:(start + count - 1)
+
+    storage_range = ascending ? ascending_range :
+                                (n - ascending_range.stop + 1):(n - ascending_range.start + 1)
+
+    return storage_range, ascending
+end
+
+function searchsortednearest(sorted, value)
+    i = searchsortedfirst(sorted, value)
+    i == 1 && return 1
+    i > length(sorted) && return length(sorted)
+    return abs(sorted[i] - value) < abs(sorted[i-1] - value) ? i : i - 1
+end
+
+end # module NumericalEarthZarrExt

--- a/src/Bathymetry/regrid_bathymetry.jl
+++ b/src/Bathymetry/regrid_bathymetry.jl
@@ -298,6 +298,19 @@ function regrid_topography(target_grid; dataset = ETOPO2022(), kw...)
     return elevation
 end
 
+"""
+    regrid_topography(target_grid, metadata; kw...)
+
+Land surface elevation regridded onto `target_grid` from `metadata`, the positive
+counterpart of [`regrid_bathymetry`](@ref). Use this form for region-windowed
+datasets such as `GLO30()`, whose `metadata` carries a `BoundingBox` region.
+"""
+function regrid_topography(target_grid, metadata; kw...)
+    elevation = regrid_bathymetry(target_grid, metadata; kw...)
+    parent(elevation) .= max.(parent(elevation), 0) # land elevation; ocean → 0
+    return elevation
+end
+
 # Regridding bathymetry for distributed grids, we handle the whole process
 # on just one rank, and share the results with the other processors.
 function regrid_bathymetry(target_grid::DistributedGrid, metadata;

--- a/src/DataWrangling/CopernicusDEM/CopernicusDEM.jl
+++ b/src/DataWrangling/CopernicusDEM/CopernicusDEM.jl
@@ -1,0 +1,121 @@
+module CopernicusDEM
+
+export GLO30, GLO90
+
+using Downloads: Downloads
+using Scratch: Scratch, @get_scratch!
+using Oceananigans.DistributedComputations: @root
+
+using ..DataWrangling: DataWrangling, AbstractStaticBathymetry, Metadatum,
+                       metadata_path, BoundingBox
+
+download_CopernicusDEM_cache::String = ""
+function __init__()
+    global download_CopernicusDEM_cache = @get_scratch!("CopernicusDEM")
+end
+
+# Variable name in the regional NetCDF we materialize from the Zarr store; this is
+# what `_regrid_bathymetry` reads back. The name inside the Zarr store itself is
+# `dataset_zarr_variable_name`, read within the Zarr extension.
+CopernicusDEM_bathymetry_variable_names = Dict(:bottom_height => "z")
+
+const dataset_zarr_variable_name = "dsm"
+
+"""
+    GLO30
+
+Copernicus DEM GLO-30: global 30 m (1 arc-second) Digital Surface Model (DSM),
+representing the Earth's surface including buildings, infrastructure, and
+vegetation. Heights are referenced to the EGM2008 geoid; ocean is set to 0.
+
+Because GLO-30 is a global 30 m product (≈ 1.3M × 0.65M cells), it is read in
+regional windows only: construct the `Metadatum` with a longitude/latitude
+`BoundingBox` and use it with [`regrid_topography`](@ref).
+
+Data is read from the Earth Data Hub Zarr store, which requires a (free) DestinE
+personal access token in the `DESTINE_ACCESS_TOKEN` environment variable. Register
+at https://platform.destine.eu/ and create a token at
+https://earthdatahub.destine.eu/account-settings#my-personal-access-tokens.
+
+Reading the Zarr store requires the `Zarr` package to be loaded (`using Zarr`).
+
+Data source: https://earthdatahub.destine.eu/collections/copernicus-dem/datasets/GLO-30
+"""
+struct GLO30 <: AbstractStaticBathymetry end
+
+"""
+    GLO90
+
+Copernicus DEM GLO-90: global 90 m (3 arc-second) Digital Surface Model, the
+coarser sibling of [`GLO30`](@ref). Same source, access, and usage; lower
+resolution and a correspondingly smaller native grid.
+
+Data source: https://earthdatahub.destine.eu/collections/copernicus-dem/datasets/GLO-90
+"""
+struct GLO90 <: AbstractStaticBathymetry end
+
+const CopernicusDEMDataset = Union{GLO30, GLO90}
+
+DataWrangling.default_download_directory(::CopernicusDEMDataset) = download_CopernicusDEM_cache
+DataWrangling.reversed_vertical_axis(::CopernicusDEMDataset) = false
+DataWrangling.longitude_interfaces(::CopernicusDEMDataset) = (-180, 180)
+DataWrangling.latitude_interfaces(::CopernicusDEMDataset) = (-90, 90)
+
+# GLO-30 is 1 arc-second (360 * 3600 × 180 * 3600); GLO-90 is 3 arc-second.
+Base.size(::GLO30) = (1296000, 648000, 1)
+Base.size(::GLO90) = (432000, 216000, 1)
+
+dataset_prefix(::GLO30) = "GLO30"
+dataset_prefix(::GLO90) = "GLO90"
+
+# Earth Data Hub (DestinE) Zarr endpoints, without scheme/credentials. The Zarr
+# extension prepends `https://edh:<token>@` using the DESTINE_ACCESS_TOKEN env var.
+zarr_host_path(::GLO30) = "api.earthdatahub.destine.eu/copernicus-dem/GLO-30-v0.zarr"
+zarr_host_path(::GLO90) = "api.earthdatahub.destine.eu/copernicus-dem/GLO-90-v0.zarr"
+
+const CopernicusDEMMetadatum = Metadatum{<:CopernicusDEMDataset}
+
+DataWrangling.dataset_variable_name(data::CopernicusDEMMetadatum) =
+    CopernicusDEM_bathymetry_variable_names[data.name]
+
+DataWrangling.metadata_filename(dataset::CopernicusDEMDataset, name, date, region) =
+    string(dataset_prefix(dataset), "_", region_suffix(region), ".nc")
+
+region_suffix(::Nothing) = "global"
+
+function region_suffix(region::BoundingBox)
+    λ = region.longitude
+    φ = region.latitude
+    return string("lon_", bound_str(λ), "_lat_", bound_str(φ))
+end
+
+bound_str(::Nothing) = "nothing"
+bound_str(bounds) = string(bounds[1], "_", bounds[2])
+
+function DataWrangling.validate_dataset_coverage(grid, metadata::CopernicusDEMMetadatum)
+    region = metadata.region
+    if !(region isa BoundingBox) || isnothing(region.longitude) || isnothing(region.latitude)
+        error("$(dataset_prefix(metadata.dataset))() must be used with a bounded region. " *
+              "Build the metadatum with a longitude/latitude BoundingBox, e.g.\n" *
+              "    metadatum = Metadatum(:bottom_height; dataset = $(dataset_prefix(metadata.dataset))(),\n" *
+              "                          region = BoundingBox(longitude = (λ₁, λ₂), latitude = (φ₁, φ₂)))\n" *
+              "    regrid_topography(grid, metadatum)")
+    end
+    return nothing
+end
+
+function Downloads.download(metadatum::CopernicusDEMMetadatum)
+    nc_path = metadata_path(metadatum)
+    @root if !isfile(nc_path)
+        zarr_to_netcdf(metadatum, nc_path)
+    end
+    return nc_path
+end
+
+# Implemented in ext/NumericalEarthZarrExt.jl once `Zarr` is loaded. The fallback
+# below fires only when the extension is not active.
+zarr_to_netcdf(metadatum, nc_path) =
+    error("Reading the Copernicus DEM Zarr store requires the Zarr package. " *
+          "Load it with `using Zarr` and set the DESTINE_ACCESS_TOKEN environment variable.")
+
+end # module CopernicusDEM

--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -335,6 +335,7 @@ include("SoilGrids/SoilGrids.jl")
 include("IBCSO/IBCSO.jl")
 include("GEBCO/GEBCO.jl")
 include("IBCAO/IBCAO.jl")
+include("CopernicusDEM/CopernicusDEM.jl")
 
 using .ETOPO
 using .ECCO
@@ -348,6 +349,7 @@ using .OSPapa
 using .IBCSO
 using .GEBCO
 using .IBCAO
+using .CopernicusDEM
 
 function dataset_modules()
     modules = Module[]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -30,6 +30,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 WorldOceanAtlasTools = "04f20302-f1b9-11e8-29d9-7d841cb0a64a"
+Zarr = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 
 [sources]
 NumericalEarth = {path = ".."}
@@ -64,6 +65,7 @@ Statistics = "<0.0.1, 1"
 Test = "<0.0.1, 1"
 Thermodynamics = "0.15.3"
 WorldOceanAtlasTools = "0.6"
+Zarr = "0.10"
 julia = "1.10"
 
 [extras]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ if filter_tests!(testsuite, args)
     delete!(testsuite, "test_jra55_ecco_en4_etopo_downloading")
     delete!(testsuite, "test_cds_downloading")
     delete!(testsuite, "test_glorys_downloading")
+    delete!(testsuite, "test_copernicus_dem_downloading")
     delete!(testsuite, "test_distributed_utils")
     delete!(testsuite, "test_reactant")
     delete!(testsuite, "test_veros") # Veros seems to have introduce a pypi conflict issue; temporarily removing from CI

--- a/test/test_copernicus_dem.jl
+++ b/test/test_copernicus_dem.jl
@@ -1,0 +1,74 @@
+include("runtests_setup.jl")
+
+using NumericalEarth.DataWrangling.CopernicusDEM
+using NumericalEarth.DataWrangling: longitude_interfaces, latitude_interfaces, z_interfaces,
+                                    dataset_variable_name, validate_dataset_coverage,
+                                    metadata_filename
+using NumericalEarth.Bathymetry: regrid_bathymetry
+
+# The actual data read requires a DestinE token, the Zarr extension, and network
+# access, so only the dataset-interface and coverage-validation logic is exercised
+# here. The regridding read path is verified manually / in a token-gated job.
+
+@testset "Copernicus DEM metadata interfaces" begin
+
+    @testset "GLO30 metadata" begin
+        ds = GLO30()
+        @test longitude_interfaces(ds) == (-180, 180)
+        @test latitude_interfaces(ds) == (-90, 90)
+        @test z_interfaces(ds) == (0, 1)
+        Nx, Ny, Nz = size(ds)
+        @test Nx == 1296000   # 360° at 1 arc-second
+        @test Ny == 648000    # 180° at 1 arc-second
+        @test Nz == 1
+
+        region = BoundingBox(longitude = (9, 11), latitude = (45, 47))
+        meta = Metadatum(:bottom_height; dataset = ds, region)
+        @test dataset_variable_name(meta) == "z"
+
+        filename = metadata_filename(ds, :bottom_height, nothing, region)
+        @test startswith(filename, "GLO30_")
+        @test endswith(filename, ".nc")
+    end
+
+    @testset "GLO90 metadata" begin
+        ds = GLO90()
+        @test longitude_interfaces(ds) == (-180, 180)
+        @test latitude_interfaces(ds) == (-90, 90)
+        Nx, Ny, Nz = size(ds)
+        @test Nx == 432000   # 360° at 3 arc-second
+        @test Ny == 216000   # 180° at 3 arc-second
+        @test Nz == 1
+
+        region = BoundingBox(longitude = (9, 11), latitude = (45, 47))
+        filename = metadata_filename(ds, :bottom_height, nothing, region)
+        @test startswith(filename, "GLO90_")
+        @test endswith(filename, ".nc")
+    end
+
+    @testset "Region-keyed filenames are distinct" begin
+        ds = GLO30()
+        region_a = BoundingBox(longitude = (9, 11), latitude = (45, 47))
+        region_b = BoundingBox(longitude = (0, 2), latitude = (50, 52))
+        name_a = metadata_filename(ds, :bottom_height, nothing, region_a)
+        name_b = metadata_filename(ds, :bottom_height, nothing, region_b)
+        @test name_a != name_b
+    end
+end
+
+@testset "Copernicus DEM requires a bounded region" begin
+    # No region → must error (a global 30 m read is not allowed).
+    meta_global = Metadatum(:bottom_height; dataset = GLO30())
+    grid = LatitudeLongitudeGrid(CPU();
+                                 size = (10, 10, 1),
+                                 longitude = (9, 11),
+                                 latitude = (45, 47),
+                                 z = (-1, 0))
+    @test_throws ErrorException validate_dataset_coverage(grid, meta_global)
+    @test_throws ErrorException regrid_bathymetry(grid, meta_global)
+
+    # Bounded region → passes validation.
+    region = BoundingBox(longitude = (9, 11), latitude = (45, 47))
+    meta_region = Metadatum(:bottom_height; dataset = GLO30(), region)
+    @test validate_dataset_coverage(grid, meta_region) === nothing
+end

--- a/test/test_copernicus_dem_downloading.jl
+++ b/test/test_copernicus_dem_downloading.jl
@@ -1,0 +1,47 @@
+# Disable HDF5 file locking before any HDF5-backed package loads: this test
+# writes a regional NetCDF and reopens it within the same session for several
+# datasets, which can otherwise trip an HDF5 lock error (-101) on reopen.
+ENV["HDF5_USE_FILE_LOCKING"] = "FALSE"
+
+include("runtests_setup.jl")
+include("download_utils.jl")
+
+using Zarr  # activates NumericalEarthZarrExt (registers the bitround filter, enables the read)
+
+using NumericalEarth.DataWrangling: metadata_path
+using NumericalEarth.DataWrangling.CopernicusDEM: GLO30, GLO90
+
+# Requires a DestinE personal access token in DESTINE_ACCESS_TOKEN (free; see
+# https://earthdatahub.destine.eu/account-settings#my-personal-access-tokens).
+# Excluded from CI in runtests.jl; run manually with the token set.
+
+const dem_region = BoundingBox(longitude = (9, 11), latitude = (45, 47))  # European Alps
+
+@testset "Downloading Copernicus DEM regional window" begin
+    for dataset in (GLO30(), GLO90())
+        metadatum = Metadatum(:bottom_height; dataset, region = dem_region)
+        filepath = metadata_path(metadatum)
+        isfile(filepath) && rm(filepath; force = true)
+        download(metadatum)
+        @test isfile(filepath)
+    end
+end
+
+@testset "Regridding Copernicus DEM topography" begin
+    for dataset in (GLO30(), GLO90())
+        grid = LatitudeLongitudeGrid(CPU();
+                                     size = (40, 40, 1),
+                                     longitude = (9, 11),
+                                     latitude = (45, 47),
+                                     z = (-1, 0))
+
+        metadatum = Metadatum(:bottom_height; dataset, region = dem_region)
+        topography = regrid_topography(grid, metadatum; cache = false)
+        z = Array(interior(topography, :, :, 1))
+
+        @test all(isfinite, z)
+        @test all(>=(0), z)        # land surface elevation; ocean clamped to 0
+        @test maximum(z) > 1000    # the Alps reach well above 1 km
+        @test maximum(z) < 5000    # but below the Mont Blanc ceiling
+    end
+end

--- a/test/test_copernicus_dem_downloading.jl
+++ b/test/test_copernicus_dem_downloading.jl
@@ -15,7 +15,11 @@ using NumericalEarth.DataWrangling.CopernicusDEM: GLO30, GLO90
 # https://earthdatahub.destine.eu/account-settings#my-personal-access-tokens).
 # Excluded from CI in runtests.jl; run manually with the token set.
 
-const dem_region = BoundingBox(longitude = (9, 11), latitude = (45, 47))  # European Alps
+# A small high-Alps window (Monte Rosa massif) — kept to 1°×1° so the GLO-30 read
+# stays light on the shared downloading CI job, while still spanning peaks > 1 km.
+const dem_longitude = (7.5, 8.5)
+const dem_latitude  = (45.5, 46.5)
+const dem_region = BoundingBox(longitude = dem_longitude, latitude = dem_latitude)
 
 @testset "Downloading Copernicus DEM regional window" begin
     for dataset in (GLO30(), GLO90())
@@ -31,8 +35,8 @@ end
     for dataset in (GLO30(), GLO90())
         grid = LatitudeLongitudeGrid(CPU();
                                      size = (40, 40, 1),
-                                     longitude = (9, 11),
-                                     latitude = (45, 47),
+                                     longitude = dem_longitude,
+                                     latitude = dem_latitude,
                                      z = (-1, 0))
 
         metadatum = Metadatum(:bottom_height; dataset, region = dem_region)


### PR DESCRIPTION
## Summary

Adds the Copernicus global Digital Surface Models **GLO-30** (30 m / 1″) and **GLO-90** (90 m / 3″) as `DataWrangling` datasets, read in regional windows from the [Earth Data Hub](https://earthdatahub.destine.eu/collections/copernicus-dem) (DestinE) Zarr store. These provide high-resolution land/coastal surface elevation; pair with `regrid_topography`.

```julia
using NumericalEarth, Oceananigans, Zarr
using NumericalEarth.DataWrangling.CopernicusDEM: GLO30
# ENV["DESTINE_ACCESS_TOKEN"] = "edh_key_…"

metadatum = Metadatum(:bottom_height; dataset = GLO30(),
                      region = BoundingBox(longitude = (9, 11), latitude = (45, 47)))
topography = regrid_topography(grid, metadatum)
```

## How it works

- **`CopernicusDEM` submodule** (`src/DataWrangling/CopernicusDEM/`): `GLO30`/`GLO90` static-bathymetry datasets. Region-mandatory (`validate_dataset_coverage` requires a `BoundingBox`) — a global 30 m read is infeasible.
- **`NumericalEarthZarrExt`** (new, `Zarr` weakdep): slices the bbox window out of the `dsm` array and materializes a regional NetCDF that the existing bathymetry regridding path consumes. Reads the windowed slab directly (`dsm` is stored `(lon, lat)`), aligning the window to the native grid by construction.
- **`bitround` filter**: GLO-90 applies the numcodecs `bitround` filter, which `Zarr.jl` lacks; the extension registers a minimal passthrough filter (decode is identity — values are stored already rounded) at load time via `__init__`.
- **Auth**: free DestinE personal access token via `DESTINE_ACCESS_TOKEN` (mirrors the GLORYS/ERA5 credential pattern).
- Adds `regrid_topography(grid, metadata)` so a region-carrying metadatum can be used for land surface elevation.

## Verification

End-to-end against the live store, European Alps (9–11°E / 45–47°N):

| dataset | min/max/mean elevation (m) |
|---|---|
| GLO30 (30 m) | 10.5 / 3728.8 / 1144.7 |
| GLO90 (90 m) | 10.5 / 3590.0 / 1156.9 |

All finite and ≥ 0; the coarser GLO-90 gives a slightly lower peak, as expected.

## Tests

- **Offline** (`test/test_copernicus_dem.jl`, runs in CI): dataset interfaces (17/17) and the bounded-region requirement (3/3).
- **Token-gated integration** (`test/test_copernicus_dem_downloading.jl`, excluded from CI like `test_glorys_downloading`): downloads + regrids both datasets (2/2 + 8/8). Requires `DESTINE_ACCESS_TOKEN`.

## Notes

- New `Zarr` weakdep + extension (`Project.toml`); `Zarr` added to test deps. No changes to existing `[deps]`.
- **Known HDF5 quirk**: regridding two *in-process-written* DEM datasets in one session can hit an HDF5 file-lock error (`-101`) on reopen of the second just-written file; each dataset works alone and from cache, and the file is valid. The integration test sets `HDF5_USE_FILE_LOCKING=FALSE` to avoid it. Normal usage (one dataset per grid) never triggers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)