### PR TITLE
Fix Reactant reconcile_state! to initialize state exchanger

### DIFF
--- a/ext/NumericalEarthReactantExt.jl
+++ b/ext/NumericalEarthReactantExt.jl
@@ -19,10 +19,6 @@ const ReactantESM{R, A, L, I, O, F, C} = Union{
     EarthSystemModel{R, A, L, I, O, F, C, <:Distributed{ReactantState}},
 }
 
-# Mirror the CPU `reconcile_state!` (initialize the state-exchanger regridder,
-# then update the state), but trace-and-run each step through Reactant. Eager
-# calls would not mutate the `ReactantState` arrays, leaving the regridder's
-# fractional indices uninitialized so `interpolate_state!` reads halo cell (0, 0).
 function reconcile_state!(model::ReactantESM)
     @jit Oceananigans.initialize!(model.interfaces.exchanger, model)
     @jit Oceananigans.TimeSteppers.update_state!(model)

--- a/ext/NumericalEarthReactantExt.jl
+++ b/ext/NumericalEarthReactantExt.jl
@@ -13,7 +13,8 @@ const OceananigansReactantExt = Base.get_extension(
      Oceananigans, :OceananigansReactantExt
 )
 
-const ReactantOSIM{R, A, L, I, O, F, C} = Union{
+# Any EarthSystemModel (every component combination) carried on `ReactantState`.
+const ReactantESM{R, A, L, I, O, F, C} = Union{
     EarthSystemModel{R, A, L, I, O, F, C, <:ReactantState},
     EarthSystemModel{R, A, L, I, O, F, C, <:Distributed{ReactantState}},
 }
@@ -22,7 +23,7 @@ const ReactantOSIM{R, A, L, I, O, F, C} = Union{
 # then update the state), but trace-and-run each step through Reactant. Eager
 # calls would not mutate the `ReactantState` arrays, leaving the regridder's
 # fractional indices uninitialized so `interpolate_state!` reads halo cell (0, 0).
-function reconcile_state!(model::ReactantOSIM)
+function reconcile_state!(model::ReactantESM)
     @jit Oceananigans.initialize!(model.interfaces.exchanger, model)
     @jit Oceananigans.TimeSteppers.update_state!(model)
     return nothing

--- a/ext/NumericalEarthReactantExt.jl
+++ b/ext/NumericalEarthReactantExt.jl
@@ -18,7 +18,15 @@ const ReactantOSIM{R, A, L, I, O, F, C} = Union{
     EarthSystemModel{R, A, L, I, O, F, C, <:Distributed{ReactantState}},
 }
 
-reconcile_state!(model::ReactantOSIM) = nothing
+# Mirror the CPU `reconcile_state!` (initialize the state-exchanger regridder,
+# then update the state), but trace-and-run each step through Reactant. Eager
+# calls would not mutate the `ReactantState` arrays, leaving the regridder's
+# fractional indices uninitialized so `interpolate_state!` reads halo cell (0, 0).
+function reconcile_state!(model::ReactantOSIM)
+    @jit Oceananigans.initialize!(model.interfaces.exchanger, model)
+    @jit Oceananigans.TimeSteppers.update_state!(model)
+    return nothing
+end
 
 import NumericalEarth.EarthSystemModels: same_time_type
 


### PR DESCRIPTION
## Summary

Closes #390.

The `ReactantOSIM` override of `reconcile_state!` in the Reactant extension was a no-op:

```julia
reconcile_state!(model::ReactantOSIM) = nothing
```

while the CPU dispatch ([`src/EarthSystemModels/earth_system_model.jl`](../blob/main/src/EarthSystemModels/earth_system_model.jl)) does real work:

```julia
function Oceananigans.TimeSteppers.reconcile_state!(model::ESM)
    initialize!(model.interfaces.exchanger, model)
    update_state!(model)
    return nothing
end
```

Because `reconcile_state!` runs at model construction, under Reactant the state-exchanger regridder's fractional indices were never populated. `interpolate_state!` then read forcing fields at halo cell `(0, 0)` instead of the correct cells, so the surface received **zero downwelling radiation** and cooled unphysically (~282 K vs ~288 K on CPU). This only manifested on spatially extended `(Bounded, Bounded)` grids — single-column `(Flat, Flat)` grids were unaffected since their regridder is trivial (`nothing` indices → direct cell access).

## Fix

Mirror the CPU `reconcile_state!`, but trace-and-run each step through Reactant `@jit` so the mutations actually land on the `ReactantState` arrays:

```julia
function reconcile_state!(model::ReactantOSIM)
    @jit Oceananigans.initialize!(model.interfaces.exchanger, model)
    @jit Oceananigans.TimeSteppers.update_state!(model)
    return nothing
end
```

This follows the `@jit` direction suggested by @glwagner and @dkytezab in the issue thread, and makes compiled and eager runs agree without requiring a manual `initialize!()` call. It also lets the differentiable-land examples drop their explicit `Oceananigans.initialize!(model_ad)` workaround.

## Testing

⚠️ Needs validation on the actual Reactant path (Julia 1.12 + Reactant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)