### PR TITLE
Make tripolar zipper-BC test independent of dataset downloads

### DIFF
--- a/test/test_prescribed_atmosphere.jl
+++ b/test/test_prescribed_atmosphere.jl
@@ -1,7 +1,4 @@
 include("runtests_setup.jl")
-include("download_utils.jl")
-
-using CDSAPI
 
 using Oceananigans.BoundaryConditions: fill_halo_regions!
 using Oceananigans.Fields: parent
@@ -33,36 +30,19 @@ end
 end
 
 @testset "Regridded prescribed atmosphere tripolar velocity zipper sign" begin
-
-    era5_dataset = ERA5HourlySingleLevel()
-    # Use a known-good ERA5 timestamp instead of the earliest available
-    # temperature date: `ERA5PrescribedAtmosphere` also requests total
-    # precipitation, and the CDS/MARS archive can return `MarsNoDataError`
-    # for the generic 1940-01-01 hourly window.
-    era5_start = DateTime(2005, 2, 1, 12)
-    era5_end = era5_start + Hour(1)
-    era5_dates = era5_start:Hour(1):era5_end
-
-    atmospheres = (
-        (name = "JRA55", atmosphere = JRA55PrescribedAtmosphere(CPU(); time_indices_in_memory = 2)),
-        (name = "ECCO", atmosphere = ECCOPrescribedAtmosphere(CPU(); dataset = ECCO4Monthly(),
-                                                                     start_date = start_date,
-                                                                     end_date = start_date + Month(1),
-                                                                     time_indices_in_memory = 2)),
-        (name = "ERA5", atmosphere = ERA5PrescribedAtmosphere(CPU(); dataset = era5_dataset,
-                                                                     start_date = era5_start,
-                                                                     end_date = era5_end,
-                                                                     time_indices_in_memory = 2))
-    )
+    # The exchanger builds its velocity state on the (tripolar) exchange grid with
+    # north-fold BCs, independent of the atmosphere's source grid or data, so a plain
+    # PrescribedAtmosphere on a lat-lon grid exercises the same path without any download.
+    # Dataset-backed atmosphere constructors are exercised by the download tests.
+    atmosphere_grid = LatitudeLongitudeGrid(CPU(); size = (36, 18, 1),
+                                            longitude = (0, 360), latitude = (-80, 80),
+                                            z = (-1, 0), halo = (3, 3, 3))
+    atmosphere = PrescribedAtmosphere(atmosphere_grid, [0.0])
 
     exchange_grid = TripolarGrid(CPU(); size = (32, 16, 1), z = (-1, 0), halo = (3, 3, 3))
+    exchanger = NumericalEarth.EarthSystemModels.InterfaceComputations.ComponentExchanger(atmosphere, exchange_grid)
 
-    for (; name, atmosphere) in atmospheres
-        @testset "$name" begin
-            exchanger = NumericalEarth.EarthSystemModels.InterfaceComputations.ComponentExchanger(atmosphere, exchange_grid)
-            for field in (exchanger.state.u, exchanger.state.v)
-                assert_tripolar_velocity_zipper(field, exchange_grid)
-            end
-        end
+    for field in (exchanger.state.u, exchanger.state.v)
+        assert_tripolar_velocity_zipper(field, exchange_grid)
     end
 end


### PR DESCRIPTION
## Summary

The `"Regridded prescribed atmosphere tripolar velocity zipper sign"` testset in `test/test_prescribed_atmosphere.jl` constructed JRA55, ECCO, and ERA5 prescribed atmospheres, all of which require network downloads. This has been failing CI flakily — most recently the ECCO4 wind download (`EXFewind_1993_01.nc`) timing out from `ecco.jpl.nasa.gov` (`RequestError: Operation too slow`).

The assertion only checks that the exchanger's velocity state on the **tripolar exchange grid** flips sign across the north fold. `ComponentExchanger(::PrescribedAtmosphere, grid)` builds `state.u`/`state.v` on the exchange grid with the north-fold(-1) BCs regardless of the atmosphere's source grid or data — so the dataset never enters the assertion. The three-way iteration was redundant for this check and the sole source of flakiness.

## Change

Replace the three dataset-backed atmospheres with a single plain `PrescribedAtmosphere` on a lat-lon source grid. This exercises the identical exchanger path with **no download**, so coverage of the zipper-sign behavior is unchanged. The `using CDSAPI` / `download_utils.jl` includes and ERA5 date scaffolding are removed as they are now unused.

Dataset-backed atmosphere constructors remain covered by the download tests (`test_ecco_atmosphere.jl`, `test_jra55.jl`, `test_cds_downloading.jl`).

## Notes

Not run locally — this machine's REPL can't precompile NumericalEarth due to an unrelated dev-Oceananigans/ClimaSeaIce method-overwrite clash. CI will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)