### PR TITLE
On-the-fly nesting BCs: ParentStateBoundary + #5726-aligned interpolate (WIP)

### DIFF
--- a/ext/NumericalEarthBreezeExt/breeze_prognostic_state.jl
+++ b/ext/NumericalEarthBreezeExt/breeze_prognostic_state.jl
@@ -1,9 +1,29 @@
 #####
-##### breeze_prognostic_state: moist thermodynamic state → Breeze prognostics
+##### Breeze prognostic maps: moist thermodynamic state → CompressibleDynamics prognostics
 #####
+#
+# Pointwise `@inline` maps from a moist thermodynamic state (temperature `T`, vapor `qᵛ`, cloud
+# liquid `qᶜˡ`, cloud ice `qᶜⁱ`, pressure `p`) to the variables Breeze integrates. Written on bare
+# scalars + gas-constant/heat-capacity/latent-heat numbers so they are GPU-safe and reusable both
+# broadcast over `Field`s (`breeze_prognostic_state`) and per boundary-face node (the on-the-fly
+# nesting boundary conditions / relaxation). `Field`-valued arguments compose lazily via
+# AbstractOperations, so the same definitions materialize fields too.
 
 using Oceananigans.Fields: Field, compute!
 using Breeze: ThermodynamicConstants, dry_air_gas_constant, vapor_gas_constant
+
+const REFERENCE_PRESSURE = 1e5  # Pa, θ reference (pˢᵗ)
+
+@inline virtual_temperature(T, qᵛ, Rᵈ, Rᵛ) = T * (1 + (Rᵛ / Rᵈ - 1) * qᵛ)
+
+@inline air_density(T, qᵛ, p, Rᵈ, Rᵛ) = p / (Rᵈ * virtual_temperature(T, qᵛ, Rᵈ, Rᵛ))
+
+@inline potential_temperature(T, p, Rᵈ, cᵖᵈ) = T * (REFERENCE_PRESSURE / p)^(Rᵈ / cᵖᵈ)
+
+@inline liquid_ice_potential_temperature(T, qᶜˡ, qᶜⁱ, p, Rᵈ, cᵖᵈ, ℒˡ, ℒⁱ) =
+    potential_temperature(T, p, Rᵈ, cᵖᵈ) * (1 - (ℒˡ * qᶜˡ + ℒⁱ * qᶜⁱ) / (cᵖᵈ * T))
+
+@inline total_water_specific_humidity(qᵛ, qᶜˡ, qᶜⁱ) = qᵛ + qᶜˡ + qᶜⁱ
 
 """
 $(TYPEDSIGNATURES)
@@ -25,23 +45,16 @@ child initial condition in `examples/era5_breeze.jl` route through this so the
 conversion lives in one place.
 """
 function NumericalEarth.Atmospheres.breeze_prognostic_state(constants::ThermodynamicConstants,
-                                                            T, qᵛ, qᶜ, qⁱ, p)
+                                                            T, qᵛ, qᶜˡ, qᶜⁱ, p)
     Rᵈ  = dry_air_gas_constant(constants)
     Rᵛ  = vapor_gas_constant(constants)
-    cₚᵈ = constants.dry_air.heat_capacity
-    Lᵥ  = constants.liquid.reference_latent_heat
-    Lₛ  = constants.ice.reference_latent_heat
+    cᵖᵈ = constants.dry_air.heat_capacity
+    ℒˡ  = constants.liquid.reference_latent_heat
+    ℒⁱ  = constants.ice.reference_latent_heat
 
-    κ    = Rᵈ / cₚᵈ
-    εfac = Rᵛ / Rᵈ - 1
-    pˢᵗ  = 1e5  # Pa
-
-    Tᵛ  = T * (1 + εfac * qᵛ)                 # virtual temperature (vapor only)
-    θ   = T * (pˢᵗ / p)^κ                     # potential temperature
-
-    ρ   = Field(p / (Rᵈ * Tᵛ))                                   # moist ideal gas law
-    θˡⁱ = Field(θ * (1 - (Lᵥ * qᶜ + Lₛ * qⁱ) / (cₚᵈ * T)))       # Breeze diagnostic form
-    qᵗ  = Field(qᵛ + qᶜ + qⁱ)
+    ρ   = Field(air_density(T, qᵛ, p, Rᵈ, Rᵛ))
+    θˡⁱ = Field(liquid_ice_potential_temperature(T, qᶜˡ, qᶜⁱ, p, Rᵈ, cᵖᵈ, ℒˡ, ℒⁱ))
+    qᵗ  = Field(total_water_specific_humidity(qᵛ, qᶜˡ, qᶜⁱ))
 
     compute!(ρ)
     compute!(θˡⁱ)

--- a/src/EarthSystemModels/NestedSimulations/NestedSimulations.jl
+++ b/src/EarthSystemModels/NestedSimulations/NestedSimulations.jl
@@ -16,6 +16,7 @@ include("nested_model.jl")
 include("nested_simulation.jl")
 include("transformed_interpolate.jl")
 include("interpolated_fts_boundary.jl")
+include("parent_state_boundary.jl")
 include("parent_boundary_conditions.jl")
 include("parent_forcings.jl")
 

--- a/src/EarthSystemModels/NestedSimulations/parent_state_boundary.jl
+++ b/src/EarthSystemModels/NestedSimulations/parent_state_boundary.jl
@@ -1,0 +1,97 @@
+#####
+##### ParentStateBoundary: a boundary value computed on the fly from several interpolated parent
+##### state fields. Internal — not a user-facing abstraction. The simple single-source case is
+##### `interpolated_fts_boundary.jl`; this is the multi-field generalization the nesting path uses
+##### to derive a child prognostic (e.g. Breeze's ρ, ρu, ρθˡⁱ, ρqᵉ) from raw parent state.
+#####
+#
+# At each boundary-face node it interpolates each source in `sources` (a `NamedTuple` of parent
+# `FieldTimeSeries`) — each with its own `interpolations` transform (e.g. `log` for pressure and
+# temperature, `identity` otherwise) — and passes the resulting `NamedTuple` of scalar state values
+# to `transform`, a pointwise map to the child prognostic. `transform` and the per-source
+# interpolation transforms are supplied by the consuming model (Breeze, in `NumericalEarthBreezeExt`);
+# this carrier knows nothing about which prognostic or which dataset.
+#
+# Reuses the node / boundary-index / clock helpers from `interpolated_fts_boundary.jl`.
+
+using Oceananigans.Fields: instantiated_location
+
+# `interpolate(func, …)` (Oceananigans #5726) returns the blend in func-space and applies no inverse —
+# the caller owns it. The carrier wants the *actual* state value (to feed the prognostic map), so
+# `_query_source` un-maps with `inverse_transform`: `log`-space interpolation of pressure becomes
+# `exp(blend of log p)` (faithful ln-p interpolation); `identity` is a plain interpolation.
+@inline inverse_transform(::typeof(identity)) = identity
+@inline inverse_transform(::typeof(log))      = exp
+@inline inverse_transform(::typeof(log2))     = exp2
+@inline inverse_transform(::typeof(log10))    = exp10
+
+# Source query applying interpolation transform `f` per source value, then un-mapping. A
+# `FieldTimeSeries` is interpolated in space + time; an `AbstractField` (or GPU-adapted source) in space.
+@inline _query_source(fts::FlavorOfFTS, source_grid, X, loc, t, f) =
+    inverse_transform(f)(Oceananigans.Fields.interpolate(f, X, Time(t), fts, Oceananigans.instantiated_location(fts), source_grid))
+
+@inline _query_source(source, source_grid, X, loc, t, f) =
+    inverse_transform(f)(Oceananigans.Fields.interpolate(f, X, source, loc, source_grid))
+
+struct ParentStateBoundary{Dim, SideType, LX, LY, LZ, S, G, I, F}
+    sources        :: S   # NamedTuple of parent FieldTimeSeries (keyed by physical variable)
+    source_grid    :: G   # one shared parent grid (all sources live on it)
+    interpolations :: I   # NamedTuple (same keys) of per-source interp transforms (log / identity)
+    transform      :: F   # (state::NamedTuple) -> scalar child prognostic
+end
+
+# User-facing-ish constructor — pre-regularization, location/side/dim tags are `Nothing`. We capture
+# one shared `source_grid` (mirroring `Interpolated`), essential for GPU since adapted FTS drop `.grid`.
+function ParentStateBoundary(sources::NamedTuple, interpolations::NamedTuple, transform)
+    grid = first(sources).grid
+    return ParentStateBoundary{Nothing, Nothing, Nothing, Nothing, Nothing,
+                               typeof(sources), typeof(grid), typeof(interpolations), typeof(transform)}(
+        sources, grid, interpolations, transform)
+end
+
+@inline ParentStateBoundary{Dim, SideType, LX, LY, LZ}(sources::S, source_grid::G, interpolations::I, transform::F) where {Dim, SideType, LX, LY, LZ, S, G, I, F} =
+    ParentStateBoundary{Dim, SideType, LX, LY, LZ, S, G, I, F}(sources, source_grid, interpolations, transform)
+
+Adapt.adapt_structure(to, c::ParentStateBoundary{D, S, LX, LY, LZ}) where {D, S, LX, LY, LZ} =
+    ParentStateBoundary{D, S, LX, LY, LZ}(map(s -> adapt(to, s), c.sources),
+                                          adapt(to, c.source_grid),
+                                          c.interpolations,
+                                          adapt(to, c.transform))
+
+function regularize_boundary_condition(c::ParentStateBoundary{Nothing}, grid, loc, dim, SideType, args...)
+    LX = typeof(loc[1]); LY = typeof(loc[2]); LZ = typeof(loc[3])
+    for s in values(c.sources)
+        validate_source_bracket(s, grid, LX, LY, LZ)
+    end
+    return ParentStateBoundary{dim, SideType, LX, LY, LZ}(c.sources, c.source_grid, c.interpolations, c.transform)
+end
+
+# Interpolate every source at the boundary-face node `X` (each via its own interpolation transform —
+# `log` for fields interpolated in log space) and apply the prognostic `transform` to the resulting
+# state. Sources are Center-located parent fields; `X` is the boundary face in the normal direction.
+@inline function _parent_state(c::ParentStateBoundary{<:Any, <:Any, LX, LY, LZ}, X, t) where {LX, LY, LZ}
+    loc   = (LX(), LY(), LZ())
+    state = map((src, itp) -> _query_source(src, c.source_grid, X, loc, t, itp), c.sources, c.interpolations)
+    return c.transform(state)
+end
+
+@inline function getbc(bc::ParentStateBoundary{1, S, LX, LY, LZ},
+                       j::Integer, k::Integer, grid::AbstractGrid, clock=nothing, args...) where {S, LX, LY, LZ}
+    i = _boundary_index(S, grid.Nx)
+    X = node(i, j, k, grid, Face(), LY(), LZ())
+    return _parent_state(bc, X, clock_time(clock))
+end
+
+@inline function getbc(bc::ParentStateBoundary{2, S, LX, LY, LZ},
+                       i::Integer, k::Integer, grid::AbstractGrid, clock=nothing, args...) where {S, LX, LY, LZ}
+    j = _boundary_index(S, grid.Ny)
+    X = node(i, j, k, grid, LX(), Face(), LZ())
+    return _parent_state(bc, X, clock_time(clock))
+end
+
+@inline function getbc(bc::ParentStateBoundary{3, S, LX, LY, LZ},
+                       i::Integer, j::Integer, grid::AbstractGrid, clock=nothing, args...) where {S, LX, LY, LZ}
+    k = _boundary_index(S, grid.Nz)
+    X = node(i, j, k, grid, LX(), LY(), Face())
+    return _parent_state(bc, X, clock_time(clock))
+end


### PR DESCRIPTION
**Draft / WIP — stacked on #386** (base is `glw/prescribed-atmosphere-refactor`; rebase onto `main` once #386 merges).

Builds the on-the-fly nesting boundary machinery that derives a child model's prognostics from raw parent state at fill time — eliminating the materialized density-weighted FTS bundle and the per-snapshot `breeze_prognostic_state` precompute.

## In this draft (committed + smoke-validated on CPU)

- **`breeze_prognostic_state` factored** into reusable pointwise maps (`air_density`, `liquid_ice_potential_temperature`, `total_water_specific_humidity`, …) — one definition, used both broadcast over `Field`s and per boundary-face node. No behavior change.
- **`ParentStateBoundary`** (internal carrier): holds a `NamedTuple` of parent-state `FieldTimeSeries` + per-source interpolation transforms (log for `p`/`T`, identity otherwise) + a prognostic map. `getbc` interpolates each source at the boundary-face node and applies the map. Interpolation uses the #5726-style `interpolate(func,…)` (func-space) and un-maps locally via `inverse_transform`, so log-space pressure = `exp(blend of log p)` (faithful ln-p). Smokes: a 2-field transform reconstructs the right face values; a log-space source recovers the geometric interpolation.

> The transform-interpolate shim (`transformed_interpolate.jl`, on #386) now mirrors **CliMA/Oceananigans.jl#5726** (`MappedData` / func-space / caller-applies-inverse). When #5726 releases, that file is deleted and the calls hit upstream verbatim.

## Still to come (this PR will grow)

- Breeze-ext prognostic maps as transforms (`ρ`, `ρu`, `ρθˡⁱ`, `ρqᵉ`) + the model hook `parent_boundary_conditions(grid, parent, ::Type{AtmosphereModel})`.
- The public factory `atmosphere_simulation(grid; parent=…)` dispatching to an internal `nested_atmosphere_simulation(grid, parent; …)` that augments BCs + Davies relaxation from the parent and delegates back to the plain factory (so the default simulation config lives in one place).
- GPU-path validation of the carrier `getbc` (CPU validated here; the kernel path needs a GPU node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
