### PR TITLE
Fix sea-ice fluxes

### DIFF
--- a/src/Radiations/apply_air_sea_ice_radiative_fluxes.jl
+++ b/src/Radiations/apply_air_sea_ice_radiative_fluxes.jl
@@ -77,15 +77,12 @@ end
     ℐꜛˡʷ = emitted_longwave_radiation(Ts, rs.σ, rs.ϵ)
     ℐₐˡʷ = absorbed_longwave_radiation(rs.ϵ, rs.ℐꜜˡʷ)
     ℐₜˢʷ = transmitted_shortwave_radiation(rs.α, rs.ℐꜜˢʷ)
-
-    # Sea-ice radiation contributes only where ice exists.
-    ice_present = ℵᵢ > 0
-    ΣQ_rad_ice = (ℐꜛˡʷ + ℐₐˡʷ + ℐₜˢʷ) * ice_present
+    ΣQ  = (ℐꜛˡʷ + ℐₐˡʷ + ℐₜˢʷ) * ℵᵢ
 
     inactive = inactive_node(i, j, kᴺ, grid, Center(), Center(), Center())
 
     @inbounds begin
-        top_heat_flux[i, j, 1] += ifelse(inactive, zero(grid), ΣQ_rad_ice)
+        top_heat_flux[i, j, 1] += ifelse(inactive, zero(grid), ΣQ)
         interface_radiative_flux.upwelling_longwave[i, j, 1]    = ℐꜛˡʷ
         interface_radiative_flux.downwelling_longwave[i, j, 1]  = - ℐₐˡʷ
         interface_radiative_flux.downwelling_shortwave[i, j, 1] = - ℐₜˢʷ

--- a/src/SeaIces/assemble_net_sea_ice_fluxes.jl
+++ b/src/SeaIces/assemble_net_sea_ice_fluxes.jl
@@ -64,8 +64,10 @@ end
     ρτˣ = atmosphere_sea_ice_fluxes.x_momentum # zonal momentum flux
     ρτʸ = atmosphere_sea_ice_fluxes.y_momentum # meridional momentum flux
 
-    # Turbulent contributions only (radiation added later by apply_air_sea_ice_radiative_fluxes!)
-    ΣQt = (𝒬ᵀ + 𝒬ᵛ) * (ℵi > 0)
+    ΣQt = (𝒬ᵀ + 𝒬ᵛ) * ℵi
+    
+    # Frazil ice does not depend on the ice concentration (it is already per-cell)
+    # While interface heat is pre-multiplied by concentration
     ΣQb = 𝒬ᶠʳᶻ + 𝒬ⁱⁿ
 
     # Mask fluxes over land for convenience


### PR DESCRIPTION
The sea ice model requires per-cell fluxes, not per-ice fluxes.
For this reason the fluxes need to be multiplied by concentration.
The only flux that does not need multiplication by concentration is the frazil ice flux which is independent of the ice state