### PR TITLE
Update to Python-free CopernicusMarine CLI branch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -97,8 +97,3 @@ Thermodynamics = "0.15.3, 1"
 WorldOceanAtlasTools = "0.6"
 ZipFile = "0.10"
 julia = "1.10"
-
-# TEST ONLY: point CopernicusMarine at the Python-free CLI branch to verify
-# downstream compatibility. Revert (or re-pin to a released version) before merging.
-[sources]
-CopernicusMarine = {url = "https://github.com/NumericalEarth/CopernicusMarine.jl", rev = "remove-python-dependence"}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NumericalEarth"
 uuid = "904d977b-046a-4731-8b86-9235c0d1ef02"
 license = "MIT"
-version = "0.5.6"
+version = "0.5.7"
 authors = ["NumericalEarth contributors"]
 
 [deps]
@@ -67,7 +67,7 @@ CFTime = "0.1, 0.2"
 ClimaSeaIce = "0.5.6"
 CondaPkg = "0.2.33"
 ConservativeRegridding = "0.2"
-CopernicusMarine = "0.1.1, 0.2"
+CopernicusMarine = "0.2"
 CubedSphere = "0.3.4"
 DataDeps = "0.7"
 Dates = "<0.0.1, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -67,7 +67,7 @@ CFTime = "0.1, 0.2"
 ClimaSeaIce = "0.5.6"
 CondaPkg = "0.2.33"
 ConservativeRegridding = "0.2"
-CopernicusMarine = "0.1.1"
+CopernicusMarine = "0.1.1, 0.2"
 CubedSphere = "0.3.4"
 DataDeps = "0.7"
 Dates = "<0.0.1, 1"
@@ -97,3 +97,8 @@ Thermodynamics = "0.15.3, 1"
 WorldOceanAtlasTools = "0.6"
 ZipFile = "0.10"
 julia = "1.10"
+
+# TEST ONLY: point CopernicusMarine at the Python-free CLI branch to verify
+# downstream compatibility. Revert (or re-pin to a released version) before merging.
+[sources]
+CopernicusMarine = {url = "https://github.com/NumericalEarth/CopernicusMarine.jl", rev = "remove-python-dependence"}

--- a/docs/CondaPkg.toml
+++ b/docs/CondaPkg.toml
@@ -1,6 +1,3 @@
 
-[deps.copernicusmarine]
-channel = "conda-forge"
-
 [deps.python]
 version = ">=3.10,<3.14"

--- a/ext/NumericalEarthCopernicusMarineExt.jl
+++ b/ext/NumericalEarthCopernicusMarineExt.jl
@@ -28,10 +28,8 @@ function Downloads.download(meta::GLORYSMetadatum;
     output_path = joinpath(output_directory, output_filename)
     isfile(output_path) && return output_path
 
-    toolbox = CopernicusMarine.copernicusmarine
-
     variable_name = GLORYS.GLORYS_dataset_variable_names[meta.name]
-    variables = CopernicusMarine.pylist([variable_name])
+    variable = [variable_name]
 
     dataset_id = GLORYS.copernicusmarine_dataset_id(meta.dataset)
     datetime_kw = if meta.dataset isa GLORYS.GLORYSStatic
@@ -47,13 +45,13 @@ function Downloads.download(meta::GLORYSMetadatum;
     z_kw = depth_bounds_kw(meta.region)
     selection_method = coordinates_selection_method(meta.region)
 
-    # netcdf3_compatible routes the write through xarray's netcdf4 engine instead of
-    # h5netcdf, whose h5py binds to the HDF5_jll libhdf5 (no ROS3 VFD) and fails in-process.
+    # The CopernicusMarine standalone executable runs the download out-of-process
+    # with its own bundled HDF5/h5py (with ROS3 VFD), so the in-process
+    # `netcdf3_compatible` workaround is no longer needed.
     kw = (; coordinates_selection_method = selection_method,
-          netcdf3_compatible = true,
           skip_existing,
           dataset_id,
-          variables,
+          variable,
           output_filename,
           output_directory)
 
@@ -68,7 +66,7 @@ function Downloads.download(meta::GLORYSMetadatum;
     additional_kw = NamedTuple(name => value for (name, value) in additional_kw)
     kw = merge(kw, datetime_kw, lon_kw, lat_kw, z_kw, additional_kw)
 
-    @root toolbox.subset(; kw...)
+    @root CopernicusMarine.subset(; kw...)
 
     return output_path
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -33,6 +33,8 @@ WorldOceanAtlasTools = "04f20302-f1b9-11e8-29d9-7d841cb0a64a"
 
 [sources]
 NumericalEarth = {path = ".."}
+# TEST ONLY: verify downstream compatibility with the Python-free CLI branch.
+CopernicusMarine = {url = "https://github.com/NumericalEarth/CopernicusMarine.jl", rev = "remove-python-dependence"}
 
 [compat]
 ArchGDAL = "0.10"
@@ -43,7 +45,7 @@ CUDA = "5.9.5"
 ClimaSeaIce = "0.5.6"
 CondaPkg = "0.2.33"
 ConservativeRegridding = "0.2"
-CopernicusMarine = "0.1"
+CopernicusMarine = "0.1, 0.2"
 Dates = "<0.0.1, 1"
 Downloads = "<0.0.1, 1"
 ExplicitImports = "1.15"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -33,8 +33,6 @@ WorldOceanAtlasTools = "04f20302-f1b9-11e8-29d9-7d841cb0a64a"
 
 [sources]
 NumericalEarth = {path = ".."}
-# TEST ONLY: verify downstream compatibility with the Python-free CLI branch.
-CopernicusMarine = {url = "https://github.com/NumericalEarth/CopernicusMarine.jl", rev = "remove-python-dependence"}
 
 [compat]
 ArchGDAL = "0.10"
@@ -45,7 +43,7 @@ CUDA = "5.9.5"
 ClimaSeaIce = "0.5.6"
 CondaPkg = "0.2.33"
 ConservativeRegridding = "0.2"
-CopernicusMarine = "0.1, 0.2"
+CopernicusMarine = "0.2"
 Dates = "<0.0.1, 1"
 Downloads = "<0.0.1, 1"
 ExplicitImports = "1.15"

--- a/test/test_glorys_downloading.jl
+++ b/test/test_glorys_downloading.jl
@@ -1,10 +1,8 @@
 include("runtests_setup.jl")
 include("download_utils.jl")
 
-using CondaPkg
-CondaPkg.add("h5py"; channel="conda-forge", version=">=3.0,<3.13")
-CondaPkg.add("hdf5"; channel="conda-forge", version="<2")
-
+# The CopernicusMarine standalone executable bundles its own HDF5/h5py, so the
+# previous in-process CondaPkg h5py/hdf5 pinning is no longer required.
 using CopernicusMarine
 
 using NumericalEarth.DataWrangling: BoundingBox, is_three_dimensional, z_interfaces


### PR DESCRIPTION
## Purpose (test PR — not for merge as-is)

Verifies that NumericalEarth.jl works against the **Python-free** CopernicusMarine.jl, which replaces `PythonCall`/`CondaPkg` with the standalone `copernicusmarine` executable.

Companion PR: **NumericalEarth/CopernicusMarine.jl#6** (`remove-python-dependence`). This branch pins `CopernicusMarine` to that branch via `[sources]` so CI exercises the new CLI end-to-end.

## What this validates

The `cds_downloading` CI job runs `test_glorys_downloading` on **ubuntu-latest** and **macOS-aarch64** with the `COPERNICUSMARINE_SERVICE_*` secrets, so it performs a real GLORYS subset download through the standalone binary.

## Changes

- **`ext/NumericalEarthCopernicusMarineExt.jl`** — migrate to the new API:
  - `CopernicusMarine.subset(; ...)` instead of the removed `CopernicusMarine.copernicusmarine` Python module.
  - `variable = [name]` (repeatable `--variable` CLI flag) instead of `CopernicusMarine.pylist(...)`.
  - Drop the `netcdf3_compatible` workaround — the binary downloads out-of-process with its own bundled, ROS3-capable HDF5/h5py, so the in-process h5py/HDF5_jll conflict that motivated it is gone.
- **`test/test_glorys_downloading.jl`** — drop the in-process `CondaPkg.add("h5py"/"hdf5")` pinning (no longer needed).
- **`Project.toml` / `test/Project.toml`** — bump `CopernicusMarine` compat to `0.2`; add `[sources]` pointing at the branch.

## Before merging

- Revert the `[sources]` entries (or re-pin to a released `CopernicusMarine` ≥ 0.2 once tagged).
- Consider a `NumericalEarth` version bump for the extension change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)