### PR TITLE
Bugfix in `get_radiative_forcing`

### DIFF
--- a/examples/coupled_conservation.jl
+++ b/examples/coupled_conservation.jl
@@ -61,6 +61,7 @@ ocean = ocean_simulation(grid;
                          momentum_advection = nothing,
                          tracer_advection = nothing,
                          coriolis = nothing,
+                         radiative_forcing = nothing,
                          closure = CATKEVerticalDiffusivity(),
                          bottom_drag_coefficient = 0)
 

--- a/src/Oceans/radiative_forcing.jl
+++ b/src/Oceans/radiative_forcing.jl
@@ -86,6 +86,7 @@ end
 end
 
 get_radiative_forcing(something) = nothing
+get_radiative_forcing(tcr::TwoColorRadiation) = tcr
 
 function get_radiative_forcing(FT::MultipleForcings)
     for forcing in FT.forcings
@@ -95,9 +96,5 @@ function get_radiative_forcing(FT::MultipleForcings)
 end
 
 get_radiative_forcing(sim::Simulation) = get_radiative_forcing(sim.model)
-
-get_radiative_forcing(model::HydrostaticFreeSurfaceModel) =
-    get_radiative_forcing(model.forcing.T)
-
-get_radiative_forcing(model::NonhydrostaticModel) =
-    get_radiative_forcing(model.forcing.T)
+get_radiative_forcing(model::HydrostaticFreeSurfaceModel) = get_radiative_forcing(model.forcing.T)
+get_radiative_forcing(model::NonhydrostaticModel) = get_radiative_forcing(model.forcing.T)

--- a/test/test_conservation.jl
+++ b/test/test_conservation.jl
@@ -43,6 +43,7 @@ end
                              tracer_advection        = nothing,
                              closure                 = CATKEVerticalDiffusivity(),
                              coriolis                = nothing,
+                             radiative_forcing       = nothing,
                              bottom_drag_coefficient = 0)
 
     Tᵢ = -1.5

--- a/test/test_ocean_only_model.jl
+++ b/test/test_ocean_only_model.jl
@@ -47,6 +47,8 @@ using Oceananigans.OrthogonalSphericalShellGrids
         free_surface = SplitExplicitFreeSurface(grid; substeps=20)
         ocean = ocean_simulation(grid; free_surface)
 
+        @test NumericalEarth.Oceans.get_radiative_forcing(ocean) isa NumericalEarth.Oceans.TwoColorRadiation
+        
         atmosphere = JRA55PrescribedAtmosphere(arch; time_indices_in_memory=4)
         radiation = JRA55PrescribedRadiation(arch; time_indices_in_memory=4)
 


### PR DESCRIPTION
in main there was no `get_radiative_forcing(::TwoColorRadiation)` method, so the fallback was called `get_radiative_forcing(something) = nothing` effectively ignoring penetrating radiation.
This PR fixes it.

This might be the cause of the cooling we find in the first 100 meters of the ocean in our OMIP simulations