### PR TITLE
Update Reactant tests for auto-initialized exchanger

### DIFF
--- a/test/test_reactant.jl
+++ b/test/test_reactant.jl
@@ -38,14 +38,13 @@ end
 
     coupled_model = OceanOnlyModel(ocean; atmosphere)
 
-    # Test that Reactant does _not_ initialize in the constructor for EarthSystemModel
+    # reconcile_state! initializes the exchanger regridder at construction (via @jit on Reactant).
     exchanger = coupled_model.interfaces.exchanger.atmosphere
     state     = exchanger.state
     regridder = exchanger.regridder
-    @test all(regridder.i .== 0)
-    @test all(regridder.j .== 0)
+    @test any(regridder.i .!= 0)
+    @test any(regridder.j .!= 0)
 
-    # This tests that update_state! is not called
-    ue = state.u
-    @test all(ue .== 0) # not initialized with Reactant
+    # update_state! populates the exchange state with the interpolated air temperature
+    @test any(state.T .!= 0)
 end


### PR DESCRIPTION
I forgot to make changes to the tests in #394 since the expected behavior is now flipped from before.
Sorry about that, it's my bad, this time I will make sure tests pass before I merge!
Thanks @dkytezab for pointing it out!

## Summary

Fixes the `test_reactant` failures introduced by #394.

#394 made `reconcile_state!` initialize the state exchanger at construction on the Reactant path (via `@jit`), so compiled and eager runs behave the same. But the existing assertions in `test/test_reactant.jl` encoded the *old* behavior — that Reactant does **not** initialize in the constructor — and so they now fail on `main`:

```
Error in testset Reactant extension tests:
Test Failed at test/test_reactant.jl:45
  Expression: all(regridder.i .== 0)
Test Failed at test/test_reactant.jl:46
  Expression: all(regridder.j .== 0)
```

## Changes

Flip the assertions to the intended post-#394 behavior:

- **Regridder is initialized**: `any(regridder.i .!= 0)` / `any(regridder.j .!= 0)` (the fractional indices are populated, previously asserted all-zero).
- **`update_state!` ran**: check the interpolated air temperature `state.T` is non-zero instead of `state.u`. `state.u` stays zero here because the idealized atmosphere leaves its velocities at the zero default, so it can't distinguish "not initialized" from "initialized with zero input"; the default air temperature is 293.15 K, so `state.T` is a meaningful signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)