### PR TITLE
Add DerivedDatasetBackend for lazily computed FieldTimeSeries

### DIFF
--- a/src/DataWrangling/ERA5/ERA5_prescribed_atmosphere.jl
+++ b/src/DataWrangling/ERA5/ERA5_prescribed_atmosphere.jl
@@ -1,7 +1,7 @@
 using ...Atmospheres: PrescribedAtmosphere, PrescribedPrecipitationFlux,
                       AtmosphereThermodynamicsParameters
 using ...EarthSystemModels.InterfaceComputations: saturation_specific_humidity
-using Oceananigans.AbstractOperations: KernelFunctionOperation
+using ..DataWrangling: DerivedDatasetBackend
 using Oceananigans.Architectures: on_architecture
 using Oceananigans.Fields: CenterField, interior
 using Thermodynamics: Liquid
@@ -83,12 +83,14 @@ function ERA5PrescribedAtmosphere(architecture = CPU();
                                                 thermodynamics_parameters
     phase = Liquid()
 
-    qᵛ = FieldTimeSeries{Center, Center, Nothing}(grid, times)
-    for n in eachindex(times)
-        q = KernelFunctionOperation{Center, Center, Nothing}(specific_humidity_from_dewpoint,
-                                                             grid, Tᵈ[n], p[n], ℂ, phase)
-        set!(qᵛ[n], q)
-    end
+    # Specific humidity has no native ERA5 single-level variable, so it is derived from
+    # dewpoint and pressure — lazily, window by window, so the derived series stays as
+    # partly-in-memory as its sources rather than materializing the whole date range.
+    humidity_backend = DerivedDatasetBackend(min(time_indices_in_memory, length(times)),
+                                             specific_humidity_from_dewpoint,
+                                             (Tᵈ, p), (ℂ, phase))
+    qᵛ = FieldTimeSeries{Center, Center, Nothing}(grid, times; backend = humidity_backend, time_indexing)
+    set!(qᵛ)
 
     precipitation_flux = PrescribedPrecipitationFlux(; rain)
 

--- a/src/DataWrangling/ERA5/ERA5_prescribed_atmosphere.jl
+++ b/src/DataWrangling/ERA5/ERA5_prescribed_atmosphere.jl
@@ -1,7 +1,7 @@
 using ...Atmospheres: PrescribedAtmosphere, PrescribedPrecipitationFlux,
                       AtmosphereThermodynamicsParameters
 using ...EarthSystemModels.InterfaceComputations: saturation_specific_humidity
-using ..DataWrangling: DerivedDatasetBackend
+using ..DataWrangling: DerivedInMemoryBackend
 using Oceananigans.Architectures: on_architecture
 using Oceananigans.Fields: CenterField, interior
 using Thermodynamics: Liquid
@@ -86,9 +86,9 @@ function ERA5PrescribedAtmosphere(architecture = CPU();
     # Specific humidity has no native ERA5 single-level variable, so it is derived from
     # dewpoint and pressure — lazily, window by window, so the derived series stays as
     # partly-in-memory as its sources rather than materializing the whole date range.
-    humidity_backend = DerivedDatasetBackend(min(time_indices_in_memory, length(times)),
-                                             specific_humidity_from_dewpoint,
-                                             (Tᵈ, p), (ℂ, phase))
+    humidity_backend = DerivedInMemoryBackend(min(time_indices_in_memory, length(times)),
+                                              specific_humidity_from_dewpoint,
+                                              (Tᵈ, p), (ℂ, phase))
     qᵛ = FieldTimeSeries{Center, Center, Nothing}(grid, times; backend = humidity_backend, time_indexing)
     set!(qᵛ)
 

--- a/src/DataWrangling/dataset_backend.jl
+++ b/src/DataWrangling/dataset_backend.jl
@@ -1,3 +1,5 @@
+using Oceananigans: location
+using Oceananigans.AbstractOperations: KernelFunctionOperation
 using Oceananigans.OutputReaders: Cyclical, AbstractInMemoryBackend, FlavorOfFTS, time_indices
 
 import Oceananigans.OutputReaders: new_backend
@@ -92,6 +94,69 @@ function set!(fts::DatasetFieldTimeSeries, backend=fts.backend)
     for t in time_indices(fts)
         metadatum = @inbounds backend.metadata[t]
         set!(fts[t], metadatum; inpainting, cache_inpainted_data=cache_data)
+    end
+
+    fill_halo_regions!(fts)
+
+    return nothing
+end
+
+"""
+    DerivedDatasetBackend{F, S, P} <: AbstractInMemoryBackend{Int}
+
+In-memory backend for a `FieldTimeSeries` whose time slices are *computed* from
+other `FieldTimeSeries` (typically dataset-backed, partly-in-memory ones) rather
+than read from disk. The backend carries
+
+- `start`, `length`: sliding-window extents, as for [`DatasetBackend`](@ref)
+- `func`: a kernel function `func(i, j, k, grid, source_slices..., parameters...)`
+- `sources`: tuple of source `FieldTimeSeries`, defined on the same grid and times
+  as the derived series; indexing a slice outside a source's resident window
+  repositions that window lazily
+- `parameters`: extra arguments appended to the kernel function call
+
+`set!` fills each resident slice by evaluating a `KernelFunctionOperation` of
+`func` over the corresponding source slices, so only the resident window is ever
+computed — the derived series is exactly as lazy as its sources.
+"""
+struct DerivedDatasetBackend{F, S, P} <: AbstractInMemoryBackend{Int}
+    start :: Int
+    length :: Int
+    func :: F
+    sources :: S
+    parameters :: P
+end
+
+"""
+    DerivedDatasetBackend(length, func, sources, parameters=())
+
+Construct a `DerivedDatasetBackend` holding `length` in-memory time indices starting
+at `1`, whose slice `n` is computed as `func(i, j, k, grid, map(s -> s[n], sources)...,
+parameters...)`.
+"""
+DerivedDatasetBackend(length::Int, func, sources, parameters=()) =
+    DerivedDatasetBackend(1, length, func, sources, parameters)
+
+# Only the window extents are meaningful device-side; drop the host-only closure state.
+Adapt.adapt_structure(to, b::DerivedDatasetBackend) =
+    DerivedDatasetBackend(b.start, b.length, nothing, nothing, nothing)
+
+Base.length(backend::DerivedDatasetBackend)  = backend.length
+Base.summary(backend::DerivedDatasetBackend) = string("DerivedDatasetBackend(", backend.start, ", ", backend.length, ")")
+
+new_backend(b::DerivedDatasetBackend, start, length) =
+    DerivedDatasetBackend(start, length, b.func, b.sources, b.parameters)
+
+const DerivedFieldTimeSeries = FlavorOfFTS{<:Any, <:Any, <:Any, <:Any, <:DerivedDatasetBackend}
+
+function set!(fts::DerivedFieldTimeSeries, backend=fts.backend)
+    LX, LY, LZ = location(fts)
+
+    for t in time_indices(fts)
+        slices  = map(source -> source[t], backend.sources)
+        derived = KernelFunctionOperation{LX, LY, LZ}(backend.func, fts.grid,
+                                                      slices..., backend.parameters...)
+        set!(fts[t], derived)
     end
 
     fill_halo_regions!(fts)

--- a/src/DataWrangling/dataset_backend.jl
+++ b/src/DataWrangling/dataset_backend.jl
@@ -102,7 +102,7 @@ function set!(fts::DatasetFieldTimeSeries, backend=fts.backend)
 end
 
 """
-    DerivedDatasetBackend{F, S, P} <: AbstractInMemoryBackend{Int}
+    DerivedInMemoryBackend{F, S, P} <: AbstractInMemoryBackend{Int}
 
 In-memory backend for a `FieldTimeSeries` whose time slices are *computed* from
 other `FieldTimeSeries` (typically dataset-backed, partly-in-memory ones) rather
@@ -119,7 +119,7 @@ than read from disk. The backend carries
 `func` over the corresponding source slices, so only the resident window is ever
 computed — the derived series is exactly as lazy as its sources.
 """
-struct DerivedDatasetBackend{F, S, P} <: AbstractInMemoryBackend{Int}
+struct DerivedInMemoryBackend{F, S, P} <: AbstractInMemoryBackend{Int}
     start :: Int
     length :: Int
     func :: F
@@ -128,26 +128,26 @@ struct DerivedDatasetBackend{F, S, P} <: AbstractInMemoryBackend{Int}
 end
 
 """
-    DerivedDatasetBackend(length, func, sources, parameters=())
+    DerivedInMemoryBackend(length, func, sources, parameters=())
 
-Construct a `DerivedDatasetBackend` holding `length` in-memory time indices starting
+Construct a `DerivedInMemoryBackend` holding `length` in-memory time indices starting
 at `1`, whose slice `n` is computed as `func(i, j, k, grid, map(s -> s[n], sources)...,
 parameters...)`.
 """
-DerivedDatasetBackend(length::Int, func, sources, parameters=()) =
-    DerivedDatasetBackend(1, length, func, sources, parameters)
+DerivedInMemoryBackend(length::Int, func, sources, parameters=()) =
+    DerivedInMemoryBackend(1, length, func, sources, parameters)
 
 # Only the window extents are meaningful device-side; drop the host-only closure state.
-Adapt.adapt_structure(to, b::DerivedDatasetBackend) =
-    DerivedDatasetBackend(b.start, b.length, nothing, nothing, nothing)
+Adapt.adapt_structure(to, b::DerivedInMemoryBackend) =
+    DerivedInMemoryBackend(b.start, b.length, nothing, nothing, nothing)
 
-Base.length(backend::DerivedDatasetBackend)  = backend.length
-Base.summary(backend::DerivedDatasetBackend) = string("DerivedDatasetBackend(", backend.start, ", ", backend.length, ")")
+Base.length(backend::DerivedInMemoryBackend)  = backend.length
+Base.summary(backend::DerivedInMemoryBackend) = string("DerivedInMemoryBackend(", backend.start, ", ", backend.length, ")")
 
-new_backend(b::DerivedDatasetBackend, start, length) =
-    DerivedDatasetBackend(start, length, b.func, b.sources, b.parameters)
+new_backend(b::DerivedInMemoryBackend, start, length) =
+    DerivedInMemoryBackend(start, length, b.func, b.sources, b.parameters)
 
-const DerivedFieldTimeSeries = FlavorOfFTS{<:Any, <:Any, <:Any, <:Any, <:DerivedDatasetBackend}
+const DerivedFieldTimeSeries = FlavorOfFTS{<:Any, <:Any, <:Any, <:Any, <:DerivedInMemoryBackend}
 
 function set!(fts::DerivedFieldTimeSeries, backend=fts.backend)
     LX, LY, LZ = location(fts)

--- a/test/test_derived_dataset_backend.jl
+++ b/test/test_derived_dataset_backend.jl
@@ -1,0 +1,52 @@
+include("runtests_setup.jl")
+
+using NumericalEarth.DataWrangling: DerivedDatasetBackend
+using Oceananigans.OutputReaders: Cyclical, FieldTimeSeries, time_indices
+
+@inline product_of_sources(i, j, k, grid, a, b) = @inbounds a[i, j, k] * b[i, j, k]
+@inline scaled_source(i, j, k, grid, a, scale) = @inbounds scale * a[i, j, k]
+
+@testset "DerivedDatasetBackend" begin
+    for arch in test_architectures
+        grid = LatitudeLongitudeGrid(arch; size = (4, 4), latitude = (0, 1), longitude = (0, 1),
+                                     topology = (Bounded, Bounded, Flat))
+        times = 0.0:1.0:9.0
+        Nt = length(times)
+
+        a = FieldTimeSeries{Center, Center, Nothing}(grid, times)
+        b = FieldTimeSeries{Center, Center, Nothing}(grid, times)
+        for n in 1:Nt
+            set!(a[n], (λ, φ) -> n + λ)
+            set!(b[n], (λ, φ) -> 10n + φ)
+        end
+
+        window = 3
+        backend = DerivedDatasetBackend(window, product_of_sources, (a, b))
+        derived = FieldTimeSeries{Center, Center, Nothing}(grid, times; backend,
+                                                           time_indexing = Cyclical())
+        set!(derived)
+
+        @test length(derived.backend) == window
+        @test collect(time_indices(derived)) == [1, 2, 3]
+
+        # Slide the window forward, jump backward, and wrap past the last index:
+        # every access must match the directly computed product, and the number
+        # of resident slices must never exceed the window.
+        for n in (1, 2, 3, 7, 8, 4, 1, Nt)
+            expected = Array(interior(a[n])) .* Array(interior(b[n]))
+            @test Array(interior(derived[n])) ≈ expected
+            @test length(time_indices(derived)) == window
+        end
+
+        # Parameters are appended to the kernel function call.
+        scale = 2.5
+        scaled = FieldTimeSeries{Center, Center, Nothing}(grid, times;
+                     backend = DerivedDatasetBackend(window, scaled_source, (a,), (scale,)),
+                     time_indexing = Cyclical())
+        set!(scaled)
+
+        for n in (2, 6, Nt)
+            @test Array(interior(scaled[n])) ≈ scale .* Array(interior(a[n]))
+        end
+    end
+end

--- a/test/test_derived_in_memory_backend.jl
+++ b/test/test_derived_in_memory_backend.jl
@@ -1,12 +1,12 @@
 include("runtests_setup.jl")
 
-using NumericalEarth.DataWrangling: DerivedDatasetBackend
+using NumericalEarth.DataWrangling: DerivedInMemoryBackend
 using Oceananigans.OutputReaders: Cyclical, FieldTimeSeries, time_indices
 
 @inline product_of_sources(i, j, k, grid, a, b) = @inbounds a[i, j, k] * b[i, j, k]
 @inline scaled_source(i, j, k, grid, a, scale) = @inbounds scale * a[i, j, k]
 
-@testset "DerivedDatasetBackend" begin
+@testset "DerivedInMemoryBackend" begin
     for arch in test_architectures
         grid = LatitudeLongitudeGrid(arch; size = (4, 4), latitude = (0, 1), longitude = (0, 1),
                                      topology = (Bounded, Bounded, Flat))
@@ -21,7 +21,7 @@ using Oceananigans.OutputReaders: Cyclical, FieldTimeSeries, time_indices
         end
 
         window = 3
-        backend = DerivedDatasetBackend(window, product_of_sources, (a, b))
+        backend = DerivedInMemoryBackend(window, product_of_sources, (a, b))
         derived = FieldTimeSeries{Center, Center, Nothing}(grid, times; backend,
                                                            time_indexing = Cyclical())
         set!(derived)
@@ -41,7 +41,7 @@ using Oceananigans.OutputReaders: Cyclical, FieldTimeSeries, time_indices
         # Parameters are appended to the kernel function call.
         scale = 2.5
         scaled = FieldTimeSeries{Center, Center, Nothing}(grid, times;
-                     backend = DerivedDatasetBackend(window, scaled_source, (a,), (scale,)),
+                     backend = DerivedInMemoryBackend(window, scaled_source, (a,), (scale,)),
                      time_indexing = Cyclical())
         set!(scaled)
 


### PR DESCRIPTION
## Problem

`ERA5PrescribedAtmosphere` keeps five of its six variables behind a partly-in-memory `DatasetBackend` (only `time_indices_in_memory` slices resident), but specific humidity — which has no native ERA5 single-level variable and must be derived from dewpoint and pressure — was materialized **eagerly over the entire date range** into a fully in-memory `FieldTimeSeries` at construction. Two consequences:

- memory for the humidity series scales with forcing length, defeating the laziness of everything else (the ceiling that matters for long calibration runs against disk-backed reanalysis, cf. the Path A / streamed-forcing workstream);
- the construction-time sweep indexes `Tᵈ[n]`, `p[n]` for every `n`, repeatedly reloading the sources' small windows from disk.

## Design

`DerivedDatasetBackend` is a sibling of `DatasetBackend` living next to it in `dataset_backend.jl`. It carries a kernel function, a tuple of source `FieldTimeSeries`, and extra parameters; its `set!` fills each resident slice by evaluating a `KernelFunctionOperation` of

```
func(i, j, k, grid, source_slices..., parameters...)
```

over the corresponding source slices. Indexing a source slice outside its resident window repositions that window lazily, so the derived series is exactly as lazy as its sources. The generic `update_field_time_series!` machinery handles window sliding (forward, backward, and `Cyclical` wrap) unchanged, and the backend `Adapt`s by dropping its host-only closure state, mirroring `DatasetBackend`.

`ERA5PrescribedAtmosphere` then builds `qᵛ` in one line with the same `time_indices_in_memory` as the other variables. **No API change** — the derived series behaves like any partly-in-memory `FieldTimeSeries`, including in-loop `fts[Time(t)]` sampling by the coupled model.

The backend is generic on purpose: any derived forcing variable (wind-speed magnitude, unit conversions with multiple inputs, JRA55-style combinations) can use it.

## Validation

- `test/test_derived_dataset_backend.jl` (new, auto-discovered, no downloads): synthetic two-source product and a parameterized single-source scaling on a small grid; verifies values against direct computation while sliding the window forward, jumping backward, and wrapping past the last index, and asserts the resident-slice count never exceeds the window. Passes locally (21/21).
- Integration check against cached ERA5 (Apr 1–6 2020, 1°×1° box): the constructed atmosphere's humidity backend is `DerivedDatasetBackend(1, 8)` over 133 hourly slices (buffer holds 8 slices, not 133), and every lazily computed slice — including backward window jumps — matches the direct `specific_humidity_from_dewpoint` kernel evaluation bit-for-bit.

## Notes for review

- `min(time_indices_in_memory, length(times))` mirrors the clamp the `Metadata`-based constructor applies to the source series.
- The stale `KernelFunctionOperation` import in `ERA5_prescribed_atmosphere.jl` was removed (the ExplicitImports QA test would flag it); the backend file imports it instead.
- Sources are required to share the derived series' grid and times; this is documented rather than checked, matching the trust level of the surrounding code. Happy to add a constructor assertion if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)