### PR TITLE
Expose stop_time in ocean and sea-ice sims

### DIFF
--- a/src/EarthSystemModels/EarthSystemModels.jl
+++ b/src/EarthSystemModels/EarthSystemModels.jl
@@ -40,7 +40,7 @@ using Thermodynamics: Thermodynamics as AtmosphericThermodynamics
 
 using Oceananigans: Oceananigans, AbstractModel, initialize!,
                     prognostic_state, restore_prognostic_state!
-using Oceananigans.Architectures: architecture, ReactantState
+using Oceananigans.Architectures: architecture, AbstractArchitecture, ReactantState
 using Oceananigans.Diagnostics: NaNChecker
 using Oceananigans.Fields: ZeroField
 using Oceananigans.Simulations: reset_clock!, Simulation
@@ -49,7 +49,7 @@ using Oceananigans.Utils: launch!, prettytime
 
 # Reactant does not support `stop_time`; it must stay `nothing` there.
 default_stop_time(grid, clock) = default_stop_time(architecture(grid), clock)
-default_stop_time(arch, clock) = clock.time isa Number ? Inf : Dates.DateTime(9999, 12, 31, 23, 59, 59)
+default_stop_time(::AbstractArchitecture, clock) = clock.time isa Number ? Inf : Dates.DateTime(9999, 12, 31, 23, 59, 59)
 default_stop_time(::ReactantState, clock) = nothing
 
 include("components.jl")

--- a/src/EarthSystemModels/EarthSystemModels.jl
+++ b/src/EarthSystemModels/EarthSystemModels.jl
@@ -30,20 +30,27 @@ export
     IceBathHeatFlux,
     ThreeEquationHeatFlux,
     # Friction velocity formulations
-    MomentumBasedFrictionVelocity
+    MomentumBasedFrictionVelocity,
+    default_stop_time
 
+import Dates
 using ClimaSeaIce.SeaIceThermodynamics: melting_temperature
 using KernelAbstractions: @kernel, @index
 using Thermodynamics: Thermodynamics as AtmosphericThermodynamics
 
 using Oceananigans: Oceananigans, AbstractModel, initialize!,
                     prognostic_state, restore_prognostic_state!
-using Oceananigans.Architectures: architecture
+using Oceananigans.Architectures: architecture, ReactantState
 using Oceananigans.Diagnostics: NaNChecker
 using Oceananigans.Fields: ZeroField
 using Oceananigans.Simulations: reset_clock!, Simulation
 using Oceananigans.TimeSteppers: Clock, reset!, tick!, time_step!, update_state!, reconcile_state!
 using Oceananigans.Utils: launch!, prettytime
+
+# Reactant does not support `stop_time`; it must stay `nothing` there.
+default_stop_time(grid, clock) = default_stop_time(architecture(grid), clock)
+default_stop_time(arch, clock) = clock.time isa Number ? Inf : Dates.DateTime(9999, 12, 31, 23, 59, 59)
+default_stop_time(::ReactantState, clock) = nothing
 
 include("components.jl")
 

--- a/src/Oceans/Oceans.jl
+++ b/src/Oceans/Oceans.jl
@@ -2,6 +2,7 @@ module Oceans
 
 export ocean_simulation, SlabOcean, PrescribedOcean
 
+import Dates
 using Adapt: Adapt, adapt
 using KernelAbstractions: @kernel, @index
 using Oceananigans: Oceananigans
@@ -21,7 +22,7 @@ using Oceananigans.Models.NonhydrostaticModels: NonhydrostaticModel
 using Oceananigans.OrthogonalSphericalShellGrids: OrthogonalSphericalShellGrids, TripolarGrid
 using Oceananigans.Operators: ℑxyᶠᶜᵃ, ℑxyᶜᶠᵃ, ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ∂xᶠᶜᶜ, ∂yᶜᶠᶜ
 using Oceananigans.Simulations: Simulation
-using Oceananigans.Timesteppers: Clock
+using Oceananigans.TimeSteppers: Clock
 using Oceananigans.TurbulenceClosures: κzᶜᶜᶠ
 using Oceananigans.TurbulenceClosures.TKEBasedVerticalDiffusivities: CATKEVerticalDiffusivity,
                                                                      CATKEMixingLength,

--- a/src/Oceans/Oceans.jl
+++ b/src/Oceans/Oceans.jl
@@ -2,7 +2,6 @@ module Oceans
 
 export ocean_simulation, SlabOcean, PrescribedOcean
 
-import Dates
 using Adapt: Adapt, adapt
 using KernelAbstractions: @kernel, @index
 using Oceananigans: Oceananigans
@@ -36,6 +35,7 @@ using ..EarthSystemModels: EarthSystemModels,
                            ocean_surface_velocities,
                            ocean_surface_salinity,
                            DegreesKelvin,
+                           default_stop_time,
                            heat_capacity
 using ..EarthSystemModels.InterfaceComputations: ComponentExchanger
 

--- a/src/Oceans/Oceans.jl
+++ b/src/Oceans/Oceans.jl
@@ -21,6 +21,7 @@ using Oceananigans.Models.NonhydrostaticModels: NonhydrostaticModel
 using Oceananigans.OrthogonalSphericalShellGrids: OrthogonalSphericalShellGrids, TripolarGrid
 using Oceananigans.Operators: ℑxyᶠᶜᵃ, ℑxyᶜᶠᵃ, ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ∂xᶠᶜᶜ, ∂yᶜᶠᶜ
 using Oceananigans.Simulations: Simulation
+using Oceananigans.Timesteppers: Clock
 using Oceananigans.TurbulenceClosures: κzᶜᶜᶠ
 using Oceananigans.TurbulenceClosures.TKEBasedVerticalDiffusivities: CATKEVerticalDiffusivity,
                                                                      CATKEMixingLength,

--- a/src/Oceans/nonhydrostatic_ocean_simulation.jl
+++ b/src/Oceans/nonhydrostatic_ocean_simulation.jl
@@ -3,7 +3,7 @@ using SeawaterPolynomials.TEOS10: TEOS10EquationOfState
 """
     nonhydrostatic_ocean_simulation(grid;
                                     clock = Clock(grid),
-                                    stop_time = clock.time isa Number ? Inf : DateTime(9999, 12, 31, 23, 59, 59),
+                                    stop_time = default_stop_time(grid, clock),
                                     Δt = 1,
                                     closure = nothing,
                                     tracers = (:T, :S),
@@ -25,8 +25,11 @@ timestepping is needed.
 
 ## Keyword Arguments
 
-- `clock`: Clock for the underlying model. Defaults to `Clock(grid)`, a numeric clock starting at `time = 0`. Pass a `DateTime`-based clock to step the simulation in calendar time (e.g. when coupling).
-- `stop_time`: Stop time for the simulation. Defaults to `Inf` for numeric clocks, or `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks.
+- `clock`: Clock for the underlying model. Defaults to `Clock(grid)`, a numeric clock starting at `time = 0`. 
+  Pass a `DateTime`-based clock to step the simulation in calendar time (e.g. when coupling).
+- `stop_time`: Stop time for the simulation. Defaults to `Inf` for numeric clocks, or 
+  `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks. On Reactant architectures it defaults to `nothing`, since 
+  Reactant does not support `stop_time`.
 - `Δt`: Timestep used by the `Simulation`. Defaults to `1` second.
 - `closure`: Turbulence closure. Defaults to `nothing` (implicit LES via WENO advection scheme).
 - `tracers`: Tuple of tracer names. Defaults to `(:T, :S)`.
@@ -41,7 +44,7 @@ timestepping is needed.
 """
 function nonhydrostatic_ocean_simulation(grid;
                                          clock = Clock(grid),
-                                         stop_time = clock.time isa Number ? Inf : Dates.DateTime(9999, 12, 31, 23, 59, 59),
+                                         stop_time = default_stop_time(grid, clock),
                                          Δt = 1,
                                          closure = nothing,
                                          tracers = (:T, :S),

--- a/src/Oceans/nonhydrostatic_ocean_simulation.jl
+++ b/src/Oceans/nonhydrostatic_ocean_simulation.jl
@@ -2,6 +2,8 @@ using SeawaterPolynomials.TEOS10: TEOS10EquationOfState
 
 """
     nonhydrostatic_ocean_simulation(grid;
+                                    clock = Clock(grid),
+                                    stop_time = clock.time isa Number ? Inf : DateTime(9999, 12, 31, 23, 59, 59),
                                     Δt = 1,
                                     closure = nothing,
                                     tracers = (:T, :S),
@@ -12,7 +14,6 @@ using SeawaterPolynomials.TEOS10: TEOS10EquationOfState
                                     advection = WENO(order=9),
                                     forcing = NamedTuple(),
                                     boundary_conditions::NamedTuple = NamedTuple(),
-                                    clock = nothing,
                                     verbose = false)
 
 Construct and return a nonhydrostatic ocean simulation suitable for Large Eddy
@@ -24,6 +25,8 @@ timestepping is needed.
 
 ## Keyword Arguments
 
+- `clock`: Clock for the underlying model. Defaults to `Clock(grid)`, a numeric clock starting at `time = 0`. Pass a `DateTime`-based clock to step the simulation in calendar time (e.g. when coupling).
+- `stop_time`: Stop time for the simulation. Defaults to `Inf` for numeric clocks, or `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks.
 - `Δt`: Timestep used by the `Simulation`. Defaults to `1` second.
 - `closure`: Turbulence closure. Defaults to `nothing` (implicit LES via WENO advection scheme).
 - `tracers`: Tuple of tracer names. Defaults to `(:T, :S)`.
@@ -34,10 +37,11 @@ timestepping is needed.
 - `advection`: Advection scheme. Defaults to `WENO(order=9)`.
 - `forcing`: Named tuple of additional forcing(s).
 - `boundary_conditions`: User-supplied boundary conditions; merged with defaults.
-- `clock`: Clock for the underlying model. Defaults to `nothing` (model builds its own).
 - `verbose`: If `true`, prints additional setup information.
 """
 function nonhydrostatic_ocean_simulation(grid;
+                                         clock = Clock(grid),
+                                         stop_time = clock.time isa Number ? Inf : Dates.DateTime(9999, 12, 31, 23, 59, 59),
                                          Δt = 1,
                                          closure = nothing,
                                          tracers = (:T, :S),
@@ -48,7 +52,6 @@ function nonhydrostatic_ocean_simulation(grid;
                                          advection = WENO(order=9),
                                          forcing = NamedTuple(),
                                          boundary_conditions::NamedTuple = NamedTuple(),
-                                         clock = nothing,
                                          verbose = false)
 
     # Set up boundary conditions using Field
@@ -70,20 +73,17 @@ function nonhydrostatic_ocean_simulation(grid;
     boundary_conditions = merge(default_boundary_conditions, boundary_conditions)
     buoyancy = SeawaterBuoyancy(; gravitational_acceleration, equation_of_state)
 
-    # Only forward `clock` when supplied so the model keeps its own default otherwise.
-    clock_kw = isnothing(clock) ? NamedTuple() : (; clock)
-
     ocean_model = NonhydrostaticModel(grid;
+                                      clock,
                                       buoyancy,
                                       closure,
                                       advection,
                                       tracers,
                                       coriolis,
                                       forcing,
-                                      boundary_conditions,
-                                      clock_kw...)
+                                      boundary_conditions)
 
-    ocean = Simulation(ocean_model; Δt, verbose)
+    ocean = Simulation(ocean_model; Δt, stop_time, verbose)
 
     return ocean
 end

--- a/src/Oceans/ocean_simulation.jl
+++ b/src/Oceans/ocean_simulation.jl
@@ -193,6 +193,8 @@ end
 
 """
     hydrostatic_ocean_simulation(grid;
+                                 clock = Clock(grid),
+                                 stop_time = clock.time isa Number ? Inf : Dates.DateTime(9999, 12, 31, 23, 59, 59),
                                  Δt = estimate_maximum_Δt(grid),
                                  closure = default_ocean_closure(),
                                  tracers = (:T, :S),
@@ -211,7 +213,6 @@ end
                                  equation_of_state = TEOS10EquationOfState(; reference_density),
                                  boundary_conditions::NamedTuple = NamedTuple(),
                                  radiative_forcing = default_radiative_forcing(grid),
-                                 clock = nothing,
                                  warn = true,
                                  verbose = false)
 
@@ -258,6 +259,8 @@ defaults on a per-field basis.
 
 ## Keyword Arguments
 
+- `clock`: Clock for the underlying model. Defaults to `Clock(grid)`, a numeric clock starting at `time = 0`. Pass a `DateTime`-based clock to step the simulation in calendar time (e.g. when coupling).
+- `stop_time`: Stop time for the simulation. Defaults to `Inf` for numeric clocks, or `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks.
 - `Δt`: Timestep used by the `Simulation`. Defaults to the maximum stable timestep estimated from the `grid`.
 - `closure`: A turbulence or mixing closure. Defaults to `default_ocean_closure()`.
 - `tracers`: Tuple of tracer names. Defaults to `(:T, :S)`.
@@ -276,13 +279,12 @@ defaults on a per-field basis.
 - `equation_of_state`: Equation of state object. Defaults to TEOS-10 (`TEOS10EquationOfState`).
 - `boundary_conditions`: User-supplied boundary conditions; merged with defaults.
 - `radiative_forcing`: Additional temperature forcing; merged into `forcing`.
-- `clock`: Clock for the underlying model. Defaults to `nothing`, in which case the
-  model builds its own default clock. Pass a `Clock` (e.g. `Clock{Float64}(time=0)` or
-  a `DateTime`-based clock) to control the time type, for instance when coupling.
 - `warn`: If `true`, warnings are emitted for potentially unintended setups.
 - `verbose`: If `true`, prints additional setup information.
 """
 function hydrostatic_ocean_simulation(grid;
+                                      clock = Clock(grid),
+                                      stop_time = clock.time isa Number ? Inf : Dates.DateTime(9999, 12, 31, 23, 59, 59),
                                       Δt = estimate_maximum_Δt(grid),
                                       closure = default_ocean_closure(),
                                       tracers = (:T, :S),
@@ -301,7 +303,6 @@ function hydrostatic_ocean_simulation(grid;
                                       equation_of_state = TEOS10EquationOfState(; reference_density),
                                       boundary_conditions::NamedTuple = NamedTuple(),
                                       radiative_forcing = default_radiative_forcing(grid),
-                                      clock = nothing,
                                       warn = true,
                                       verbose = false)
 
@@ -413,10 +414,8 @@ function hydrostatic_ocean_simulation(grid;
         tracer_advection = merge(tracer_advection, tke_advection)
     end
 
-    # Only forward `clock` when supplied so the model keeps its own default otherwise.
-    clock_kw = isnothing(clock) ? NamedTuple() : (; clock)
-
     ocean_model = HydrostaticFreeSurfaceModel(grid;
+                                              clock,
                                               buoyancy,
                                               closure,
                                               biogeochemistry,
@@ -427,10 +426,9 @@ function hydrostatic_ocean_simulation(grid;
                                               free_surface,
                                               coriolis,
                                               forcing,
-                                              boundary_conditions,
-                                              clock_kw...)
+                                              boundary_conditions)
 
-    ocean = Simulation(ocean_model; Δt, verbose)
+    ocean = Simulation(ocean_model; Δt, stop_time, verbose)
 
     return ocean
 end

--- a/src/Oceans/ocean_simulation.jl
+++ b/src/Oceans/ocean_simulation.jl
@@ -194,7 +194,7 @@ end
 """
     hydrostatic_ocean_simulation(grid;
                                  clock = Clock(grid),
-                                 stop_time = clock.time isa Number ? Inf : Dates.DateTime(9999, 12, 31, 23, 59, 59),
+                                 stop_time = default_stop_time(grid, clock),
                                  Δt = estimate_maximum_Δt(grid),
                                  closure = default_ocean_closure(),
                                  tracers = (:T, :S),
@@ -259,8 +259,11 @@ defaults on a per-field basis.
 
 ## Keyword Arguments
 
-- `clock`: Clock for the underlying model. Defaults to `Clock(grid)`, a numeric clock starting at `time = 0`. Pass a `DateTime`-based clock to step the simulation in calendar time (e.g. when coupling).
-- `stop_time`: Stop time for the simulation. Defaults to `Inf` for numeric clocks, or `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks.
+- `clock`: Clock for the underlying model. Defaults to `Clock(grid)`, a numeric clock starting at `time = 0`. 
+  Pass a `DateTime`-based clock to step the simulation in calendar time (e.g. when coupling).
+- `stop_time`: Stop time for the simulation. Defaults to `Inf` for numeric clocks, or 
+  `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks. On Reactant architectures it defaults to `nothing`, since 
+  Reactant does not support `stop_time`.
 - `Δt`: Timestep used by the `Simulation`. Defaults to the maximum stable timestep estimated from the `grid`.
 - `closure`: A turbulence or mixing closure. Defaults to `default_ocean_closure()`.
 - `tracers`: Tuple of tracer names. Defaults to `(:T, :S)`.
@@ -284,7 +287,7 @@ defaults on a per-field basis.
 """
 function hydrostatic_ocean_simulation(grid;
                                       clock = Clock(grid),
-                                      stop_time = clock.time isa Number ? Inf : Dates.DateTime(9999, 12, 31, 23, 59, 59),
+                                      stop_time = default_stop_time(grid, clock),
                                       Δt = estimate_maximum_Δt(grid),
                                       closure = default_ocean_closure(),
                                       tracers = (:T, :S),

--- a/src/SeaIces/SeaIces.jl
+++ b/src/SeaIces/SeaIces.jl
@@ -11,6 +11,7 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceMo
 using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ
 using Oceananigans.OrthogonalSphericalShellGrids: OrthogonalSphericalShellGrids
 using Oceananigans.Simulations: Simulation
+using Oceananigans.Timesteppers: Clock
 using Oceananigans.Units: minutes
 using Oceananigans.Utils: launch!
 using KernelAbstractions: @kernel, @index

--- a/src/SeaIces/SeaIces.jl
+++ b/src/SeaIces/SeaIces.jl
@@ -2,6 +2,7 @@ module SeaIces
 
 export sea_ice_simulation, FreezingLimitedOceanTemperature
 
+import Dates
 using Oceananigans: Oceananigans
 using Oceananigans.Architectures: architecture
 using Oceananigans.Coriolis: HydrostaticSphericalCoriolis
@@ -11,7 +12,7 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceMo
 using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ
 using Oceananigans.OrthogonalSphericalShellGrids: OrthogonalSphericalShellGrids
 using Oceananigans.Simulations: Simulation
-using Oceananigans.Timesteppers: Clock
+using Oceananigans.TimeSteppers: Clock
 using Oceananigans.Units: minutes
 using Oceananigans.Utils: launch!
 using KernelAbstractions: @kernel, @index

--- a/src/SeaIces/SeaIces.jl
+++ b/src/SeaIces/SeaIces.jl
@@ -2,7 +2,6 @@ module SeaIces
 
 export sea_ice_simulation, FreezingLimitedOceanTemperature
 
-import Dates
 using Oceananigans: Oceananigans
 using Oceananigans.Architectures: architecture
 using Oceananigans.Coriolis: HydrostaticSphericalCoriolis
@@ -17,7 +16,7 @@ using Oceananigans.Units: minutes
 using Oceananigans.Utils: launch!
 using KernelAbstractions: @kernel, @index
 
-using ..EarthSystemModels: EarthSystemModels
+using ..EarthSystemModels: EarthSystemModels, default_stop_time
 using ..EarthSystemModels.InterfaceComputations: InterfaceComputations, ComponentExchanger,
                                                  ThreeEquationHeatFlux
 

--- a/src/SeaIces/sea_ice_simulation.jl
+++ b/src/SeaIces/sea_ice_simulation.jl
@@ -25,6 +25,8 @@ end
 
 """
     sea_ice_simulation(grid, ocean=nothing;
+                       clock = Clock(grid),
+                       stop_time = clock.time isa Number ? Inf : Dates.DateTime(9999, 12, 31, 23, 59, 59),
                        Δt = 5minutes,
                        ice_salinity = 4, # psu
                        advection = nothing,
@@ -42,8 +44,7 @@ end
                                                             density=sea_ice_density),
                        conductivity = 2, # W m⁻¹ K⁻¹
                        internal_heat_flux = ConductiveFlux(; conductivity),
-                       snow_thermodynamics = default_snow_thermodynamics(grid),
-                       clock = nothing)
+                       snow_thermodynamics = default_snow_thermodynamics(grid))
 
 Construct a sea ice simulation with the given grid and optional ocean simulation.
 The sea ice model is configured with a slab thermodynamics, Elasto-Visco-Plastic rheology,
@@ -59,6 +60,8 @@ Arguments
 
 Keyword Arguments
 =================
+- `clock`: Clock for the underlying model. Defaults to `Clock(grid)`, a numeric clock starting at `time = 0`. Pass a `DateTime`-based clock to step the simulation in calendar time (e.g. when coupling).
+- `stop_time`: Stop time for the simulation. Defaults to `Inf` for numeric clocks, or `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks.
 - `Δt`: time step for the sea ice simulation
 - `ice_salinity`: salinity of the sea ice (psu)
 - `advection`: optional advection scheme for the sea ice model; if `nothing` (default), no advection
@@ -81,10 +84,10 @@ Keyword Arguments
                         `ConductiveFlux` with specified conductivity)
 - `snow_thermodynamics`: thermodynamics for the snow layer (default is a slab thermodynamics with
                          specified conductivity and prescribed temperature)
-- `clock`: clock for the sea ice model. Defaults to `nothing`, in which case the model builds its
-           own default clock; pass a `Clock` to control the time type (e.g. when coupling)
 """
 function sea_ice_simulation(grid, ocean=nothing;
+                            clock = Clock(grid),
+                            stop_time = clock.time isa Number ? Inf : Dates.DateTime(9999, 12, 31, 23, 59, 59),
                             Δt = 5minutes,
                             ice_salinity = 4, # psu
                             advection = nothing,
@@ -102,8 +105,7 @@ function sea_ice_simulation(grid, ocean=nothing;
                                                                  density=sea_ice_density),
                             conductivity = 2, # W m⁻¹ K⁻¹
                             internal_heat_flux = ConductiveFlux(; conductivity),
-                            snow_thermodynamics = default_snow_thermodynamics(grid),
-                            clock = nothing)
+                            snow_thermodynamics = default_snow_thermodynamics(grid))
 
     # Build consistent boundary conditions for the ice model:
     # - bottom -> flux boundary condition
@@ -132,11 +134,9 @@ function sea_ice_simulation(grid, ocean=nothing;
     top_heat_flux    = Field{Center, Center, Nothing}(grid)
     snowfall         = Field{Center, Center, Nothing}(grid)
 
-    # Only forward `clock` when supplied so the model keeps its own default otherwise.
-    clock_kw = isnothing(clock) ? NamedTuple() : (; clock)
-
     # Build the sea ice model
     sea_ice_model = SeaIceModel(grid;
+                                clock,
                                 ice_salinity,
                                 advection,
                                 tracers,
@@ -150,11 +150,10 @@ function sea_ice_simulation(grid, ocean=nothing;
                                 dynamics,
                                 timestepper,
                                 bottom_heat_flux,
-                                top_heat_flux,
-                                clock_kw...)
+                                top_heat_flux)
 
     verbose = false
-    sea_ice = Simulation(sea_ice_model; Δt, verbose)
+    sea_ice = Simulation(sea_ice_model; Δt, stop_time, verbose)
 
     return sea_ice
 end

--- a/src/SeaIces/sea_ice_simulation.jl
+++ b/src/SeaIces/sea_ice_simulation.jl
@@ -26,7 +26,7 @@ end
 """
     sea_ice_simulation(grid, ocean=nothing;
                        clock = Clock(grid),
-                       stop_time = clock.time isa Number ? Inf : Dates.DateTime(9999, 12, 31, 23, 59, 59),
+                       stop_time = default_stop_time(grid, clock),
                        Δt = 5minutes,
                        ice_salinity = 4, # psu
                        advection = nothing,
@@ -60,8 +60,11 @@ Arguments
 
 Keyword Arguments
 =================
-- `clock`: Clock for the underlying model. Defaults to `Clock(grid)`, a numeric clock starting at `time = 0`. Pass a `DateTime`-based clock to step the simulation in calendar time (e.g. when coupling).
-- `stop_time`: Stop time for the simulation. Defaults to `Inf` for numeric clocks, or `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks.
+- `clock`: Clock for the underlying model. Defaults to `Clock(grid)`, a numeric clock starting at `time = 0`. 
+  Pass a `DateTime`-based clock to step the simulation in calendar time (e.g. when coupling).
+- `stop_time`: Stop time for the simulation. Defaults to `Inf` for numeric clocks, or 
+  `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks. On Reactant architectures it defaults to `nothing`, since 
+  Reactant does not support `stop_time`.
 - `Δt`: time step for the sea ice simulation
 - `ice_salinity`: salinity of the sea ice (psu)
 - `advection`: optional advection scheme for the sea ice model; if `nothing` (default), no advection
@@ -87,7 +90,7 @@ Keyword Arguments
 """
 function sea_ice_simulation(grid, ocean=nothing;
                             clock = Clock(grid),
-                            stop_time = clock.time isa Number ? Inf : Dates.DateTime(9999, 12, 31, 23, 59, 59),
+                            stop_time = default_stop_time(grid, clock),
                             Δt = 5minutes,
                             ice_salinity = 4, # psu
                             advection = nothing,


### PR DESCRIPTION
This PR exposes `stop_time` as a kwarg in to the ocean and sea-ice simulation constructors. It defaults to `Inf` for numeric clocks or `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks. To determine which, the `clock` kwarg now defaults to `Clock(grid)`. 