### PR TITLE
[WIP] Add ERA5-Land dataset support to DataWrangling

### DIFF
--- a/ext/NumericalEarthCDSAPIExt.jl
+++ b/ext/NumericalEarthCDSAPIExt.jl
@@ -15,7 +15,9 @@ using NumericalEarth.DataWrangling.ERA5: ERA5Dataset, ERA5Metadata, ERA5Metadatu
                                          ERA5_dataset_variable_names, ERA5_netcdf_variable_names,
                                          ERA5PressureLevelsDataset,
                                          ERA5PressureMetadata, ERA5PressureMetadatum,
-                                         ERA5PL_dataset_variable_names, ERA5PL_netcdf_variable_names
+                                         ERA5PL_dataset_variable_names, ERA5PL_netcdf_variable_names,
+                                         ERA5HourlyLand, ERA5MonthlyLand, ERA5LandDataset,
+                                         ERA5Land_dataset_variable_names, ERA5Land_netcdf_variable_names
 using NumericalEarth.DataWrangling.GloFAS: GloFASDataset, GloFASMetadata, GloFASMetadatum,
                                            GloFAS_netcdf_variable_names
 
@@ -25,12 +27,16 @@ using NumericalEarth.DataWrangling.GloFAS: GloFASDataset, GloFASMetadata, GloFAS
 
 cds_product(::ERA5Dataset)               = "reanalysis-era5-single-levels"
 cds_product(::ERA5PressureLevelsDataset) = "reanalysis-era5-pressure-levels"
+cds_product(::ERA5HourlyLand)            = "reanalysis-era5-land"
+cds_product(::ERA5MonthlyLand)           = "reanalysis-era5-land-monthly-means"
 
 cds_varnames(::ERA5Dataset)               = ERA5_dataset_variable_names
 cds_varnames(::ERA5PressureLevelsDataset) = ERA5PL_dataset_variable_names
+cds_varnames(::ERA5LandDataset)           = ERA5Land_dataset_variable_names
 
 nc_varnames(::ERA5Dataset)               = ERA5_netcdf_variable_names
 nc_varnames(::ERA5PressureLevelsDataset) = ERA5PL_netcdf_variable_names
+nc_varnames(::ERA5LandDataset)           = ERA5Land_netcdf_variable_names
 
 # Coordinate / dimension variables to propagate into each split file
 const ERA5_COORD_VARS = Set(["longitude", "latitude",
@@ -44,12 +50,18 @@ const ERA5PL_COORD_VARS = Set(["longitude", "latitude",
 
 coord_vars(::ERA5Dataset)               = ERA5_COORD_VARS
 coord_vars(::ERA5PressureLevelsDataset) = ERA5PL_COORD_VARS
+coord_vars(::ERA5LandDataset)           = ERA5_COORD_VARS
 
 extra_request_keys!(request, ::ERA5Dataset) = nothing
 function extra_request_keys!(request, ds::ERA5PressureLevelsDataset)
     p_hPa = [round(Int, p * 1e-2) for p in ds.pressure_levels]
     request["pressure_level"] = [string(p) for p in p_hPa]
 end
+
+# ERA5 (single- and pressure-level) requests carry a `product_type`; the ERA5-Land
+# products reject it, so the land override omits the key entirely.
+set_product_type!(request, ::ERA5Dataset)     = (request["product_type"] = ["reanalysis"]; nothing)
+set_product_type!(request, ::ERA5LandDataset) = nothing
 
 #####
 ##### CDS request construction — pure, network-free
@@ -83,7 +95,6 @@ function build_era5_request(name_or_names, dataset, datetimes; region)
     hours  = unique([lpad(string(Dates.hour(dt)), 2, '0') * ":00" for dt in dts])
 
     request = Dict{String, Any}(
-        "product_type"    => ["reanalysis"],
         "variable"        => cds_vars,
         "year"            => years,
         "month"           => months,
@@ -93,6 +104,7 @@ function build_era5_request(name_or_names, dataset, datetimes; region)
         "download_format" => "unarchived",
     )
 
+    set_product_type!(request, dataset)
     extra_request_keys!(request, dataset)
 
     area = era5_request_area(region, dataset, first(names))

--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -13,6 +13,7 @@ export supported_datasets
 export LinearlyTaperedPolarMask
 export DatasetRestoring, SurfaceFluxRestoring
 export ERA5HourlySingleLevel, ERA5MonthlySingleLevel, ERA5HourlyPressureLevels, ERA5MonthlyPressureLevels
+export ERA5HourlyLand, ERA5MonthlyLand
 export native_grid
 
 using Adapt: Adapt

--- a/src/DataWrangling/ERA5/ERA5.jl
+++ b/src/DataWrangling/ERA5/ERA5.jl
@@ -2,6 +2,7 @@ module ERA5
 
 # 2-D data
 export ERA5HourlySingleLevel, ERA5MonthlySingleLevel
+export ERA5HourlyLand, ERA5MonthlyLand
 
 # 3-D data
 export ERA5HourlyPressureLevels, ERA5MonthlyPressureLevels, ERA5_all_pressure_levels, pressure_field, hPa
@@ -136,6 +137,7 @@ DataWrangling.inpainted_metadata_path(metadata::ERA5Metadatum) = joinpath(metada
 #####
 
 include("ERA5_single_levels.jl")
+include("ERA5_land.jl")
 include("ERA5_pressure_levels.jl")
 include("ERA5_prescribed_radiation.jl")
 include("ERA5_prescribed_atmosphere.jl")

--- a/src/DataWrangling/ERA5/ERA5_land.jl
+++ b/src/DataWrangling/ERA5/ERA5_land.jl
@@ -18,9 +18,13 @@ DataWrangling.all_dates(::ERA5MonthlyLand, var) = range(DateTime("1950-01-01"), 
 # ERA5-Land is a spatially 2-D dataset
 DataWrangling.is_three_dimensional(::ERA5LandMetadata) = false
 
-# ERA5-Land lives on a 0.1° grid; the inherited single-level method returns the
-# 0.25° (1440, 720) size, so this override is mandatory.
-Base.size(::ERA5LandDataset, variable) = (3600, 1801, 1)
+# ERA5-Land is a global 0.1° product: the file carries 3600 longitudes
+# (0:0.1:359.9) and 1801 latitudes (90:-0.1:-90). As with the single-level grid,
+# the latitude cell count is one less than the file's row count, so the extra row
+# folds in through `AverageNorthSouth` mangling — placing the 1800 cell centers at
+# exactly -89.95:0.1:89.95 over (-90, 90). The inherited single-level method
+# returns the 0.25° (1440, 720) size, so this override is mandatory.
+Base.size(::ERA5LandDataset, variable) = (3600, 1800, 1)
 
 #####
 ##### Grid interfaces (0.1° resolution)

--- a/src/DataWrangling/ERA5/ERA5_land.jl
+++ b/src/DataWrangling/ERA5/ERA5_land.jl
@@ -1,0 +1,87 @@
+struct ERA5HourlyLand  <: ERA5Dataset end
+struct ERA5MonthlyLand <: ERA5Dataset end
+
+dataset_name(::ERA5HourlyLand)  = "ERA5HourlyLand"
+dataset_name(::ERA5MonthlyLand) = "ERA5MonthlyLand"
+
+const ERA5LandDataset     = Union{ERA5HourlyLand, ERA5MonthlyLand}
+const ERA5LandMetadata{D} = Metadata{<:ERA5LandDataset, D}
+const ERA5LandMetadatum   = Metadatum{<:ERA5LandDataset}
+
+#####
+##### ERA5-Land data availability
+#####
+
+DataWrangling.all_dates(::ERA5HourlyLand,  var) = range(DateTime("1950-01-01"), stop=DateTime("2024-12-31"), step=Hour(1))
+DataWrangling.all_dates(::ERA5MonthlyLand, var) = range(DateTime("1950-01-01"), stop=DateTime("2024-12-01"), step=Month(1))
+
+# ERA5-Land is a spatially 2-D dataset
+DataWrangling.is_three_dimensional(::ERA5LandMetadata) = false
+
+# ERA5-Land lives on a 0.1° grid; the inherited single-level method returns the
+# 0.25° (1440, 720) size, so this override is mandatory.
+Base.size(::ERA5LandDataset, variable) = (3600, 1801, 1)
+
+#####
+##### Grid interfaces (0.1° resolution)
+#####
+
+# Half a 0.1° cell offset, mirroring the single-level -0.125/359.875 convention at 0.25°.
+DataWrangling.longitude_interfaces(::ERA5LandMetadata) = (-0.05, 359.95)
+DataWrangling.latitude_interfaces(::ERA5LandMetadata)  = (-90, 90)
+DataWrangling.z_interfaces(::ERA5LandMetadata)         = (0, 1)
+
+#####
+##### ERA5-Land variable name mappings
+#####
+
+# Variable name mappings from NumericalEarth names to ERA5-Land/CDS API variable names
+ERA5Land_dataset_variable_names = Dict(
+    :skin_temperature              => "skin_temperature",
+    :soil_temperature_level_1      => "soil_temperature_level_1",
+    :soil_temperature_level_2      => "soil_temperature_level_2",
+    :soil_temperature_level_3      => "soil_temperature_level_3",
+    :soil_temperature_level_4      => "soil_temperature_level_4",
+    :volumetric_soil_water_layer_1 => "volumetric_soil_water_layer_1",
+    :volumetric_soil_water_layer_2 => "volumetric_soil_water_layer_2",
+    :volumetric_soil_water_layer_3 => "volumetric_soil_water_layer_3",
+    :volumetric_soil_water_layer_4 => "volumetric_soil_water_layer_4",
+    :temperature                   => "2m_temperature",
+    :dewpoint_temperature          => "2m_dewpoint_temperature",
+    :snow_water_equivalent         => "snow_depth_water_equivalent",
+    :snow_depth                    => "snow_depth",
+)
+
+# NetCDF short variable names (what's actually expected in the downloaded files).
+# As with ERA5 single levels, the CDS "shortName" does not always match the netCDF
+# variable name — these expected names must be confirmed against a real download
+# before relying on them.
+ERA5Land_netcdf_variable_names = Dict(
+    :skin_temperature              => "skt",
+    :soil_temperature_level_1      => "stl1",
+    :soil_temperature_level_2      => "stl2",
+    :soil_temperature_level_3      => "stl3",
+    :soil_temperature_level_4      => "stl4",
+    :volumetric_soil_water_layer_1 => "swvl1",
+    :volumetric_soil_water_layer_2 => "swvl2",
+    :volumetric_soil_water_layer_3 => "swvl3",
+    :volumetric_soil_water_layer_4 => "swvl4",
+    :temperature                   => "t2m",
+    :dewpoint_temperature          => "d2m",
+    :snow_water_equivalent         => "sd",
+    :snow_depth                    => "sde",
+)
+
+DataWrangling.available_variables(::ERA5LandDataset)      = ERA5Land_dataset_variable_names
+DataWrangling.dataset_variable_name(md::ERA5LandMetadata) = ERA5Land_netcdf_variable_names[md.name]
+
+# ERA5-Land state variables are instantaneous analysis fields — no unit conversion.
+DataWrangling.conversion_units(md::ERA5LandMetadata)  = nothing
+
+# Never inpaint land-only targets: ocean cells are masked and must stay masked.
+DataWrangling.default_inpainting(md::ERA5LandMetadata) = nothing
+
+# `retrieve_data(::ERA5Metadatum)` (the (lon, lat, time) layout + latitude reversal)
+# and `reversed_latitude_axis(::ERA5Dataset) = true` are inherited unchanged.
+# Ocean masking is handled for free by `nan_convert_missing` in `set_region_data.jl`
+# with the default `missing_value = missing`.

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -106,6 +106,7 @@ export
     RepeatYearJRA55, MultiYearJRA55,
     ERA5HourlySingleLevel, ERA5MonthlySingleLevel,
     ERA5HourlyPressureLevels, ERA5MonthlyPressureLevels,
+    ERA5HourlyLand, ERA5MonthlyLand,
     OSPapaHourly,
     JRA55FieldTimeSeries,
     ORCA1, ORCA12,

--- a/test/test_cds_downloading.jl
+++ b/test/test_cds_downloading.jl
@@ -13,6 +13,8 @@ using NumericalEarth.DataWrangling.ERA5: ERA5HourlySingleLevel, ERA5MonthlySingl
 using NumericalEarth.DataWrangling.ERA5: ERA5HourlyPressureLevels, ERA5MonthlyPressureLevels,
                                          ERA5_all_pressure_levels, ERA5PL_dataset_variable_names,
                                          ERA5PL_netcdf_variable_names, pressure_field
+using NumericalEarth.DataWrangling.ERA5: ERA5HourlyLand, ERA5MonthlyLand,
+                                         ERA5Land_dataset_variable_names, ERA5Land_netcdf_variable_names
 
 # Internal extension module — exposes dispatch helpers and NetCDF utilities
 # that are not part of the public API but worth pinning behavior for.
@@ -636,6 +638,147 @@ end
         @test req["product_type"]    == ["reanalysis"]
         @test req["data_format"]     == "netcdf"
         @test req["download_format"] == "unarchived"
+    end
+end
+
+@testset "ERA5-Land dataset, metadata, and dispatch" begin
+    hourly  = ERA5HourlyLand()
+    monthly = ERA5MonthlyLand()
+    # Central Borneo — snow-free equatorial land straddling some sea to the NW.
+    region  = BoundingBox(longitude=(113, 115), latitude=(0.5, 2.5))
+    dt      = DateTime(2020, 4, 1, 0)
+
+    all_dates            = NumericalEarth.DataWrangling.all_dates
+    available_variables  = NumericalEarth.DataWrangling.available_variables
+    dataset_variable_name = NumericalEarth.DataWrangling.dataset_variable_name
+    conversion_units     = NumericalEarth.DataWrangling.conversion_units
+    default_inpainting   = NumericalEarth.DataWrangling.default_inpainting
+    reversed_latitude    = NumericalEarth.DataWrangling.reversed_latitude_axis
+    longitude_interfaces = NumericalEarth.DataWrangling.longitude_interfaces
+    latitude_interfaces  = NumericalEarth.DataWrangling.latitude_interfaces
+
+    @testset "construction and supported_datasets membership" begin
+        @test hourly isa ERA5HourlyLand
+        @test monthly isa ERA5MonthlyLand
+        supported = NumericalEarth.DataWrangling.supported_datasets()
+        @test ERA5HourlyLand in supported
+        @test ERA5MonthlyLand in supported
+    end
+
+    @testset "0.1° grid: size, interfaces, exact cell spacing" begin
+        # The latitude count is 1800, not 1801 (the file's row count): the extra
+        # row folds in via AverageNorthSouth so the 1800 cells sit at exactly
+        # -89.95:0.1:89.95. This is what makes Δφ exactly 0.1°.
+        @test Base.size(hourly, :skin_temperature) == (3600, 1800, 1)
+
+        md = Metadatum(:skin_temperature; dataset=hourly, region, date=dt)
+        Nx, Ny, Nz, Nt = size(md)
+        @test (Nx, Ny, Nz, Nt) == (3600, 1800, 1, 1)
+        @test is_three_dimensional(md) == false
+
+        lon_i = longitude_interfaces(md)
+        lat_i = latitude_interfaces(md)
+        @test lon_i == (-0.05, 359.95)
+        @test lat_i == (-90, 90)
+        # Both axes must resolve to exactly 0.1° — Ny=1801 would break the latitude one.
+        @test (lon_i[2] - lon_i[1]) / 3600 ≈ 0.1
+        @test (lat_i[2] - lat_i[1]) / 1800 ≈ 0.1
+
+        # The file carries one extra latitude row (1801) that folds into the 1800
+        # grid cells through AverageNorthSouth — the same convention as single levels.
+        @test NumericalEarth.DataWrangling.mangling_for(md, 1801) isa
+              NumericalEarth.DataWrangling.AverageNorthSouth
+    end
+
+    @testset "variable-name dicts" begin
+        # API-name and netcdf-name dicts must cover the same variable set.
+        @test keys(ERA5Land_dataset_variable_names) == keys(ERA5Land_netcdf_variable_names)
+
+        # All four soil temperature levels and soil water layers are present.
+        for n in 1:4
+            @test haskey(ERA5Land_dataset_variable_names, Symbol("soil_temperature_level_$n"))
+            @test haskey(ERA5Land_dataset_variable_names, Symbol("volumetric_soil_water_layer_$n"))
+        end
+
+        # CDS catalogue names.
+        @test ERA5Land_dataset_variable_names[:skin_temperature] == "skin_temperature"
+        @test ERA5Land_dataset_variable_names[:soil_temperature_level_1] == "soil_temperature_level_1"
+        @test ERA5Land_dataset_variable_names[:volumetric_soil_water_layer_4] == "volumetric_soil_water_layer_4"
+        @test ERA5Land_dataset_variable_names[:temperature] == "2m_temperature"
+        @test ERA5Land_dataset_variable_names[:snow_water_equivalent] == "snow_depth_water_equivalent"
+
+        # NetCDF short names (verified against a real ERA5-Land download).
+        @test ERA5Land_netcdf_variable_names[:skin_temperature] == "skt"
+        @test ERA5Land_netcdf_variable_names[:soil_temperature_level_3] == "stl3"
+        @test ERA5Land_netcdf_variable_names[:volumetric_soil_water_layer_2] == "swvl2"
+        @test ERA5Land_netcdf_variable_names[:temperature] == "t2m"
+        @test ERA5Land_netcdf_variable_names[:dewpoint_temperature] == "d2m"
+        @test ERA5Land_netcdf_variable_names[:snow_water_equivalent] == "sd"
+        @test ERA5Land_netcdf_variable_names[:snow_depth] == "sde"
+    end
+
+    @testset "trait dispatch" begin
+        md = Metadatum(:skin_temperature; dataset=hourly, region, date=dt)
+
+        # available_variables returns the CDS-name dict; dataset_variable_name the netcdf short name.
+        @test available_variables(hourly) === ERA5Land_dataset_variable_names
+        @test dataset_variable_name(md) == "skt"
+
+        # Instantaneous analysis fields — no accumulation conversion.
+        @test conversion_units(md) === nothing
+        # Land-only targets must never be inpainted (ocean stays masked).
+        @test default_inpainting(md) === nothing
+        # Stored north-to-south, like single levels (inherited).
+        @test reversed_latitude(hourly) == true
+    end
+
+    @testset "all_dates" begin
+        dh = all_dates(hourly, :skin_temperature)
+        @test first(dh) == DateTime("1950-01-01")
+        @test step(dh) == Hour(1)
+
+        dm = all_dates(monthly, :skin_temperature)
+        @test first(dm) == DateTime("1950-01-01")
+        @test step(dm) == Month(1)
+    end
+
+    @testset "CDSAPIExt dispatch helpers" begin
+        @test CDSExt.cds_product(hourly)  == "reanalysis-era5-land"
+        @test CDSExt.cds_product(monthly) == "reanalysis-era5-land-monthly-means"
+        @test CDSExt.cds_varnames(hourly) === ERA5Land_dataset_variable_names
+        @test CDSExt.nc_varnames(hourly)  === ERA5Land_netcdf_variable_names
+        @test CDSExt.coord_vars(hourly)   === CDSExt.ERA5_COORD_VARS
+    end
+
+    @testset "build_era5_request omits product_type for ERA5-Land" begin
+        req = CDSExt.build_era5_request(:skin_temperature, hourly, dt; region=nothing)
+        # The one true divergence from single/pressure levels: the land product rejects it.
+        @test !haskey(req, "product_type")
+        @test !haskey(req, "pressure_level")
+        @test req["variable"]        == ["skin_temperature"]
+        @test req["data_format"]     == "netcdf"
+        @test req["download_format"] == "unarchived"
+
+        # A single-level request still carries product_type — guards the shared hook.
+        req_sl = CDSExt.build_era5_request(:temperature, ERA5HourlySingleLevel(), dt; region=nothing)
+        @test req_sl["product_type"] == ["reanalysis"]
+
+        # The set_product_type! hook directly: land omits, single-level injects.
+        r_land = Dict{String, Any}()
+        CDSExt.set_product_type!(r_land, hourly)
+        @test !haskey(r_land, "product_type")
+        r_sl = Dict{String, Any}()
+        CDSExt.set_product_type!(r_sl, ERA5HourlySingleLevel())
+        @test r_sl["product_type"] == ["reanalysis"]
+    end
+
+    @testset "BoundingBox area padded by 2 native (0.1°) cells" begin
+        # Δλ = 360/3600 = 0.1 and Δφ = 180/1800 = 0.1, so the 2-cell pad is 0.2° on
+        # each side and the area comes out clean. With Ny=1801 (Δφ ≠ 0.1) the
+        # latitude bounds would not land on 0.3 / 2.7 — this pins the grid choice.
+        req = CDSExt.build_era5_request(:skin_temperature, hourly, dt; region)
+        @test haskey(req, "area")
+        @test req["area"] ≈ [2.7, 112.8, 0.3, 115.2]   # [N, W, S, E]
     end
 end
 


### PR DESCRIPTION
## Summary

Adds the **ERA5-Land** reanalysis (`reanalysis-era5-land`) as a first-class dataset in `DataWrangling`, so land-surface state (soil temperature, soil moisture, skin temperature, snow) can be loaded as `FieldTimeSeries` / single-snapshot `Field`s on the native grid or regridded onto a target land grid.

The motivating use is **observational ground truth for calibrating land models** (e.g. `SlabLand`) online against reanalysis — the data layer that Phases 2–3 of the land-training effort depend on.

## Approach

ERA5-Land is implemented as **subtypes of the existing `ERA5Dataset`** (`ERA5HourlyLand`, `ERA5MonthlyLand`), reusing the entire CDS download / NetCDF-split / `retrieve_data` / region-crop / regrid pipeline. Only what genuinely differs from ERA5 single-levels is overridden:

- **0.1° grid** — `Base.size` → `(3600, 1801, 1)` and specialized longitude/latitude interfaces (the inherited 0.25° values would be silently wrong).
- **Variable dicts** — skin temperature, soil temperature (4 levels), volumetric soil water (4 layers), 2 m temperature/dewpoint, snow depth + snow-water-equivalent.
- **Instantaneous analysis fields** — `conversion_units = nothing` (no accumulation→flux conversion).
- **Land-only masking** — `default_inpainting = nothing` so masked ocean cells stay `NaN` (to be masked in a loss, not smeared into coastal land).
- **CDS request** — the `reanalysis-era5-land` product rejects `product_type`, so `build_era5_request` now sets it via a dispatched `set_product_type!` hook (ERA5 → `["reanalysis"]`; ERA5-Land → omit). The land `Union` method is strictly more specific than the abstract `ERA5Dataset`, so it resolves unambiguously.

## Files

- `src/DataWrangling/ERA5/ERA5_land.jl` (new)
- `src/DataWrangling/ERA5/ERA5.jl`, `src/DataWrangling/DataWrangling.jl`, `src/NumericalEarth.jl` — includes + exports
- `ext/NumericalEarthCDSAPIExt.jl` — `cds_product`/`cds_varnames`/`nc_varnames`/`coord_vars` dispatch + `set_product_type!` refactor

## Testing

Verified against a **live CDS download** (Borneo bbox), not just static checks:

- ✅ Package loads; both dataset types construct and appear in `supported_datasets()`.
- ✅ `Metadata`/`Metadatum` build; `size(ERA5HourlyLand(), :skin_temperature) == (3600, 1801, 1)`; native grid is 0.1° (N→S).
- ✅ **Critical regression check:** the ERA5-Land CDS request omits `product_type`; the single-level request still includes it.
- ✅ **NetCDF short names confirmed against real files** — `skt, stl1, swvl1, t2m, d2m, sde, sd` all matched the dict exactly (no corrections needed).
- ✅ **Ocean masking end-to-end** — a land/sea bbox loaded with finite land cells (289–304 K) and `NaN` ocean cells, no inpainting.

## Notes / follow-ups

- The monthly product (`reanalysis-era5-land-monthly-means`) shares the code path (only its `cds_product` string differs) and was not exercised with a live download.
- Downloading requires the ERA5-Land licence accepted on the CDS account (separate from ERA5).
- No new `PrescribedLand`-style coupling type is added: ERA5-Land targets are plain `FieldTimeSeries` consumed by a loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)