### PR TITLE
Fix breeze_over_four_oceans docs example + add missing datasets to table

### DIFF
--- a/docs/src/Metadata/metadata_overview.md
+++ b/docs/src/Metadata/metadata_overview.md
@@ -183,6 +183,8 @@ NumericalEarth currently ships connectors for the following data products:
 | `ORCA1`            | `:bottom_height`, `:mesh_mask`                            | [ORCA1 mesh and bathymetry (Zenodo)](https://zenodo.org/records/4436658)                           |
 | `ORCA12`           | `:bottom_height`, `:mesh_mask`                            | [ORCA12 mesh and bathymetry (Zenodo)](https://zenodo.org/records/15495870)                         |
 | `GLORYSStatic`     | `:depth`                                                  | [Copernicus GLORYS static product](https://data.marine.copernicus.eu/product/GLOBAL_MULTIYEAR_PHY_001_030/description) |
+| `GLO30`            | `:bottom_height`                                          | [Copernicus DEM GLO-30 (Earth Data Hub)](https://earthdatahub.destine.eu/collections/copernicus-dem/datasets/GLO-30)   |
+| `GLO90`            | `:bottom_height`                                          | [Copernicus DEM GLO-90 (Earth Data Hub)](https://earthdatahub.destine.eu/collections/copernicus-dem/datasets/GLO-90)   |
 | **Ocean reanalysis and climatology** |                                     |                                                                                                     |
 | `ECCO2Monthly`     | [Supported variables](@ref dataset-ecco2monthly-vars)     | [ECCO2 documentation](https://ecco.jpl.nasa.gov/products/all/)                                     |
 | `ECCO2Daily`       | [Supported variables](@ref dataset-ecco2daily-vars)       | [ECCO2 documentation](https://ecco.jpl.nasa.gov/products/all/)                                     |
@@ -207,4 +209,5 @@ NumericalEarth currently ships connectors for the following data products:
 | `OSPapaFluxHourly` | air-sea fluxes, stresses, evaporation, precipitation, and skin temperature | [Ocean Station Papa flux dataset](https://www.pmel.noaa.gov/ocs/Papa) |
 | **Land** |                                                    |                                                                                                     |
 | `SoilGrids 2.0`     | Global profiles of soil texture, bulk density, and organic content in upper 2 meters  | [SoilGrids documentation](https://docs.isric.org/globaldata/soilgrids/)                                   |
+| `GloFASReanalysis` | `:river_discharge`                                       | [GloFAS-ERA5 river-discharge reanalysis (CDS)](https://cds.climate.copernicus.eu/datasets/cems-glofas-historical?tab=overview) |
 

--- a/examples/breeze_over_four_oceans.jl
+++ b/examples/breeze_over_four_oceans.jl
@@ -64,7 +64,7 @@ nh_ocean_atmos         = atmosphere_simulation(grid; potential_temperature=θᵃ
 # A background zonal wind `U₀` provides a nonzero wind speed for the
 # similarity theory flux computation.
 
-reference_state = slab_ocean_atmos.dynamics.reference_state
+reference_state = slab_ocean_atmos.model.dynamics.reference_state
 
 θᵢ(x, z) = reference_state.potential_temperature + 0.1 * randn() * (z < 500)
 set!(prescribed_ocean_atmos, θ=θᵢ, u=U₀)

--- a/examples/breeze_over_four_oceans.jl
+++ b/examples/breeze_over_four_oceans.jl
@@ -67,10 +67,10 @@ nh_ocean_atmos         = atmosphere_simulation(grid; potential_temperature=θᵃ
 reference_state = slab_ocean_atmos.model.dynamics.reference_state
 
 θᵢ(x, z) = reference_state.potential_temperature + 0.1 * randn() * (z < 500)
-set!(prescribed_ocean_atmos, θ=θᵢ, u=U₀)
-set!(slab_ocean_atmos,       θ=θᵢ, u=U₀)
-set!(full_ocean_atmos,       θ=θᵢ, u=U₀)
-set!(nh_ocean_atmos,         θ=θᵢ, u=U₀)
+set!(prescribed_ocean_atmos.model, θ=θᵢ, u=U₀)
+set!(slab_ocean_atmos.model,       θ=θᵢ, u=U₀)
+set!(full_ocean_atmos.model,       θ=θᵢ, u=U₀)
+set!(nh_ocean_atmos.model,         θ=θᵢ, u=U₀)
 
 # ## Prescribed ocean (constant SST)
 #
@@ -168,7 +168,7 @@ nh_sim         = Simulation(nh_model; Δt, stop_time)
 # ## Progress callbacks
 
 function prescribed_progress(sim)
-    atmos = sim.model.atmosphere
+    atmos = sim.model.atmosphere.model
     u, v, w = atmos.velocities
     umax = maximum(abs, u)
     wmax = maximum(abs, w)
@@ -179,7 +179,7 @@ function prescribed_progress(sim)
 end
 
 function slab_progress(sim)
-    atmos = sim.model.atmosphere
+    atmos = sim.model.atmosphere.model
     u, v, w = atmos.velocities
     umax = maximum(abs, u)
     wmax = maximum(abs, w)
@@ -193,7 +193,7 @@ function slab_progress(sim)
 end
 
 function full_progress(sim)
-    atmos = sim.model.atmosphere
+    atmos = sim.model.atmosphere.model
     u, v, w = atmos.velocities
     umax = maximum(abs, u)
     wmax = maximum(abs, w)
@@ -209,7 +209,7 @@ function full_progress(sim)
 end
 
 function nh_progress(sim)
-    atmos = sim.model.atmosphere
+    atmos = sim.model.atmosphere.model
     u, v, w = atmos.velocities
     umax = maximum(abs, u)
     wmax = maximum(abs, w)
@@ -236,16 +236,16 @@ add_callback!(nh_sim,         nh_progress,         IterationInterval(400))
 # * Full simulation: atmospheric θ, u, cloud water, and w, plus full-depth ocean temperature T.
 # * Nonhydrostatic simulation: atmospheric θ, u, cloud water, and w, plus full-depth ocean temperature T.
 
-u_p, v_p, w_p = prescribed_ocean_atmos.velocities
-θ_p = liquid_ice_potential_temperature(prescribed_ocean_atmos)
+u_p, v_p, w_p = prescribed_ocean_atmos.model.velocities
+θ_p = liquid_ice_potential_temperature(prescribed_ocean_atmos.model)
 
 prescribed_sim.output_writers[:atmos] = JLD2Writer(prescribed_model, (; θ=θ_p, u=u_p),
                                                    filename = "prescribed_ocean_atmos",
                                                    schedule = TimeInterval(1minute),
                                                    overwrite_existing = true)
 
-u_s, v_s, w_s = slab_ocean_atmos.velocities
-θ_s = liquid_ice_potential_temperature(slab_ocean_atmos)
+u_s, v_s, w_s = slab_ocean_atmos.model.velocities
+θ_s = liquid_ice_potential_temperature(slab_ocean_atmos.model)
 
 slab_sim.output_writers[:atmos] = JLD2Writer(slab_model, (; θ=θ_s, u=u_s),
                                              filename = "slab_ocean_atmos",
@@ -257,9 +257,9 @@ slab_sim.output_writers[:sst] = JLD2Writer(slab_model, (; SST=slab_ocean.tempera
                                            schedule = TimeInterval(1minute),
                                            overwrite_existing = true)
 
-u_f, v_f, w_f = full_ocean_atmos.velocities
-θ_f = liquid_ice_potential_temperature(full_ocean_atmos)
-qˡ_f = full_ocean_atmos.microphysical_fields.qˡ
+u_f, v_f, w_f = full_ocean_atmos.model.velocities
+θ_f = liquid_ice_potential_temperature(full_ocean_atmos.model)
+qˡ_f = full_ocean_atmos.model.microphysical_fields.qˡ
 
 full_sim.output_writers[:atmos] = JLD2Writer(full_model, (; θ=θ_f, u=u_f, qˡ=qˡ_f, w=w_f),
                                              filename = "full_ocean_atmos",
@@ -271,9 +271,9 @@ full_sim.output_writers[:ocean] = JLD2Writer(full_model, (; T=ocean.model.tracer
                                              schedule = TimeInterval(1minute),
                                              overwrite_existing = true)
 
-u_nh, v_nh, w_nh = nh_ocean_atmos.velocities
-θ_nh = liquid_ice_potential_temperature(nh_ocean_atmos)
-qˡ_nh = nh_ocean_atmos.microphysical_fields.qˡ
+u_nh, v_nh, w_nh = nh_ocean_atmos.model.velocities
+θ_nh = liquid_ice_potential_temperature(nh_ocean_atmos.model)
+qˡ_nh = nh_ocean_atmos.model.microphysical_fields.qˡ
 
 nh_sim.output_writers[:atmos] = JLD2Writer(nh_model, (; θ=θ_nh, u=u_nh, qˡ=qˡ_nh, w=w_nh),
                                            filename = "nh_ocean_atmos",


### PR DESCRIPTION
## Summary

Two related docs fixes. The dev docs have been frozen at a pre-ERA5 build for ~a month because every push-to-`main` docs **deploy** has failed silently.

### 1. Fix the deploy-blocking example

`examples/breeze_over_four_oceans.jl` accessed `slab_ocean_atmos.dynamics.reference_state`, but `atmosphere_simulation` returns a `Simulation` — `dynamics` lives on `.model` (`AnelasticDynamics`, verified to hold `reference_state`). The bad access threw a `FieldError` that aborted the whole docs build.

**Why PR CI never caught it:** the example has `build_always=false`, so per `docs/make.jl` + `docs.yml` it is executed **only** on push-to-`main`/tags or on PRs labelled `build all examples`. Ordinary PR CI skips it. So PRs stayed green while every `main` deploy died before publishing — freezing dev at the 2026-05-26 build (just before ERA5 was added in #298).

### 2. Add missing datasets to the supported-datasets table

`docs/src/Metadata/metadata_overview.md` never listed some shipped datasets:
- `GLO30`, `GLO90` (CopernicusDEM, `:bottom_height`) — *Bathymetry and static grids*
- `GloFASReanalysis` (`:river_discharge`) — *Land*

(ERA5 was already in the source table since #298; it simply never deployed.)

## Verification

This PR carries the **`build all examples`** label so CI runs `breeze_over_four_oceans` and confirms the fix on the full deploy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)