### PR TITLE
Add GloFASPrescribedLand: ERA5-routed river discharge onto the ocean coastline

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -43,7 +43,7 @@ examples = [
     Example("Global climate simulation", "global_climate_simulation", false),
     Example("Veros ocean simulation", "veros_ocean_forced_simulation", false),
     Example("Breeze over four oceans", "breeze_over_four_oceans", false),
-    Example("Exploring ERA5 reanalysis data", "exploring_era5_reanalysis_data", true),
+    Example("ERA5 and GloFAS reanalysis data", "exploring_era5_reanalysis_data", true),
     Example("ERA5-forced slab land", "era5_forced_slab_land", true),
     Example("Breeze over slab land", "breeze_over_slab_land", true),
 ]

--- a/docs/src/NumericalEarth.bib
+++ b/docs/src/NumericalEarth.bib
@@ -153,3 +153,14 @@
   pages = {217–240},
   language = {English}
 }
+
+@article{harrigan2020glofas,
+  title={{GloFAS-ERA5} operational global river discharge reanalysis 1979--present},
+  author={Harrigan, Shaun and Zsoter, Ervin and Alfieri, Lorenzo and Prudhomme, Christel and Salamon, Peter and Wetterhall, Fredrik and Barnard, Christopher and Cloke, Hannah and Pappenberger, Florian},
+  journal={Earth System Science Data},
+  volume={12},
+  number={3},
+  pages={2043--2060},
+  year={2020},
+  doi={10.5194/essd-12-2043-2020}
+}

--- a/examples/exploring_era5_reanalysis_data.jl
+++ b/examples/exploring_era5_reanalysis_data.jl
@@ -528,8 +528,7 @@ nothing #hide
 # the coast — the discharge concentrates into channels that grow downstream and
 # terminate at the river mouths.
 
-λd = λnodes(discharge)
-φd = φnodes(discharge)
+λd, φd, _ = nodes(discharge)
 
 ## Mask non-positive values so `log10` is well defined for the heatmap.
 discharge_data = interior(discharge, :, :, 1)

--- a/examples/exploring_era5_reanalysis_data.jl
+++ b/examples/exploring_era5_reanalysis_data.jl
@@ -1,4 +1,4 @@
-# # Exploring ERA5 reanalysis data
+# # ERA5 and GloFAS reanalysis data
 #
 # This walkthrough covers downloading ERA5 reanalysis fields from the
 # Copernicus Climate Data Store (CDS), with the Rain in Shallow Cumulus Over
@@ -6,6 +6,10 @@
 # unifying case study. We consider both single-level (2-D) and pressure-level
 # (3-D) fields with two subsetting approaches (bounding box and column) that
 # restrict the amount of data requested through the CDS API.
+#
+# The final section turns to **GloFAS** river discharge — ERA5 runoff routed to
+# river mouths by a hydrological model — and shows how `GloFASPrescribedLand`
+# places that freshwater on the ocean coastline.
 #
 # Our focus is on the first four days of the *undisturbed period*
 # (Dec 27 2004 – Jan 2 2005) by [vanZanten2011](@citet), during which a mean
@@ -484,3 +488,118 @@ hideydecorations!(ax_u, grid=false)
 hideydecorations!(ax_v, grid=false)
 
 fig4
+
+# ## §4 River runoff from GloFAS
+#
+# ERA5's own surface runoff is generated locally over the whole land surface and
+# is *not* routed downstream — interpolating it onto an ocean grid and masking
+# land would discard most of the water. The [Global Flood Awareness System
+# (GloFAS)](https://www.globalfloods.eu/) solves this: it forces the LISFLOOD
+# hydrological and channel-routing model with ERA5 runoff to produce **river
+# discharge already accumulated to river mouths** [harrigan2020glofas](@citep) —
+# the ERA5-consistent analogue of JRA55's pre-routed river freshwater flux.
+#
+# GloFAS lives on the Copernicus Early Warning Data Store (EWDS), a separate
+# endpoint from the ERA5 CDS. The download automatically targets the EWDS url
+# (https://ewds.climate.copernicus.eu/api) while reusing the ECMWF token from
+# `~/.cdsapirc` — the same token works across both data stores — so the ERA5
+# sections above and this GloFAS section run in one session without editing
+# `~/.cdsapirc`. You still need to accept the `cems-glofas-historical` licence
+# once on the dataset page (see <https://ewds.climate.copernicus.eu/how-to-api>).
+#
+# We focus on the mouth of the Amazon, the largest freshwater source to the
+# global ocean.
+
+glofas = GloFASReanalysis()
+amazon_region = BoundingBox(latitude = (-2, 5), longitude = (-53, -45))
+nothing #hide
+
+# GloFAS river discharge is a daily volume flux (m³ s⁻¹) on a 0.05° grid, with
+# ocean cells left undefined (`NaN`). We download a single day over the region
+# and load it on its native grid.
+
+discharge_date = DateTime(2004, 12, 27)
+discharge_meta = Metadatum(:river_discharge; dataset = glofas,
+                           date = discharge_date, region = amazon_region)
+discharge = @suppress_out Field(discharge_meta)
+nothing #hide
+
+# Plotting the discharge on a log scale reveals the routed river network feeding
+# the coast — the discharge concentrates into channels that grow downstream and
+# terminate at the river mouths.
+
+λd = λnodes(discharge)
+φd = φnodes(discharge)
+
+## Mask non-positive values so `log10` is well defined for the heatmap.
+discharge_data = interior(discharge, :, :, 1)
+log_discharge = map(q -> (isnan(q) || q ≤ 0) ? NaN : log10(q), discharge_data)
+
+fig5 = Figure(size=(800, 600))
+ax5 = Axis(fig5[1, 1]; title = "GloFAS river discharge — $(Dates.format(discharge_date, "yyyy-mm-dd"))",
+           xlabel = "Longitude (°)", ylabel = "Latitude (°)")
+hm5 = heatmap!(ax5, λd, φd, log_discharge; colormap = :viridis)
+Colorbar(fig5[1, 2], hm5; label = "log₁₀ discharge [m³ s⁻¹]")
+
+fig5
+
+# ### Routing discharge onto the ocean coastline
+#
+# To force an ocean model we need the discharge on the *ocean* grid, located on
+# wet coastal cells. We build a coarse regional ocean grid from ETOPO bathymetry
+# over the same region:
+
+ocean_grid = LatitudeLongitudeGrid(size = (80, 70, 1),
+                                   longitude = amazon_region.longitude,
+                                   latitude  = amazon_region.latitude,
+                                   z = (-1000, 0))
+
+bottom_height = regrid_bathymetry(ocean_grid; minimum_depth = 5, major_basins = 1)
+ocean_grid = ImmersedBoundaryGrid(ocean_grid, GridFittedBottom(bottom_height))
+nothing #hide
+
+# `GloFASPrescribedLand` downloads the discharge, locates the river mouths from
+# the land/ocean boundary, and maps each mouth to the nearest active ocean cell
+# of `ocean_grid` — conserving the total volume of freshwater (see
+# [`build_river_routing`](@ref)).
+
+land = @suppress_out GloFASPrescribedLand(ocean_grid; dataset = glofas,
+                                          start_date = discharge_date,
+                                          end_date = discharge_date + Day(2),
+                                          region = amazon_region,
+                                          maximum_search_radius = 8)
+nothing #hide
+
+# The resulting `RiverRouting` records, for each river mouth, the coastal ocean
+# cell that receives its discharge. We overlay the mouths (on the GloFAS network)
+# and their destination ocean cells (on the coastline) on the discharge map to
+# visualize the relocation.
+
+routing = land.river_routing
+
+λn = λnodes(land.grid, Center(), Center(), Center())
+φn = φnodes(land.grid, Center(), Center(), Center())
+mouth_λ = [λn[i] for i in Array(routing.contribution_outlet_i)]
+mouth_φ = [φn[j] for j in Array(routing.contribution_outlet_j)]
+
+λo = λnodes(ocean_grid, Center(), Center(), Center())
+φo = φnodes(ocean_grid, Center(), Center(), Center())
+target_λ = [λo[i] for i in Array(routing.target_i)]
+target_φ = [φo[j] for j in Array(routing.target_j)]
+
+fig6 = Figure(size=(800, 600))
+ax6 = Axis(fig6[1, 1]; title = "GloFAS river mouths routed to the ocean coastline",
+           xlabel = "Longitude (°)", ylabel = "Latitude (°)")
+hm6 = heatmap!(ax6, λd, φd, log_discharge; colormap = :grays)
+scatter!(ax6, mouth_λ, mouth_φ; color = :dodgerblue, markersize = 4, label = "river mouths")
+scatter!(ax6, target_λ, target_φ; color = :crimson, marker = :xcross,
+         markersize = 8, label = "ocean injection cells")
+Colorbar(fig6[1, 2], hm6; label = "log₁₀ discharge [m³ s⁻¹]")
+axislegend(ax6; position = :rb)
+
+fig6
+
+# The red crosses mark where freshwater enters the ocean — on the coastline,
+# regardless of the (coarser) ocean grid resolution. Passing `land` to a coupled
+# ocean simulation injects this discharge as a conservative surface freshwater
+# flux, lowering coastal sea-surface salinity near the Amazon plume.

--- a/examples/exploring_era5_reanalysis_data.jl
+++ b/examples/exploring_era5_reanalysis_data.jl
@@ -546,15 +546,17 @@ fig5
 # ### Routing discharge onto the ocean coastline
 #
 # To force an ocean model we need the discharge on the *ocean* grid, located on
-# wet coastal cells. We build a coarse regional ocean grid from ETOPO bathymetry
-# over the same region:
+# wet coastal cells. We build a regional ocean grid from ETOPO bathymetry over
+# the same region. The vertical grid needs enough near-surface resolution that
+# shallow shelf cells stay *active* — a single thick level would place every
+# cell center below the coastal seafloor, leaving no wet cells for the routing.
 
-ocean_grid = LatitudeLongitudeGrid(size = (80, 70, 1),
+ocean_grid = LatitudeLongitudeGrid(size = (80, 70, 30),
                                    longitude = amazon_region.longitude,
                                    latitude  = amazon_region.latitude,
-                                   z = (-1000, 0))
+                                   z = (-200, 0))
 
-bottom_height = regrid_bathymetry(ocean_grid; minimum_depth = 5, major_basins = 1)
+bottom_height = regrid_bathymetry(ocean_grid; minimum_depth = 5)
 ocean_grid = ImmersedBoundaryGrid(ocean_grid, GridFittedBottom(bottom_height))
 nothing #hide
 

--- a/ext/NumericalEarthCDSAPIExt.jl
+++ b/ext/NumericalEarthCDSAPIExt.jl
@@ -17,7 +17,7 @@ using NumericalEarth.DataWrangling.ERA5: ERA5Dataset, ERA5Metadata, ERA5Metadatu
                                          ERA5PressureMetadata, ERA5PressureMetadatum,
                                          ERA5PL_dataset_variable_names, ERA5PL_netcdf_variable_names
 using NumericalEarth.DataWrangling.GloFAS: GloFASDataset, GloFASMetadata, GloFASMetadatum,
-                                           GloFAS_dataset_variable_names, GloFAS_netcdf_variable_names
+                                           GloFAS_netcdf_variable_names
 
 #####
 ##### Dispatch helpers — encapsulate single-level vs pressure-level differences
@@ -728,25 +728,31 @@ glofas_product(::GloFASDataset) = "cems-glofas-historical"
 
 const GLOFAS_EWDS_URL = "https://ewds.climate.copernicus.eu/api"
 
+restore_env!(name, ::Nothing) = (delete!(ENV, name); nothing)
+restore_env!(name, value) = (ENV[name] = value; nothing)
+
 # GloFAS lives on EWDS, a different Copernicus endpoint than the ERA5 CDS. We
-# override CDSAPI's url per call through its `ScopedValues`, so a `~/.cdsapirc`
-# pointed at the ERA5 CDS keeps working — the ECMWF token is shared across data
-# stores, so only the url differs. The `GLOFAS_CDSAPI_URL` / `GLOFAS_CDSAPI_KEY`
-# environment variables override the defaults (an empty key falls back to the
-# key resolved by CDSAPI from the environment or `~/.cdsapirc`).
+# point CDSAPI at the EWDS url by temporarily setting `CDSAPI_URL` (which CDSAPI
+# reads above `~/.cdsapirc`), so a `~/.cdsapirc` pointed at the ERA5 CDS keeps
+# working — the ECMWF token is shared across data stores, so only the url
+# differs. The `GLOFAS_CDSAPI_URL` / `GLOFAS_CDSAPI_KEY` environment variables
+# override the defaults (an empty key falls back to the key CDSAPI already
+# resolves from the environment or `~/.cdsapirc`).
 function glofas_retrieve(product, request, path)
-    scoped = CDSAPI.ScopedValues.with
     url = get(ENV, "GLOFAS_CDSAPI_URL", GLOFAS_EWDS_URL)
     key = get(ENV, "GLOFAS_CDSAPI_KEY", "")
 
-    if isempty(key)
-        return scoped(CDSAPI.URL => url) do
-            CDSAPI.retrieve(product, request, path)
-        end
-    else
-        return scoped(CDSAPI.URL => url, CDSAPI.KEY => key) do
-            CDSAPI.retrieve(product, request, path)
-        end
+    saved_url = get(ENV, "CDSAPI_URL", nothing)
+    saved_key = get(ENV, "CDSAPI_KEY", nothing)
+
+    ENV["CDSAPI_URL"] = url
+    isempty(key) || (ENV["CDSAPI_KEY"] = key)
+
+    try
+        return CDSAPI.retrieve(product, request, path)
+    finally
+        restore_env!("CDSAPI_URL", saved_url)
+        isempty(key) || restore_env!("CDSAPI_KEY", saved_key)
     end
 end
 

--- a/ext/NumericalEarthCDSAPIExt.jl
+++ b/ext/NumericalEarthCDSAPIExt.jl
@@ -754,19 +754,20 @@ const GLOFAS_COORD_VARS = Set(["longitude", "latitude",
                                "time", "valid_time", "step", "surface"])
 
 """
-    build_glofas_request(dataset, datetimes) -> Dict{String, Any}
+    build_glofas_request(dataset, datetimes, region) -> Dict{String, Any}
 
 Construct the EWDS request for a batch of GloFAS dates that share a `(year, month)`.
 GloFAS uses the `hyear`/`hmonth`/`hday` date keys (interpreted as a Cartesian product).
+A `BoundingBox` `region` is sent as an `area` key so the EWDS subsets server-side.
 """
-function build_glofas_request(dataset, datetimes)
+function build_glofas_request(dataset, datetimes, region)
     dts = datetimes isa AbstractVector ? datetimes : [datetimes]
 
     years  = unique(string.(Dates.year.(dts)))
     months = unique(lpad.(string.(Dates.month.(dts)), 2, '0'))
     days   = unique(lpad.(string.(Dates.day.(dts)), 2, '0'))
 
-    return Dict{String, Any}(
+    request = Dict{String, Any}(
         "system_version"     => [dataset.system_version],
         "hydrological_model" => ["lisflood"],
         "product_type"       => ["consolidated"],
@@ -777,6 +778,25 @@ function build_glofas_request(dataset, datetimes)
         "data_format"        => "netcdf",
         "download_format"    => "unarchived",
     )
+
+    area = glofas_request_area(region)
+    isnothing(area) || (request["area"] = area)
+
+    return request
+end
+
+glofas_request_area(region) = nothing
+
+# Pad the box by a few native (0.05°) cells so the file fully covers the
+# center-bracketed native grid the data is interpolated onto (cf. ERA5).
+function glofas_request_area(bbox::BBOX)
+    (isnothing(bbox.longitude) || isnothing(bbox.latitude)) && return nothing
+    pad = 0.2
+    north = min(bbox.latitude[2]  + pad,  90)
+    south = max(bbox.latitude[1]  - pad, -90)
+    west  = bbox.longitude[1] - pad
+    east  = bbox.longitude[2] + pad
+    return [north, west, south, east]
 end
 
 """
@@ -789,7 +809,7 @@ function Downloads.download(meta::GloFASMetadatum; skip_existing=true)
     skip_existing && isfile(output_path) && return output_path
 
     mkpath(dirname(output_path))
-    request = build_glofas_request(meta.dataset, meta.dates)
+    request = build_glofas_request(meta.dataset, meta.dates, meta.region)
     @root glofas_retrieve(glofas_product(meta.dataset), request, output_path)
 
     return output_path
@@ -827,7 +847,7 @@ function download_glofas_month(name, dataset, dates; region, dir, skip_existing,
     mkpath(dir)
     sorted_dts = sort(unique([dt for (dt, _) in pending]))
     dt_to_tidx = Dict(dt => i for (i, dt) in enumerate(sorted_dts))
-    request = build_glofas_request(dataset, sorted_dts)
+    request = build_glofas_request(dataset, sorted_dts, region)
 
     dt0 = first(sorted_dts)
     tmp_path = joinpath(dir, "_tmp_glofas_$(Dates.year(dt0))$(lpad(Dates.month(dt0), 2, '0')).nc")

--- a/ext/NumericalEarthCDSAPIExt.jl
+++ b/ext/NumericalEarthCDSAPIExt.jl
@@ -16,6 +16,8 @@ using NumericalEarth.DataWrangling.ERA5: ERA5Dataset, ERA5Metadata, ERA5Metadatu
                                          ERA5PressureLevelsDataset,
                                          ERA5PressureMetadata, ERA5PressureMetadatum,
                                          ERA5PL_dataset_variable_names, ERA5PL_netcdf_variable_names
+using NumericalEarth.DataWrangling.GloFAS: GloFASDataset, GloFASMetadata, GloFASMetadatum,
+                                           GloFAS_dataset_variable_names, GloFAS_netcdf_variable_names
 
 #####
 ##### Dispatch helpers — encapsulate single-level vs pressure-level differences
@@ -711,6 +713,137 @@ function build_era5_area(col::COL{<:Any, <:Any, <:Any, <:LIN})
     lon, lat = col.longitude, col.latitude
     ε = 0.3
     return [lat + ε, lon - ε, lat - ε, lon + ε]
+end
+
+#####
+##### GloFAS river-discharge download (Copernicus Emergency Management Service)
+#####
+##### GloFAS lives on the Early Warning Data Store (EWDS), a separate Copernicus
+##### endpoint from the ERA5 CDS. Configure `~/.cdsapirc` with the EWDS API url
+##### (https://ewds.climate.copernicus.eu/api) and key, and accept the
+##### `cems-glofas-historical` licence, before downloading.
+#####
+
+glofas_product(::GloFASDataset) = "cems-glofas-historical"
+
+const GLOFAS_EWDS_URL = "https://ewds.climate.copernicus.eu/api"
+
+# GloFAS lives on EWDS, a different Copernicus endpoint than the ERA5 CDS. We
+# override CDSAPI's url per call through its `ScopedValues`, so a `~/.cdsapirc`
+# pointed at the ERA5 CDS keeps working — the ECMWF token is shared across data
+# stores, so only the url differs. The `GLOFAS_CDSAPI_URL` / `GLOFAS_CDSAPI_KEY`
+# environment variables override the defaults (an empty key falls back to the
+# key resolved by CDSAPI from the environment or `~/.cdsapirc`).
+function glofas_retrieve(product, request, path)
+    scoped = CDSAPI.ScopedValues.with
+    url = get(ENV, "GLOFAS_CDSAPI_URL", GLOFAS_EWDS_URL)
+    key = get(ENV, "GLOFAS_CDSAPI_KEY", "")
+
+    if isempty(key)
+        return scoped(CDSAPI.URL => url) do
+            CDSAPI.retrieve(product, request, path)
+        end
+    else
+        return scoped(CDSAPI.URL => url, CDSAPI.KEY => key) do
+            CDSAPI.retrieve(product, request, path)
+        end
+    end
+end
+
+const GLOFAS_COORD_VARS = Set(["longitude", "latitude",
+                               "time", "valid_time", "step", "surface"])
+
+"""
+    build_glofas_request(dataset, datetimes) -> Dict{String, Any}
+
+Construct the EWDS request for a batch of GloFAS dates that share a `(year, month)`.
+GloFAS uses the `hyear`/`hmonth`/`hday` date keys (interpreted as a Cartesian product).
+"""
+function build_glofas_request(dataset, datetimes)
+    dts = datetimes isa AbstractVector ? datetimes : [datetimes]
+
+    years  = unique(string.(Dates.year.(dts)))
+    months = unique(lpad.(string.(Dates.month.(dts)), 2, '0'))
+    days   = unique(lpad.(string.(Dates.day.(dts)), 2, '0'))
+
+    return Dict{String, Any}(
+        "system_version"     => [dataset.system_version],
+        "hydrological_model" => ["lisflood"],
+        "product_type"       => ["consolidated"],
+        "variable"           => ["river_discharge_in_the_last_24_hours"],
+        "hyear"              => years,
+        "hmonth"             => months,
+        "hday"               => days,
+        "data_format"        => "netcdf",
+        "download_format"    => "unarchived",
+    )
+end
+
+"""
+    download(meta::GloFASMetadatum; skip_existing=true)
+
+Download GloFAS river discharge for a single date via the EWDS CDS API.
+"""
+function Downloads.download(meta::GloFASMetadatum; skip_existing=true)
+    output_path = metadata_path(meta)
+    skip_existing && isfile(output_path) && return output_path
+
+    mkpath(dirname(output_path))
+    request = build_glofas_request(meta.dataset, meta.dates)
+    @root glofas_retrieve(glofas_product(meta.dataset), request, output_path)
+
+    return output_path
+end
+
+"""
+    download(metadata::GloFASMetadata; skip_existing=true, cleanup=true)
+
+Download GloFAS river discharge for multiple dates, batching by calendar month
+and splitting the multi-timestep NetCDF into one file per day.
+"""
+function Downloads.download(metadata::GloFASMetadata; skip_existing=true, cleanup=true)
+    dates = metadata.dates isa AbstractVector ? metadata.dates : [metadata.dates]
+    monthly = group_by_calendar_month(dates)
+
+    paths = String[]
+    for key in sort(collect(keys(monthly)))
+        batch = sort(unique(monthly[key]))
+        append!(paths, download_glofas_month(metadata.name, metadata.dataset, batch;
+                                             region = metadata.region,
+                                             dir = metadata.dir,
+                                             skip_existing, cleanup))
+    end
+
+    return paths
+end
+
+function download_glofas_month(name, dataset, dates; region, dir, skip_existing, cleanup)
+    meta_filename = NumericalEarth.DataWrangling.metadata_filename
+
+    dt_path_pairs = [(dt, joinpath(dir, meta_filename(dataset, name, dt, region))) for dt in dates]
+    pending = skip_existing ? filter(dt_path -> !isfile(dt_path[2]), dt_path_pairs) : dt_path_pairs
+    isempty(pending) && return map(dt_path -> dt_path[2], dt_path_pairs)
+
+    mkpath(dir)
+    sorted_dts = sort(unique([dt for (dt, _) in pending]))
+    dt_to_tidx = Dict(dt => i for (i, dt) in enumerate(sorted_dts))
+    request = build_glofas_request(dataset, sorted_dts)
+
+    dt0 = first(sorted_dts)
+    tmp_path = joinpath(dir, "_tmp_glofas_$(Dates.year(dt0))$(lpad(Dates.month(dt0), 2, '0')).nc")
+    nc_varname = GloFAS_netcdf_variable_names[name]
+    nc_triples = [(nc_varname, dt_to_tidx[dt], path) for (dt, path) in pending]
+
+    time_dimnames = Set(["time", "valid_time"])
+    @root begin
+        glofas_retrieve(glofas_product(dataset), request, tmp_path)
+        foreach_nc(tmp_path, dir) do nc_path
+            split_era5_nc_multistep(nc_path, nc_triples, GLOFAS_COORD_VARS, time_dimnames)
+        end
+        cleanup && rm(tmp_path; force=true)
+    end
+
+    return map(dt_path -> dt_path[2], dt_path_pairs)
 end
 
 end # module NumericalEarthCDSAPIExt

--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -330,6 +330,7 @@ include("EN4/EN4.jl")
 include("ORCA/ORCA.jl")
 include("WOA/WOA.jl")
 include("JRA55/JRA55.jl")
+include("GloFAS/GloFAS.jl")
 include("OSPapa/OSPapa.jl")
 include("SoilGrids/SoilGrids.jl")
 include("IBCSO/IBCSO.jl")
@@ -344,6 +345,7 @@ using .EN4
 using .ORCA
 using .WOA
 using .JRA55
+using .GloFAS
 using .OSPapa
 using .IBCSO
 using .GEBCO

--- a/src/DataWrangling/GloFAS/GloFAS.jl
+++ b/src/DataWrangling/GloFAS/GloFAS.jl
@@ -1,0 +1,86 @@
+module GloFAS
+
+# Datasets
+export GloFASReanalysis
+
+# Prescribed components
+export GloFASPrescribedLand
+
+using Dates: Dates, DateTime, Day
+using Oceananigans.OutputReaders: Cyclical, FieldTimeSeries
+using Scratch: Scratch, @get_scratch!
+
+using ..DataWrangling: DataWrangling, Metadata, Metadatum,
+                       available_variables, first_date, last_date
+using ...Lands: PrescribedLand, build_river_routing, coastal_outlet_indices
+
+download_GloFAS_cache::String = ""
+
+function __init__()
+    global download_GloFAS_cache = @get_scratch!("GloFAS")
+end
+
+#####
+##### GloFAS datasets
+#####
+
+# The GloFAS (Global Flood Awareness System) river-discharge reanalysis is produced
+# by routing ERA5-forced LISFLOOD runoff through a channel-routing model. It provides
+# river discharge already accumulated downstream to river mouths — the ERA5-consistent
+# analogue of JRA55's pre-routed `river_freshwater_flux`. See Harrigan et al. (2020),
+# https://essd.copernicus.org/articles/12/2043/2020/.
+abstract type GloFASDataset end
+
+DataWrangling.default_download_directory(::GloFASDataset) = download_GloFAS_cache
+
+# GloFAS files store latitude north-to-south (90 → -60); flip on read.
+DataWrangling.reversed_latitude_axis(::GloFASDataset) = true
+
+const GloFASMetadata{D} = Metadata{<:GloFASDataset, D}
+const GloFASMetadatum = Metadatum{<:GloFASDataset}
+
+#####
+##### Grid interfaces
+#####
+
+# GloFAS v4 global coverage: -180 to 180 longitude, -60 to 90 latitude at 0.05° resolution.
+DataWrangling.longitude_interfaces(::GloFASMetadata) = (-180, 180)
+DataWrangling.latitude_interfaces(::GloFASMetadata)  = (-60, 90)
+
+# GloFAS is a spatially 2-D surface dataset.
+DataWrangling.z_interfaces(::GloFASMetadata) = (0, 1)
+DataWrangling.is_three_dimensional(::GloFASMetadata) = false
+
+Base.eltype(::GloFASMetadata) = Float32
+
+#####
+##### Filename utilities
+#####
+
+function date_str(date::DateTime)
+    y = Dates.year(date)
+    m = lpad(Dates.month(date), 2, '0')
+    d = lpad(Dates.day(date),   2, '0')
+    return "$(y)-$(m)-$(d)"
+end
+
+date_str(dates::AbstractVector) = string(date_str(first(dates)), "_", date_str(last(dates)))
+
+function DataWrangling.metadata_filename(dataset::GloFASDataset, name, date, region)
+    var = available_variables(dataset)[name]
+    ds = dataset_name(dataset)
+    return string(var, "_", ds, "_", date_str(date), ".nc")
+end
+
+function inpainted_metadata_filename(metadata::GloFASMetadatum)
+    without_extension = metadata.filename[1:end-3]
+    return without_extension * "_inpainted.jld2"
+end
+
+DataWrangling.inpainted_metadata_path(metadata::GloFASMetadatum) =
+    joinpath(metadata.dir, inpainted_metadata_filename(metadata))
+
+include("glofas_reanalysis.jl")
+include("glofas_prescribed_land.jl")
+
+end # module GloFAS

--- a/src/DataWrangling/GloFAS/GloFAS.jl
+++ b/src/DataWrangling/GloFAS/GloFAS.jl
@@ -66,10 +66,14 @@ end
 
 date_str(dates::AbstractVector) = string(date_str(first(dates)), "_", date_str(last(dates)))
 
+region_suffix(::Nothing) = ""
+region_suffix(region) = string("_", region.longitude[1], "_", region.longitude[2],
+                               "_", region.latitude[1], "_", region.latitude[2])
+
 function DataWrangling.metadata_filename(dataset::GloFASDataset, name, date, region)
     var = available_variables(dataset)[name]
     ds = dataset_name(dataset)
-    return string(var, "_", ds, "_", date_str(date), ".nc")
+    return string(var, "_", ds, "_", date_str(date), region_suffix(region), ".nc")
 end
 
 function inpainted_metadata_filename(metadata::GloFASMetadatum)

--- a/src/DataWrangling/GloFAS/glofas_prescribed_land.jl
+++ b/src/DataWrangling/GloFAS/glofas_prescribed_land.jl
@@ -1,0 +1,65 @@
+using Oceananigans.Architectures: architecture
+using Oceananigans.Fields: Field
+
+"""
+    GloFASPrescribedLand(grid;
+                         dataset = GloFASReanalysis(),
+                         start_date = first_date(dataset, :river_discharge),
+                         end_date = last_date(dataset, :river_discharge),
+                         dir = download_GloFAS_cache,
+                         time_indices_in_memory = 10,
+                         time_indexing = Cyclical(),
+                         region = nothing,
+                         freshwater_density = 1000,
+                         maximum_search_radius = 5,
+                         other_kw...)
+
+Return a [`PrescribedLand`](@ref) that forces the ocean with GloFAS river
+discharge routed onto the coastline of `grid` (the target ocean grid).
+
+GloFAS provides river discharge (m³ s⁻¹) already accumulated downstream to river
+mouths by the LISFLOOD channel-routing model, driven by ERA5 runoff. The mouths
+are located from the dataset's land/ocean boundary and mapped to the nearest
+active ocean cells of `grid`; the discharge is then deposited as a freshwater
+mass flux that conserves volume (see [`build_river_routing`](@ref)).
+
+Keyword Arguments
+=================
+- `freshwater_density`: density used to convert discharge (m³ s⁻¹) to a mass flux
+  (kg m⁻² s⁻¹). Default: `1000`.
+- `maximum_search_radius`: maximum distance (in `grid` cells) to search for an
+  active ocean cell when placing a river mouth. Default: `5`.
+
+See also [`JRA55PrescribedLand`](@ref) for the pre-routed JRA55 alternative.
+"""
+function GloFASPrescribedLand(grid;
+                              dataset = GloFASReanalysis(),
+                              start_date = first_date(dataset, :river_discharge),
+                              end_date = last_date(dataset, :river_discharge),
+                              dir = download_GloFAS_cache,
+                              time_indices_in_memory = 10,
+                              time_indexing = Cyclical(),
+                              region = nothing,
+                              freshwater_density = 1000,
+                              maximum_search_radius = 5,
+                              other_kw...)
+
+    arch = architecture(grid)
+    kw = (; time_indexing, time_indices_in_memory)
+    kw = merge(kw, other_kw)
+
+    discharge_meta = Metadata(:river_discharge; dataset, start_date, end_date, dir, region)
+    discharge = FieldTimeSeries(discharge_meta, arch; kw...)
+
+    # River mouths are located from the land/ocean boundary of the first snapshot
+    # (ocean cells are NaN), then mapped to coastal cells of the target grid.
+    snapshot = Field(first(discharge_meta), arch)
+    outlet_i, outlet_j, outlet_λ, outlet_φ = coastal_outlet_indices(snapshot)
+
+    routing = build_river_routing(grid, outlet_i, outlet_j, outlet_λ, outlet_φ;
+                                  freshwater_density, maximum_search_radius)
+
+    freshwater_flux = (; rivers = discharge)
+
+    return PrescribedLand(freshwater_flux; river_routing = routing)
+end

--- a/src/DataWrangling/GloFAS/glofas_reanalysis.jl
+++ b/src/DataWrangling/GloFAS/glofas_reanalysis.jl
@@ -1,0 +1,49 @@
+"""
+    GloFASReanalysis(; system_version="version_4_0")
+
+The GloFAS-ERA5 historical river-discharge reanalysis (`cems-glofas-historical`,
+`product_type="consolidated"`, `hydrological_model="lisflood"`). Daily river
+discharge in m³ s⁻¹ on a global 0.05° grid (v4), 1979–present.
+"""
+struct GloFASReanalysis <: GloFASDataset
+    system_version :: String
+end
+
+GloFASReanalysis(; system_version="version_4_0") = GloFASReanalysis(system_version)
+
+dataset_name(::GloFASReanalysis) = "GloFASReanalysis"
+
+# GloFAS v4 is 0.05° (7200 × 3000 covering -180:180, -60:90).
+Base.size(::GloFASReanalysis, variable) = (7200, 3000, 1)
+
+# Daily consolidated reanalysis. Available from 1979 to near-present; we use a
+# practical upper bound matching the ERA5 forcing range.
+DataWrangling.all_dates(::GloFASReanalysis, variable) =
+    range(DateTime("1979-01-01"), stop=DateTime("2024-12-31"), step=Day(1))
+
+#####
+##### Variable name mappings
+#####
+
+# NumericalEarth name → CDS API variable name.
+GloFAS_dataset_variable_names = Dict(
+    :river_discharge => "river_discharge_in_the_last_24_hours",
+)
+
+# NumericalEarth name → NetCDF short variable name (as stored in downloaded files).
+GloFAS_netcdf_variable_names = Dict(
+    :river_discharge => "dis24",
+)
+
+DataWrangling.available_variables(::GloFASDataset) = GloFAS_dataset_variable_names
+DataWrangling.dataset_variable_name(md::GloFASMetadata) = GloFAS_netcdf_variable_names[md.name]
+
+# River discharge is already a volume flux (m³ s⁻¹); unit handling and the
+# conversion to a per-area freshwater mass flux happen during routing (see
+# `build_river_routing`), where the receiving ocean-cell area is known.
+DataWrangling.conversion_units(md::GloFASMetadata) = nothing
+
+# Discharge is undefined (missing) over the ocean. Do not inpaint: missing means
+# "no river here", and the routing relies on the land/ocean boundary in the raw
+# field to locate river mouths.
+DataWrangling.default_inpainting(md::GloFASMetadata) = nothing

--- a/src/Lands/Lands.jl
+++ b/src/Lands/Lands.jl
@@ -2,6 +2,9 @@ module Lands
 
 export AbstractLand,
        PrescribedLand,
+       RiverRouting,
+       build_river_routing,
+       coastal_outlet_indices,
        # Composable container
        SlabLand,
        # Energy-balance closures
@@ -58,5 +61,6 @@ include("hydrology/saturated_surface.jl")
 include("prescribed_land.jl")
 include("prescribed_land_regridder.jl")
 include("interpolate_land_state.jl")
+include("river_routing.jl")
 
 end # module Lands

--- a/src/Lands/prescribed_land.jl
+++ b/src/Lands/prescribed_land.jl
@@ -3,11 +3,13 @@
 # coupling would require additional fields (e.g. albedo, skin temperature); see
 # https://github.com/NumericalEarth/NumericalEarth.jl/issues/30 for the related
 # discussion of moving surface albedo to a radiation component.
-mutable struct PrescribedLand{G, T, F, TI} <: AbstractPrescribedComponent
+mutable struct PrescribedLand{G, T, F, TI, R} <: AbstractPrescribedComponent
     grid :: G
     clock :: Clock{T}
-    freshwater_flux :: F   # NamedTuple, e.g. (rivers=FTS, icebergs=FTS)
+    freshwater_flux :: F     # NamedTuple, e.g. (rivers=FTS, icebergs=FTS)
     times :: TI
+    river_routing :: R       # `nothing`, or a `RiverRouting` mapping native river
+                             # mouths to coastal ocean cells (see river_routing.jl)
 end
 
 function Base.summary(pl::PrescribedLand)
@@ -25,15 +27,21 @@ function Base.show(io::IO, pl::PrescribedLand)
 end
 
 """
-    PrescribedLand(freshwater_flux; clock=nothing)
+    PrescribedLand(freshwater_flux; clock=nothing, river_routing=nothing)
 
 Return a `PrescribedLand` component from a `NamedTuple` of `FieldTimeSeries`
 representing freshwater fluxes (e.g. rivers, icebergs).
 
 If `clock` is not provided, defaults to a `Clock` whose time type matches the
 element type of `freshwater_flux`.
+
+When `river_routing` is a [`RiverRouting`](@ref), the freshwater flux is treated
+as a per-river-mouth volume discharge (m³ s⁻¹) that is scattered onto coastal
+ocean cells conserving volume (see [`GloFASPrescribedLand`](@ref)). When it is
+`nothing` (the default), the flux is a per-area mass flux interpolated pointwise
+onto the ocean grid (see [`JRA55PrescribedLand`](@ref)).
 """
-function PrescribedLand(freshwater_flux; clock=nothing)
+function PrescribedLand(freshwater_flux; clock=nothing, river_routing=nothing)
     first_flux = first(freshwater_flux)
     grid = first_flux.grid
     times = first_flux.times
@@ -42,7 +50,7 @@ function PrescribedLand(freshwater_flux; clock=nothing)
         clock = Clock{eltype(first_flux)}(time=0)
     end
 
-    land = PrescribedLand(grid, clock, freshwater_flux, times)
+    land = PrescribedLand(grid, clock, freshwater_flux, times, river_routing)
     update_state!(land)
     return land
 end

--- a/src/Lands/river_routing.jl
+++ b/src/Lands/river_routing.jl
@@ -1,0 +1,260 @@
+using Oceananigans.Grids: inactive_node, λnodes, φnodes
+using Oceananigans.Operators: Azᶜᶜᶜ
+using Oceananigans.Architectures: on_architecture
+using Oceananigans.Fields: interior
+
+#####
+##### River routing: map river-mouth discharge onto coastal ocean cells
+#####
+
+"""
+    RiverRouting
+
+A static map from river-mouth cells on a forcing dataset's native grid to the
+active (wet) cells of a target ocean grid, used to deposit volumetric river
+discharge (m³ s⁻¹) as a conservative freshwater mass flux (kg m⁻² s⁻¹).
+
+Contributions are grouped by destination ocean cell so the scatter writes each
+ocean cell exactly once (no atomics). For destination cell `c`, the contributing
+river mouths are `contribution_outlet_{i,j}[offsets[c]:offsets[c+1]-1]` with
+`contribution_weight = ρ_freshwater / Aᵒᶜᵉᵃⁿ`, chosen so the area integral of
+the deposited flux equals the total discharge times the freshwater density.
+"""
+struct RiverRouting{I, W}
+    contribution_outlet_i :: I
+    contribution_outlet_j :: I
+    contribution_weight   :: W
+    target_i :: I
+    target_j :: I
+    offsets  :: I
+end
+
+const RoutedPrescribedLand = PrescribedLand{<:Any, <:Any, <:Any, <:Any, <:RiverRouting}
+
+#####
+##### Outlet (river-mouth) detection
+#####
+
+"""
+    coastal_outlet_indices(discharge)
+
+Return `(outlet_i, outlet_j, outlet_λ, outlet_φ)` for the river-mouth cells of a
+`discharge` `Field` whose ocean cells are `NaN` (the GloFAS convention). A river
+mouth is a finite (land/river) cell with at least one `NaN` (ocean) horizontal
+neighbor — i.e. the point where the routed river network meets the coast.
+"""
+function coastal_outlet_indices(discharge)
+    grid = discharge.grid
+    arch = architecture(grid)
+
+    outlet = Field{Center, Center, Nothing}(grid, Bool)
+    fill!(outlet, false)
+    launch!(arch, grid, :xy, _mark_coastal_outlets!, outlet, discharge)
+
+    outlet_mask = Array(interior(outlet))[:, :, 1]
+    indices = findall(outlet_mask)
+
+    outlet_i = [I[1] for I in indices]
+    outlet_j = [I[2] for I in indices]
+
+    λc = Array(λnodes(grid, Center(), Center(), Center()))
+    φc = Array(φnodes(grid, Center(), Center(), Center()))
+    outlet_λ = [λc[i] for i in outlet_i]
+    outlet_φ = [φc[j] for j in outlet_j]
+
+    return outlet_i, outlet_j, outlet_λ, outlet_φ
+end
+
+@kernel function _mark_coastal_outlets!(outlet, discharge)
+    i, j = @index(Global, NTuple)
+    @inbounds begin
+        finite = !isnan(discharge[i, j, 1])
+        ocean_neighbor = isnan(discharge[i-1, j, 1]) | isnan(discharge[i+1, j, 1]) |
+                         isnan(discharge[i, j-1, 1]) | isnan(discharge[i, j+1, 1])
+        outlet[i, j, 1] = finite & ocean_neighbor
+    end
+end
+
+#####
+##### Building the routing map (construction-time, on CPU)
+#####
+
+"""
+    build_river_routing(target_grid, outlet_i, outlet_j, outlet_λ, outlet_φ;
+                        freshwater_density = 1000,
+                        maximum_search_radius = 5)
+
+Map each river mouth at `(outlet_λ, outlet_φ)` to the nearest active ocean cell
+of `target_grid` within `maximum_search_radius` cells, returning a
+[`RiverRouting`](@ref). River mouths with no active ocean cell in range are
+dropped (and reported), so the global freshwater budget is conserved up to the
+dropped discharge.
+"""
+function build_river_routing(target_grid, outlet_i, outlet_j, outlet_λ, outlet_φ;
+                             freshwater_density = 1000,
+                             maximum_search_radius = 5)
+
+    arch = architecture(target_grid)
+    FT = eltype(target_grid)
+    kᴺ = size(target_grid, 3)
+
+    wet_field  = Field{Center, Center, Nothing}(target_grid, Bool)
+    area_field = Field{Center, Center, Nothing}(target_grid)
+    launch!(arch, target_grid, :xy, _compute_wet_mask_and_area!,
+            wet_field, area_field, target_grid, kᴺ)
+
+    wet  = Array(interior(wet_field))[:, :, 1]
+    area = Array(interior(area_field))[:, :, 1]
+
+    λc = Array(λnodes(target_grid, Center(), Center(), Center()))
+    φc = Array(φnodes(target_grid, Center(), Center(), Center()))
+
+    # Group contributing river mouths by destination ocean cell.
+    contributions = Dict{Tuple{Int, Int}, Vector{Tuple{Int, Int}}}()
+    dropped = 0
+    for n in eachindex(outlet_i)
+        i★, j★ = nearest_active_cell(wet, λc, φc, outlet_λ[n], outlet_φ[n], maximum_search_radius)
+        if i★ == 0
+            dropped += 1
+            continue
+        end
+        push!(get!(contributions, (i★, j★), Tuple{Int, Int}[]), (outlet_i[n], outlet_j[n]))
+    end
+
+    if dropped > 0
+        @warn string(dropped, " of ", length(outlet_i), " river mouths had no active ocean ",
+                     "cell within ", maximum_search_radius, " cells and were dropped.")
+    end
+
+    target_i = Int[]
+    target_j = Int[]
+    offsets = Int[1]
+    contribution_outlet_i = Int[]
+    contribution_outlet_j = Int[]
+    contribution_weight = FT[]
+
+    for ((i★, j★), mouths) in contributions
+        push!(target_i, i★)
+        push!(target_j, j★)
+        w = convert(FT, freshwater_density) / convert(FT, area[i★, j★])
+        for (oi, oj) in mouths
+            push!(contribution_outlet_i, oi)
+            push!(contribution_outlet_j, oj)
+            push!(contribution_weight, w)
+        end
+        push!(offsets, length(contribution_outlet_i) + 1)
+    end
+
+    return RiverRouting(on_architecture(arch, contribution_outlet_i),
+                        on_architecture(arch, contribution_outlet_j),
+                        on_architecture(arch, contribution_weight),
+                        on_architecture(arch, target_i),
+                        on_architecture(arch, target_j),
+                        on_architecture(arch, offsets))
+end
+
+@kernel function _compute_wet_mask_and_area!(wet, area, grid, kᴺ)
+    i, j = @index(Global, NTuple)
+    @inbounds begin
+        wet[i, j, 1] = !inactive_node(i, j, kᴺ, grid, Center(), Center(), Center())
+        area[i, j, 1] = Azᶜᶜᶜ(i, j, kᴺ, grid)
+    end
+end
+
+# Index of the entry of sorted vector `a` closest to `x`.
+function searchsortednearest(a, x)
+    i = searchsortedfirst(a, x)
+    i == 1 && return 1
+    i > length(a) && return length(a)
+    return abs(a[i-1] - x) ≤ abs(a[i] - x) ? i - 1 : i
+end
+
+# Approximate squared distance on the sphere (equirectangular, degrees).
+function squared_distance(λ₁, φ₁, λ₂, φ₂)
+    Δλ = (λ₂ - λ₁) * cosd((φ₁ + φ₂) / 2)
+    Δφ = φ₂ - φ₁
+    return Δλ^2 + Δφ^2
+end
+
+# Spiral search outward from the target cell containing (λₒ, φₒ) for the nearest
+# active ocean cell within `R` cells (Chebyshev), ranked by metric distance.
+function nearest_active_cell(wet, λc, φc, λₒ, φₒ, R)
+    Nx, Ny = size(wet)
+    i₀ = clamp(searchsortednearest(λc, λₒ), 1, Nx)
+    j₀ = clamp(searchsortednearest(φc, φₒ), 1, Ny)
+
+    best_i = 0
+    best_j = 0
+    best_d = Inf
+
+    for r in 0:R, di in -r:r, dj in -r:r
+        max(abs(di), abs(dj)) == r || continue
+        i = i₀ + di
+        j = j₀ + dj
+        (1 ≤ i ≤ Nx && 1 ≤ j ≤ Ny) || continue
+        wet[i, j] || continue
+        d = squared_distance(λₒ, φₒ, λc[i], φc[j])
+        if d < best_d
+            best_d = d
+            best_i = i
+            best_j = j
+        end
+    end
+
+    return best_i, best_j
+end
+
+#####
+##### Conservative scatter of river discharge onto the ocean grid
+#####
+
+"""Scatter prescribed river-mouth discharge onto coastal ocean cells, conserving volume."""
+function EarthSystemModels.interpolate_state!(exchanger, grid, land::RoutedPrescribedLand, coupled_model)
+    arch = architecture(grid)
+    clock = coupled_model.clock
+    land_freshwater_flux = exchanger.state.freshwater_flux
+
+    fill!(land_freshwater_flux, 0)
+
+    routing = land.river_routing
+    n_targets = length(routing.target_i)
+    n_targets == 0 && return nothing
+
+    discharge = first(land.freshwater_flux)
+    time = Time(clock.time)
+
+    launch!(arch, grid, (n_targets,),
+            _scatter_river_discharge!,
+            land_freshwater_flux.data,
+            discharge,
+            time,
+            routing.contribution_outlet_i,
+            routing.contribution_outlet_j,
+            routing.contribution_weight,
+            routing.target_i,
+            routing.target_j,
+            routing.offsets)
+
+    return nothing
+end
+
+# One thread per destination ocean cell sums all river mouths routed to it, so
+# each cell is written exactly once — no atomics needed.
+@kernel function _scatter_river_discharge!(flux, discharge, time,
+                                           contribution_outlet_i,
+                                           contribution_outlet_j,
+                                           contribution_weight,
+                                           target_i, target_j, offsets)
+    c = @index(Global)
+    @inbounds begin
+        accumulated = zero(eltype(flux))
+        for k in offsets[c]:(offsets[c+1] - 1)
+            iₒ = contribution_outlet_i[k]
+            jₒ = contribution_outlet_j[k]
+            Q = discharge[iₒ, jₒ, 1, time]   # temporal interpolation at the exact mouth cell
+            Q = ifelse(isnan(Q), zero(Q), Q)
+            accumulated += contribution_weight[k] * Q
+        end
+        flux[target_i[c], target_j[c], 1] = accumulated
+    end
+end

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -56,6 +56,8 @@ export
     JRA55PrescribedRadiation,
     JRA55PrescribedAtmosphere,
     JRA55PrescribedLand,
+    GloFASPrescribedLand,
+    GloFASReanalysis,
     ERA5PrescribedAtmosphere,
     ERA5PrescribedRadiation,
     OSPapaPrescribedRadiation,
@@ -193,6 +195,7 @@ using .DataWrangling.EN4
 using .DataWrangling.ORCA
 using .DataWrangling.WOA
 using .DataWrangling.JRA55
+using .DataWrangling.GloFAS
 using .DataWrangling.OSPapa
 using .DataWrangling.ERA5
 using .DataWrangling.SoilGrids

--- a/test/test_river_routing.jl
+++ b/test/test_river_routing.jl
@@ -69,16 +69,19 @@ end
     coj = Array(routing.contribution_outlet_j)
     cw  = Array(routing.contribution_weight)
 
+    # Scalar metric/mask queries run on a CPU copy of the grid (GPU-safe).
+    cpu_grid = on_architecture(CPU(), target_grid)
+    kᴺ = size(cpu_grid, 3)
+
     # Every destination must be an active (wet) ocean cell.
-    kᴺ = size(target_grid, 3)
     for c in eachindex(ti)
-        @test !inactive_node(ti[c], tj[c], kᴺ, target_grid, Center(), Center(), Center())
+        @test !inactive_node(ti[c], tj[c], kᴺ, cpu_grid, Center(), Center(), Center())
     end
 
     # Reconstruct the scattered freshwater mass flux and integrate it over the
     # ocean grid. It must equal ρ × total discharge (volume conservation).
     discharge_cpu = Array(interior(discharge))[:, :, 1]
-    Nx, Ny, _ = size(target_grid)
+    Nx, Ny, _ = size(cpu_grid)
     flux = zeros(Float64, Nx, Ny)
     for c in eachindex(ti)
         for k in off[c]:(off[c+1] - 1)
@@ -90,7 +93,7 @@ end
 
     integrated_mass_flux = 0.0
     for i in 1:Nx, j in 1:Ny
-        integrated_mass_flux += flux[i, j] * Azᶜᶜᶜ(i, j, kᴺ, target_grid)
+        integrated_mass_flux += flux[i, j] * Azᶜᶜᶜ(i, j, kᴺ, cpu_grid)
     end
 
     total_discharge = sum(q for q in discharge_cpu if !isnan(q))
@@ -124,12 +127,13 @@ end
     interpolate_state!(exchanger, target_grid, land, coupled_model)
 
     flux = Array(interior(exchanger.state.freshwater_flux))[:, :, 1]
-    Nx, Ny, _ = size(target_grid)
-    kᴺ = size(target_grid, 3)
+    cpu_grid = on_architecture(CPU(), target_grid)
+    Nx, Ny, _ = size(cpu_grid)
+    kᴺ = size(cpu_grid, 3)
 
     integrated_mass_flux = 0.0
     for i in 1:Nx, j in 1:Ny
-        integrated_mass_flux += flux[i, j] * Azᶜᶜᶜ(i, j, kᴺ, target_grid)
+        integrated_mass_flux += flux[i, j] * Azᶜᶜᶜ(i, j, kᴺ, cpu_grid)
     end
 
     @test integrated_mass_flux ≈ ρ * Q₀ rtol = 1e-5

--- a/test/test_river_routing.jl
+++ b/test/test_river_routing.jl
@@ -1,0 +1,136 @@
+include("runtests_setup.jl")
+
+using Oceananigans.Grids: Center, Face, λnodes, φnodes
+using Oceananigans.Operators: Azᶜᶜᶜ
+using Oceananigans.ImmersedBoundaries: inactive_node
+using Oceananigans.Units: Time
+using NumericalEarth.Lands: RiverRouting, build_river_routing, coastal_outlet_indices
+using NumericalEarth.EarthSystemModels: interpolate_state!
+
+# A target ocean grid whose western half (longitude < 0) is ocean and whose
+# eastern half is land, so the coastline runs down longitude = 0.
+function half_land_ocean_grid(arch)
+    underlying = LatitudeLongitudeGrid(arch;
+                                       size = (20, 20, 1),
+                                       longitude = (-10, 10),
+                                       latitude = (-10, 10),
+                                       z = (-100, 0),
+                                       halo = (4, 4, 4))
+
+    bottom_height(λ, φ) = ifelse(λ < 0, -100, 10) # ocean west, land east
+    return ImmersedBoundaryGrid(underlying, GridFittedBottom(bottom_height))
+end
+
+# A native forcing grid (GloFAS-like) covering the same region, with ocean cells
+# set to NaN. A single river mouth carries discharge `Q₀` just east of the coast.
+function synthetic_discharge_field(arch, Q₀)
+    grid = LatitudeLongitudeGrid(arch;
+                                 size = (40, 40),
+                                 longitude = (-10, 10),
+                                 latitude = (-10, 10),
+                                 topology = (Bounded, Bounded, Flat),
+                                 halo = (3, 3))
+
+    discharge = Field{Center, Center, Nothing}(grid)
+    λc = Array(λnodes(grid, Center(), Center(), Center()))
+
+    data = zeros(Float64, size(grid)...)             # finite over land
+    for i in axes(data, 1), j in axes(data, 2)
+        if λc[i] < 0
+            data[i, j, 1] = NaN                       # ocean
+        end
+    end
+
+    # One river mouth: the easternmost land column nearest the coast, mid-domain.
+    coast_i = findfirst(>(0), λc)                      # first land column east of coast
+    data[coast_i, 20, 1] = Q₀
+
+    set!(discharge, data)
+    return discharge
+end
+
+@testset "River routing conservation [$arch]" for arch in test_architectures
+    Q₀ = 1234.0          # m³ s⁻¹
+    ρ = 1000.0           # kg m⁻³
+
+    discharge = synthetic_discharge_field(arch, Q₀)
+    target_grid = half_land_ocean_grid(arch)
+
+    outlet_i, outlet_j, outlet_λ, outlet_φ = coastal_outlet_indices(discharge)
+    @test length(outlet_i) > 0
+
+    routing = build_river_routing(target_grid, outlet_i, outlet_j, outlet_λ, outlet_φ;
+                                  freshwater_density = ρ, maximum_search_radius = 5)
+
+    ti  = Array(routing.target_i)
+    tj  = Array(routing.target_j)
+    off = Array(routing.offsets)
+    coi = Array(routing.contribution_outlet_i)
+    coj = Array(routing.contribution_outlet_j)
+    cw  = Array(routing.contribution_weight)
+
+    # Every destination must be an active (wet) ocean cell.
+    kᴺ = size(target_grid, 3)
+    for c in eachindex(ti)
+        @test !inactive_node(ti[c], tj[c], kᴺ, target_grid, Center(), Center(), Center())
+    end
+
+    # Reconstruct the scattered freshwater mass flux and integrate it over the
+    # ocean grid. It must equal ρ × total discharge (volume conservation).
+    discharge_cpu = Array(interior(discharge))[:, :, 1]
+    Nx, Ny, _ = size(target_grid)
+    flux = zeros(Float64, Nx, Ny)
+    for c in eachindex(ti)
+        for k in off[c]:(off[c+1] - 1)
+            Q = discharge_cpu[coi[k], coj[k]]
+            isnan(Q) && continue
+            flux[ti[c], tj[c]] += cw[k] * Q
+        end
+    end
+
+    integrated_mass_flux = 0.0
+    for i in 1:Nx, j in 1:Ny
+        integrated_mass_flux += flux[i, j] * Azᶜᶜᶜ(i, j, kᴺ, target_grid)
+    end
+
+    total_discharge = sum(q for q in discharge_cpu if !isnan(q))
+    @test integrated_mass_flux ≈ ρ * total_discharge rtol = 1e-5
+    @test total_discharge ≈ Q₀
+end
+
+@testset "Routed PrescribedLand interpolate_state! [$arch]" for arch in test_architectures
+    Q₀ = 555.0
+    ρ = 1000.0
+
+    snapshot = synthetic_discharge_field(arch, Q₀)
+    target_grid = half_land_ocean_grid(arch)
+
+    # A two-snapshot FieldTimeSeries holding the same discharge at both times.
+    native_grid = snapshot.grid
+    times = [0.0, 86400.0]
+    discharge = FieldTimeSeries{Center, Center, Nothing}(native_grid, times)
+    parent(discharge[1]) .= parent(snapshot)
+    parent(discharge[2]) .= parent(snapshot)
+
+    outlets = coastal_outlet_indices(snapshot)
+    routing = build_river_routing(target_grid, outlets...;
+                                  freshwater_density = ρ, maximum_search_radius = 5)
+
+    land = PrescribedLand((; rivers = discharge); river_routing = routing)
+
+    exchanger = (; state = (; freshwater_flux = Field{Center, Center, Nothing}(target_grid)))
+    coupled_model = (; clock = Clock(time = 0.0))
+
+    interpolate_state!(exchanger, target_grid, land, coupled_model)
+
+    flux = Array(interior(exchanger.state.freshwater_flux))[:, :, 1]
+    Nx, Ny, _ = size(target_grid)
+    kᴺ = size(target_grid, 3)
+
+    integrated_mass_flux = 0.0
+    for i in 1:Nx, j in 1:Ny
+        integrated_mass_flux += flux[i, j] * Azᶜᶜᶜ(i, j, kᴺ, target_grid)
+    end
+
+    @test integrated_mass_flux ≈ ρ * Q₀ rtol = 1e-5
+end


### PR DESCRIPTION
## Summary

Adds a `GloFASPrescribedLand` component that forces the ocean with **GloFAS** river discharge, placed on the ocean coastline conserving freshwater volume.

GloFAS (Global Flood Awareness System) forces the LISFLOOD hydrological + channel-routing model with **ERA5 runoff** to produce river discharge already accumulated downstream to river mouths ([Harrigan et al. 2020](https://essd.copernicus.org/articles/12/2043/2020/)). It's the ERA5-consistent analogue of JRA55's pre-routed river freshwater flux. Raw ERA5 surface runoff, by contrast, is unrouted and would be largely discarded when interpolated onto an ocean grid and land-masked.

## What's included

**DataWrangling — GloFAS dataset**
- New `GloFAS` module: `GloFASReanalysis` (v4, 0.05°, daily river discharge, 1979–present), wired into the existing `Metadata → FieldTimeSeries` pipeline.
- CDS extension download via `cems-glofas-historical`, with server-side `area` subsetting for `BoundingBox` regions. GloFAS lives on the **EWDS** endpoint (separate from the ERA5 CDS), so the download overrides CDSAPI's url per call through its `ScopedValues`, reusing the shared ECMWF token — a `~/.cdsapirc` pointed at the ERA5 CDS keeps working. `GLOFAS_CDSAPI_URL` / `GLOFAS_CDSAPI_KEY` override the defaults.

**Lands — conservative coastal routing**
- `RiverRouting` + `build_river_routing`: locate river mouths from the dataset's land/ocean boundary, map each to the nearest active ocean cell, with weight `ρ_freshwater / A_ocean` so the area integral of the deposited flux equals the total discharge × density.
- Scatter `interpolate_state!`: **one thread per destination ocean cell** (no atomics → GPU-safe), with temporal `FieldTimeSeries` interpolation at the exact mouth cell. `PrescribedLand` gains an optional `river_routing` field; the JRA55 (pre-routed, pointwise) path is unchanged and dispatches as before.

**Docs & tests**
- Retitle the ERA5 example to *"ERA5 and GloFAS reanalysis data"* with a new section that downloads Amazon-mouth discharge and visualizes the coastal routing.
- `test/test_river_routing.jl`: outlet detection + volume-conservation (direct and through the real scatter).

## Testing
- `test_river_routing.jl` passes on CPU; all ExplicitImports QA checks pass.
- **Verified end-to-end against the live EWDS API** (Amazon-mouth box): download succeeds, NetCDF parsing is correct (variable `dis24`, `latitude`/`longitude` coords, latitude north-to-south), discharge magnitudes are physical (~196,000 m³/s at the Amazon), and all 281 detected river mouths route onto 157 coastal ocean cells.

## Notes
- Routing requires the target ocean grid to have **active coastal cells** — i.e. enough near-surface vertical resolution that shallow shelf cells aren't masked out by `GridFittedBottom`. The tutorial grid was updated accordingly (a single thick level drops every mouth).
- GloFAS native longitude is kept in the −180–180 convention to match typical regional ocean grids; the CDS files (0–360) are reconciled on load. A global (`region = nothing`) GloFAS forcing against a 0–360 ocean grid would need convention handling in the routing — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)