### PR TITLE
Fix radiative forcing for a zstar grid

### DIFF
--- a/src/Oceans/radiative_forcing.jl
+++ b/src/Oceans/radiative_forcing.jl
@@ -45,9 +45,12 @@ end
 const c = Center()
 const f = Face()
 
+# In zstar we might have positive z, so  `exp(κ * z)` is not correct
 @inline function beers_law_radiation(i, j, k, grid, J₀ , κ)
-    z = Oceananigans.Grids.znode(i, j, k, grid, c, c, f)
-    return J₀ * exp(κ * z)
+    Nz = size(grid, 3)
+    z  = Oceananigans.Grids.znode(i, j, k,    grid, c, c, f)
+    η  = Oceananigans.Grids.znode(i, j, Nz+1, grid, c, c, f)
+    return J₀ * exp(κ * (z - η))
 end
 
 @inline function (R::TwoColorRadiation)(i, j, k, grid, clock, fields)


### PR DESCRIPTION
The formulation was not correct because it assumed that `z == 0` at the surface. 
However, for a zstar grid, especially when we have a very small surface grid cell (for example 1m), `z` at `Nz` might be positive, therefore the radiation computed with `exp(\kappa z)` amplifies instead of reducing the incoming solar flux and the simulation explodes.

This PR fixes the penetrative radiation