### PR TITLE
Add ESA WorldCover land-cover dataset (categorical aggregation)

### DIFF
--- a/ext/NumericalEarthArchGDALExt.jl
+++ b/ext/NumericalEarthArchGDALExt.jl
@@ -4,6 +4,8 @@ using ArchGDAL: ArchGDAL
 using NCDatasets: NCDataset, defDim, defVar
 using NumericalEarth: NumericalEarth
 
+const ESAWorldCover = NumericalEarth.DataWrangling.ESAWorldCover
+
 function NumericalEarth.DataWrangling.IBCAO.reproject_ibcao_to_netcdf(tiff_path, nc_path)
     ArchGDAL.read(tiff_path) do src
         # Warp from EPSG:3996 (Polar Stereographic) to EPSG:4326 (WGS84)
@@ -39,6 +41,143 @@ function NumericalEarth.DataWrangling.IBCAO.reproject_ibcao_to_netcdf(tiff_path,
                 lat_var[:] = range(64 + 0.005, 90 - 0.005; length=Ny)
                 z_var[:, :] = data
             end
+        end
+    end
+
+    return nothing
+end
+
+#####
+##### ESA WorldCover: anonymous COG tiles → regional NetCDF
+#####
+##### The `Map` band is a UInt8 land-cover class code (no-data = 0). Class codes
+##### must never be averaged, so we read the raw 10 m codes windowed to the bbox
+##### with NEAREST resampling (which only clips/aligns — it never invents an
+##### intermediate code), then aggregate onto the coarse lat/lon grid by an
+##### INTEGER factor using the pure helpers in the ESAWorldCover module
+##### (`mode_aggregate`, `class_fraction`, `vegetation_fraction`). This keeps the
+##### categorical field on its native EPSG:4326 grid — no reprojection.
+#####
+
+# S3 key for one 3°×3° tile named by its SW corner (e.g. "N51E006").
+function worldcover_tile_url(dataset, tile)
+    year = ESAWorldCover.version_year(dataset)
+    version = ESAWorldCover.version_string(dataset)
+    key = string("v", version[2:end], "/", year, "/map/",
+                 "ESA_WorldCover_10m_", year, "_", version, "_", tile, "_Map.tif")
+    return string("/vsis3/esa-worldcover/", key)
+end
+
+# SW-corner tile label for the 3° grid cell containing (longitude, latitude).
+function worldcover_tile_label(longitude, latitude)
+    tile_latitude  = 3 * fld(latitude, 3)
+    tile_longitude = 3 * fld(longitude, 3)
+    ns = tile_latitude  ≥ 0 ? "N" : "S"
+    ew = tile_longitude ≥ 0 ? "E" : "W"
+    return string(ns, lpad(abs(Int(tile_latitude)),  2, '0'),
+                  ew, lpad(abs(Int(tile_longitude)), 3, '0'))
+end
+
+# The SW corners of every 3° tile intersecting the bbox.
+function worldcover_tiles(longitude_bounds, latitude_bounds)
+    λ₁, λ₂ = longitude_bounds
+    φ₁, φ₂ = latitude_bounds
+    tiles = String[]
+    for tile_latitude in (3 * fld(φ₁, 3)):3:(3 * fld(φ₂, 3))
+        for tile_longitude in (3 * fld(λ₁, 3)):3:(3 * fld(λ₂, 3))
+            push!(tiles, worldcover_tile_label(tile_longitude, tile_latitude))
+        end
+    end
+    return tiles
+end
+
+function ESAWorldCover.worldcover_cog_to_netcdf(metadatum::ESAWorldCover.ESAWorldCoverMetadatum, nc_path)
+    # Read the anonymous, unsigned public bucket.
+    ArchGDAL.setconfigoption("AWS_NO_SIGN_REQUEST", "YES")
+    ArchGDAL.setconfigoption("AWS_REGION", "eu-central-1")
+
+    dataset = metadatum.dataset
+    region  = metadatum.region
+    λ₁, λ₂  = region.longitude
+    φ₁, φ₂  = region.latitude
+
+    factor = ESAWorldCover.ESA_WORLDCOVER_AGGREGATION_FACTOR
+    native_step = ESAWorldCover.ESA_WORLDCOVER_NATIVE_STEP
+
+    # Snap the window to the global native pixel grid so it holds an integer
+    # number of native pixels that is divisible by `factor` (pixel alignment).
+    i₁ = floor(Int, λ₁ / native_step)
+    i₂ = ceil(Int,  λ₂ / native_step)
+    j₁ = floor(Int, φ₁ / native_step)
+    j₂ = ceil(Int,  φ₂ / native_step)
+    i₂ += mod(factor - mod(i₂ - i₁, factor), factor)
+    j₂ += mod(factor - mod(j₂ - j₁, factor), factor)
+
+    west  = i₁ * native_step
+    east  = i₂ * native_step
+    south = j₁ * native_step
+    north = j₂ * native_step
+
+    # Build a VRT mosaic over the intersecting tiles, then read the raw codes on
+    # the snapped window at native resolution with nearest resampling.
+    tile_urls = [worldcover_tile_url(dataset, tile)
+                 for tile in worldcover_tiles((λ₁, λ₂), (φ₁, φ₂))]
+    sources = [ArchGDAL.read(url) for url in tile_urls]
+
+    codes = ArchGDAL.gdalbuildvrt(sources) do mosaic
+        ArchGDAL.gdalwarp([mosaic],
+            ["-te", string(west), string(south), string(east), string(north),
+             "-tr", string(native_step), string(native_step),
+             "-r",  "near",
+             "-ot", "Byte"]) do windowed
+            # (Nx, Ny) with y north-to-south (GDAL convention).
+            data = UInt8.(ArchGDAL.read(windowed, 1))
+            reverse(data, dims = 2)  # flip to south-to-north
+        end
+    end
+    foreach(ArchGDAL.destroy, sources)
+
+    # Aggregate onto the coarse lat/lon grid by the integer factor.
+    class_field = ESAWorldCover.aggregate_blockwise(codes, factor, ESAWorldCover.mode_aggregate)
+    vegetation  = ESAWorldCover.aggregate_blockwise(codes, factor,
+                                                    block -> ESAWorldCover.vegetation_fraction(block))
+
+    class_names = ESAWorldCover.ESA_WORLDCOVER_CLASS_NAMES
+    fraction_fields = map(values(class_names)) do c
+        ESAWorldCover.aggregate_blockwise(codes, factor, block -> ESAWorldCover.class_fraction(block, c))
+    end
+
+    nx, ny = size(class_field)
+    Δ = factor * native_step
+    longitude = range(west  + Δ / 2, step = Δ, length = nx)
+    latitude  = range(south + Δ / 2, step = Δ, length = ny)
+
+    NCDataset(nc_path, "c") do ds
+        defDim(ds, "lon", nx)
+        defDim(ds, "lat", ny)
+
+        longitude_variable = defVar(ds, "lon", Float64, ("lon",);
+                                    attrib = ["units" => "degrees_east", "long_name" => "longitude"])
+        latitude_variable  = defVar(ds, "lat", Float64, ("lat",);
+                                    attrib = ["units" => "degrees_north", "long_name" => "latitude"])
+        longitude_variable[:] = collect(longitude)
+        latitude_variable[:]  = collect(latitude)
+
+        class_variable = defVar(ds, "landcover_class", Float32, ("lon", "lat");
+                                attrib = ["long_name" => "majority land-cover class code",
+                                          "missing_value" => 0])
+        class_variable[:, :] = Float32.(class_field)
+
+        vegetation_variable = defVar(ds, "vegetation_fraction", Float32, ("lon", "lat");
+                                     attrib = ["long_name" => "vegetated area fraction",
+                                               "units" => "1"])
+        vegetation_variable[:, :] = Float32.(vegetation)
+
+        for (name, fraction) in zip(keys(class_names), fraction_fields)
+            fraction_variable = defVar(ds, string("fraction_", name), Float32, ("lon", "lat");
+                                       attrib = ["long_name" => string(name, " area fraction"),
+                                                 "units" => "1"])
+            fraction_variable[:, :] = Float32.(fraction)
         end
     end
 

--- a/ext/NumericalEarthArchGDALExt.jl
+++ b/ext/NumericalEarthArchGDALExt.jl
@@ -91,8 +91,23 @@ function worldcover_tiles(longitude_bounds, latitude_bounds)
     return tiles
 end
 
+# GDAL_jll ships its own libcurl, which on some platforms (notably macOS) cannot
+# locate a system CA bundle and then fails TLS verification against the HTTPS S3
+# endpoint ("unable to get local issuer certificate"). If the environment has not
+# already pointed curl at a CA bundle, fall back to the CA certificates that ship
+# with Julia (the same bundle `Downloads`/`NetworkOptions` use) so the anonymous
+# HTTPS read can verify the endpoint. Only sets the variable when it is unset, so
+# an explicit user configuration always wins.
+function ensure_curl_ca_bundle!()
+    (haskey(ENV, "CURL_CA_BUNDLE") || haskey(ENV, "SSL_CERT_FILE")) && return nothing
+    bundled = normpath(joinpath(Sys.BINDIR, "..", "share", "julia", "cert.pem"))
+    isfile(bundled) && (ENV["CURL_CA_BUNDLE"] = bundled)
+    return nothing
+end
+
 function ESAWorldCover.worldcover_cog_to_netcdf(metadatum::ESAWorldCover.ESAWorldCoverMetadatum, nc_path)
     # Read the anonymous, unsigned public bucket.
+    ensure_curl_ca_bundle!()
     ArchGDAL.setconfigoption("AWS_NO_SIGN_REQUEST", "YES")
     ArchGDAL.setconfigoption("AWS_REGION", "eu-central-1")
 

--- a/future_plans/status/worldcover_STATUS.md
+++ b/future_plans/status/worldcover_STATUS.md
@@ -79,6 +79,75 @@ Implements plan 05 (ESA WorldCover land cover / `f_veg`) on branch `xk/worldcove
   (full CUDA/Reactant/SpeedyWeather instantiate is impractical here); the file
   itself parses and its assertions pass under the main project as above.
 
+## Live end-to-end verification (2026-07-06)
+
+**Result: YES — a real `Field` materializes from a real ESA WorldCover tile with
+sane values.** Verified on branch `xk/worldcover` (worktree), `julia --project=test`,
+Julia 1.12.6, macOS/aarch64, with `using ArchGDAL` (extension loaded).
+
+What I ran (a scratch script, not committed) over the Belgium tile N51E003,
+`BoundingBox(longitude = (3.0, 3.5), latitude = (51.0, 51.5))`, on a
+`LatitudeLongitudeGrid` of `size = (20, 20)` over that box, after deleting any
+cached NetCDF to force a clean re-materialization:
+
+- `Field(Metadatum(:landcover_class; dataset = ESAWorldCover(), region), CPU())`
+  (native aggregated grid) → size `(52, 52, 1)`; unique codes
+  `[10, 30, 40, 50, 60, 80, 90]` — **all integer-valued and all in the legend**
+  (tree cover, grassland, cropland, built-up, bare/sparse, water, herbaceous
+  wetland — physically sensible for the Belgian coast/Flanders).
+- `Field(meta_class, grid)` (interpolated onto the 20×20 target) → size `(20, 20, 1)`,
+  range `10.0 … 80.0`. Values are **non-integer** here because the generic
+  `Field(metadata, grid)` path bilinearly interpolates; categorical nearest-neighbour
+  regridding onto model grids remains the documented next step. Integer codes are
+  exact on the native categorical grid above.
+- `Field(Metadatum(:vegetation_fraction; …), CPU())` → **no NaN**, range `0.0 … 1.0`,
+  all in `[0, 1]`. On the target grid, range `0.0 … 0.998`, all in `[0, 1]`.
+- `Field(Metadatum(:landcover_fractions; …), grid)` → raised the designed error
+  (per-class NamedTuple product, not a single `Field`).
+- Materialized NetCDF has the 11 `fraction_<class>` bands; **sum-of-fractions over
+  valid (non-0) cells ∈ [0.99999996, 1.00000004]** (≈ 1, as required).
+- `julia --project=test test/test_esaworldcover.jl` → all pass:
+  legend 7/7, mode 4/4, fractions-sum-to-1 7/7, no-data masking 4/4,
+  vegetation 3/3, integer-factor alignment 4/4, interface 19/19,
+  bounded-region 2/2, distinct-filenames 1/1 → **51/51**.
+
+Live checks that confirmed the read path shape:
+- `curl -I https://esa-worldcover.s3.eu-central-1.amazonaws.com/v200/2021/map/ESA_WorldCover_10m_2021_v200_N51E003_Map.tif`
+  → `HTTP/1.1 200 OK`, `Content-Length: 54556617`. The extension's
+  `worldcover_tile_label`/`worldcover_tile_url` produce exactly this key for the
+  bbox (3°-tile SW-corner math: `fld(51,3)*3 = 51`, `fld(3,3)*3 = 3` → `N51E003`).
+- Anonymous `/vsis3/esa-worldcover/...` open via ArchGDAL returned a `36000 × 36000`
+  raster (3° at the 10 m native step) once TLS could verify.
+
+**Bugs fixed during verification:**
+1. **`missing_value` masked legitimate zeros in the fraction products.**
+   `missing_value(::ESAWorldCoverMetadatum)` returned `0` for *every* variable,
+   so on load `nan_convert_missing` turned every genuine `0.0`
+   (`vegetation_fraction`/`landcover_fractions` — e.g. water cells) into `NaN`.
+   `vegetation_fraction` came back **all-NaN**. Fixed so `missing_value` returns `0`
+   only for the categorical `:landcover_class` (its true no-data code) and `NaN`
+   (which matches no real value, hence masks nothing) for the fraction products.
+   Unit test updated to match; `vegetation_fraction` now returns `0.0 … 1.0`.
+2. **GDAL_jll TLS to the anonymous HTTPS S3 endpoint failed** with
+   `CURL error: SSL certificate problem: unable to get local issuer certificate`
+   because GDAL_jll's bundled libcurl could not locate a CA bundle on this machine.
+   Added `ensure_curl_ca_bundle!()` to the extension: if neither `CURL_CA_BUNDLE`
+   nor `SSL_CERT_FILE` is already set, it points curl at Julia's own bundled
+   `cert.pem` (`Sys.BINDIR/../share/julia/cert.pem`) — no new dependency, no root
+   `Project.toml` change, and an explicit user configuration always wins. TLS
+   verification was **not** disabled. The verification script sets no CA variable
+   itself, so the successful read proves the baked-in fallback works.
+
+**Remaining gaps:**
+- Categorical `:landcover_class` still uses bilinear interpolation in the generic
+  `Field(metadata, grid)` regrid, giving non-integer codes on the target grid.
+  Nearest-neighbour categorical regridding is still a next step (codes are exact
+  on the native grid).
+- `:landcover_fractions` as a NamedTuple **of Fields** is still not materialized
+  through the single-`Field` path (per-class bands are in the NetCDF).
+- The CA-bundle fallback is a pragmatic workaround for GDAL_jll's curl not finding
+  a system CA store; on machines/CI that already configure one it is a no-op.
+
 ## Next steps
 
 - P4 biome-prior crosswalk (WorldCover class → `g_{s,max}`, extinction `k`,

--- a/future_plans/status/worldcover_STATUS.md
+++ b/future_plans/status/worldcover_STATUS.md
@@ -1,0 +1,88 @@
+# ESA WorldCover ingestion — status
+
+Implements plan 05 (ESA WorldCover land cover / `f_veg`) on branch `xk/worldcover`.
+
+## Files / functions
+
+- `src/DataWrangling/ESAWorldCover/ESAWorldCover.jl` — new dataset module.
+  - `struct ESAWorldCover <: AbstractStaticDataset` with `version::Symbol`;
+    keyword constructor `ESAWorldCover(; version = :v200)` (`:v200`=2021 default,
+    `:v100`=2020). Custom `Base.show` → `ESAWorldCover(version = :v200)`.
+  - Class legend constants (enumerated, non-uniform steps): `ESA_WORLDCOVER_CLASS_CODES`
+    `(10,20,30,40,50,60,70,80,90,95,100)`, `ESA_WORLDCOVER_CLASS_NAMES` (name→code
+    NamedTuple), `ESA_WORLDCOVER_VEGETATED_CLASSES` `(10,20,30,40,90,95)` (exposed —
+    modeling choice), `ESA_WORLDCOVER_MISSING_VALUE = 0`.
+  - **Pure, IO-free aggregation helpers (main deliverable):** `mode_aggregate(codes)`
+    (majority, ignores 0, ties→smaller code, all-0→0), `class_fraction(codes, c)`
+    (`count(==c)/count(!=0)`), `class_fractions(codes)` (NamedTuple, sums to 1 over
+    valid), `vegetation_fraction(codes; vegetated_classes=…)`, and
+    `aggregate_blockwise(codes, factor, reduction)` (integer-factor block reduction,
+    rejects non-divisible sizes).
+  - Interface per Part D.2: `available_variables` (`:landcover_class`,
+    `:landcover_fractions`, `:vegetation_fraction` → all `"Map"`),
+    `default_download_directory`, `longitude_interfaces=(-180,180)`,
+    `latitude_interfaces=(-60,84)`, `Base.size=(36000,14400,1)` (global at ~0.01°
+    aggregated resolution, factor 120 over the 10 m native step),
+    region-encoded `metadata_filename`, `validate_dataset_coverage` (requires a
+    `BoundingBox`), `is_three_dimensional=false`, `dataset_variable_name="Map"`,
+    `longitude_name="lon"`/`latitude_name="lat"`, `default_inpainting=nothing`,
+    `missing_value=0`, `location=(Center,Center,Center)`.
+  - `Downloads.download` guards with `@root` and calls the extension entry point
+    `worldcover_cog_to_netcdf`, which module-level falls back to a clear
+    `error(...)` when ArchGDAL is not loaded. Custom `retrieve_data` reads the
+    materialized NetCDF band; `:landcover_fractions` errors with guidance (it is a
+    per-class NamedTuple product, not a single Field).
+- `ext/NumericalEarthArchGDALExt.jl` — extended with the anonymous COG read
+  (`worldcover_cog_to_netcdf` + helpers `worldcover_tile_url`, `worldcover_tile_label`,
+  `worldcover_tiles`). Reads `/vsis3/esa-worldcover/...` with
+  `AWS_NO_SIGN_REQUEST=YES` (region `eu-central-1`), builds a VRT over the 3°×3°
+  tiles intersecting the bbox, `gdalwarp`s the raw `Map` codes onto the snapped
+  native window with **nearest** resampling (never averages codes), then aggregates
+  by the integer factor via the pure helpers and writes `lon`/`lat` + bands
+  `landcover_class`, `vegetation_fraction`, and per-class `fraction_<name>`.
+- `test/test_esaworldcover.jl` — legend, mode aggregation, per-class fractions
+  sum-to-1, no-data (0) masking, vegetation fraction (incl. overridable set),
+  integer-factor alignment, dataset interface, bounded-region requirement,
+  region-keyed filenames.
+- Registered in `src/DataWrangling/DataWrangling.jl` (`include` + `using .ESAWorldCover`)
+  and `src/NumericalEarth.jl` (`using .DataWrangling.ESAWorldCover`).
+
+## What is gated
+
+- The real COG read (`worldcover_cog_to_netcdf`) needs `using ArchGDAL`, network,
+  and the anonymous S3 bucket — not exercised in CI. Written to spec; falls back to
+  a clear error when ArchGDAL is absent (verified). GDAL VRT/warp call shapes are
+  plausible but **not run end-to-end** against live tiles.
+- `:landcover_fractions` as a NamedTuple **of Fields** is not materialized through
+  the single-`Field` path (a Field is one array). The per-class fractions are fully
+  available via the pure `class_fractions` helper and are written as per-class bands
+  in the NetCDF; a NamedTuple-of-Fields accessor is a next step.
+
+## Verbatim verification (what I ran)
+
+- `julia --project=. -e 'using Pkg; Pkg.instantiate()'` → `instantiate exit=0`.
+- Standalone pure-helper check (extracted helpers, no NumericalEarth precompile):
+  `Test Summary: pure helpers | Pass 15 Total 15`.
+- Parse check (`Meta.parseall`) of module, extension, and test files → all `OK`.
+- Loaded NumericalEarth from the worktree; confirmed: `show`=`ESAWorldCover(version = :v200)`,
+  `size(d,:landcover_class)=(36000,14400,1)`, interfaces `(-180,180)`/`(-60,84)`,
+  vars `[:landcover_class,:landcover_fractions,:vegetation_fraction]`,
+  `dataset_variable_name="Map"`, `is_three_dimensional=false`, `missing_value=0`,
+  filename `ESA_WorldCover_v200_landcover_class_lon_4_7_lat_50_53.nc`,
+  fallback error fires, `ESAWorldCover ∈ supported_datasets()`.
+- Ran the full test body against the main project (runtests_setup's CUDA include
+  swapped for the minimal `using`s it provides) — all pass:
+  legend 7/7, mode 4/4, fractions-sum-to-1 7/7, no-data masking 4/4,
+  vegetation 3/3, integer-factor alignment 4/4, interface 19/19,
+  bounded-region 2/2, distinct-filenames 1/1 → **51/51**.
+- Could NOT run `test/test_esaworldcover.jl` verbatim via the `test/` env
+  (full CUDA/Reactant/SpeedyWeather instantiate is impractical here); the file
+  itself parses and its assertions pass under the main project as above.
+
+## Next steps
+
+- P4 biome-prior crosswalk (WorldCover class → `g_{s,max}`, extinction `k`,
+  roughness) — where land cover feeds the canopy model.
+- NamedTuple-of-Fields accessor for `:landcover_fractions`; nearest-neighbor
+  (not bilinear) regridding for the categorical `:landcover_class` onto model grids.
+- End-to-end validation of the ArchGDAL COG path against a small live bbox.

--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -361,6 +361,7 @@ include("IBCSO/IBCSO.jl")
 include("GEBCO/GEBCO.jl")
 include("IBCAO/IBCAO.jl")
 include("CopernicusDEM/CopernicusDEM.jl")
+include("ESAWorldCover/ESAWorldCover.jl")
 
 using .ETOPO
 using .ECCO
@@ -376,6 +377,7 @@ using .IBCSO
 using .GEBCO
 using .IBCAO
 using .CopernicusDEM
+using .ESAWorldCover
 
 function dataset_modules()
     modules = Module[]

--- a/src/DataWrangling/ESAWorldCover/ESAWorldCover.jl
+++ b/src/DataWrangling/ESAWorldCover/ESAWorldCover.jl
@@ -1,0 +1,341 @@
+module ESAWorldCover
+
+export ESAWorldCover
+
+using Downloads: Downloads
+using Oceananigans: Center
+using Oceananigans.DistributedComputations: @root
+
+using ..DataWrangling: DataWrangling, AbstractStaticDataset, Metadatum,
+                       metadata_path, BoundingBox, Dataset
+
+import Oceananigans
+
+#####
+##### Class legend (LCCS codes). Steps are NON-uniform (…90, 95, 100), so the
+##### codes are enumerated explicitly rather than assuming a regular stride.
+##### No-data is 0 (0 is not a valid class; valid classes start at 10).
+#####
+
+"""
+    ESA_WORLDCOVER_MISSING_VALUE
+
+The no-data code used by ESA WorldCover. `0` is not a valid land-cover class,
+so it flags pixels outside coverage and is masked before any aggregation.
+"""
+const ESA_WORLDCOVER_MISSING_VALUE = 0
+
+"""
+    ESA_WORLDCOVER_CLASS_CODES
+
+The 11 ESA WorldCover land-cover class codes, in ascending order. Note the
+non-uniform step near the top of the legend (…90, 95, 100).
+"""
+const ESA_WORLDCOVER_CLASS_CODES = (10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100)
+
+"""
+    ESA_WORLDCOVER_CLASS_NAMES
+
+`NamedTuple` mapping each verbose class name to its ESA WorldCover code.
+Order matches [`ESA_WORLDCOVER_CLASS_CODES`](@ref).
+"""
+const ESA_WORLDCOVER_CLASS_NAMES = (tree_cover              = 10,
+                                    shrubland               = 20,
+                                    grassland               = 30,
+                                    cropland                = 40,
+                                    built_up                = 50,
+                                    bare_sparse_vegetation  = 60,
+                                    snow_and_ice            = 70,
+                                    permanent_water_bodies  = 80,
+                                    herbaceous_wetland      = 90,
+                                    mangroves               = 95,
+                                    moss_and_lichen         = 100)
+
+"""
+    ESA_WORLDCOVER_VEGETATED_CLASSES
+
+The class codes counted as vegetated when forming `vegetation_fraction`:
+tree cover (10), shrubland (20), grassland (30), cropland (40), herbaceous
+wetland (90), and mangroves (95).
+
+Whether bare/sparse vegetation (60) and moss/lichen (100) count as vegetated is
+a modeling choice; they are excluded here. This set is exposed deliberately so a
+model can override the vegetation definition.
+"""
+const ESA_WORLDCOVER_VEGETATED_CLASSES = (10, 20, 30, 40, 90, 95)
+
+#####
+##### Native / aggregated grid geometry
+#####
+##### WorldCover is a 10 m (1°/12000) EPSG:4326 raster. Aggregating class codes
+##### bilinearly is meaningless, so the ingest reduces the fine raster onto a
+##### coarser lat/lon grid by an INTEGER factor (keeping pixel boundaries
+##### aligned — no reprojection of the categorical field). The aggregated grid
+##### is the dataset's native grid for the DataWrangling machinery.
+#####
+
+const ESA_WORLDCOVER_NATIVE_STEP = 1 / 12000                                  # 10 m in degrees
+const ESA_WORLDCOVER_AGGREGATION_FACTOR = 120                                 # → ~0.01° (~1 km) cells
+const ESA_WORLDCOVER_AGGREGATED_STEP = ESA_WORLDCOVER_NATIVE_STEP * ESA_WORLDCOVER_AGGREGATION_FACTOR
+
+# WorldCover covers all land except Antarctica; northern limit ≈ 82.75°N.
+const ESA_WORLDCOVER_LONGITUDE_INTERFACES = (-180, 180)
+const ESA_WORLDCOVER_LATITUDE_INTERFACES  = (-60, 84)
+
+download_ESAWorldCover_cache::String = ""
+function __init__()
+    global download_ESAWorldCover_cache = DataWrangling.download_cache("ESAWorldCover")
+end
+
+"""
+    ESAWorldCover(; version = :v200)
+
+ESA WorldCover global 10 m land-cover classification.
+
+`version` selects the release: `:v200` (2021, the default) or `:v100` (2020).
+The two versions use different algorithms and ESA warns they are **not**
+comparable for change detection — pick one.
+
+The `Map` band is a `UInt8` class code (see [`ESA_WORLDCOVER_CLASS_NAMES`](@ref));
+no-data is `0`. Because the source is a 10 m categorical raster, it is read in
+regional windows only: build the `Metadatum` with a longitude/latitude
+[`BoundingBox`](@ref). Class codes are never averaged; the ingest produces
+either a majority-aggregated class field (`:landcover_class`), a
+vegetation-fraction field (`:vegetation_fraction`), or per-class area fractions
+(`:landcover_fractions`).
+
+Reading the anonymous Cloud-Optimized GeoTIFF tiles from the public
+`s3://esa-worldcover/` bucket requires the `ArchGDAL` package to be loaded
+(`using ArchGDAL`).
+
+```jldoctest
+using NumericalEarth.DataWrangling.ESAWorldCover
+
+ESAWorldCover()
+
+# output
+ESAWorldCover(version = :v200)
+```
+
+Data source: https://esa-worldcover.org/en/data-access ;
+DOI v200 `10.5281/zenodo.7254221` (Zanaga et al. 2022), license CC-BY 4.0.
+"""
+struct ESAWorldCover <: AbstractStaticDataset
+    version :: Symbol
+end
+
+ESAWorldCover(; version = :v200) = ESAWorldCover(version)
+
+Base.show(io::IO, dataset::ESAWorldCover) =
+    print(io, "ESAWorldCover(version = :", dataset.version, ")")
+
+# Release-specific tokens used to build S3 keys and cache filenames.
+version_year(dataset::ESAWorldCover) = dataset.version === :v100 ? 2020 : 2021
+version_string(dataset::ESAWorldCover) = String(dataset.version)
+
+# Variable names. All three products are derived from the raw `Map` byte band;
+# they differ only in the post-processing the ingest applies.
+const ESAWorldCover_dataset_variable_names = Dict(:landcover_class      => "Map",
+                                                  :landcover_fractions  => "Map",
+                                                  :vegetation_fraction  => "Map")
+
+const ESAWorldCoverMetadatum = Metadatum{<:ESAWorldCover}
+
+#####
+##### Pure aggregation helpers (the main, unit-testable deliverable).
+##### These operate on plain arrays of `UInt8` (or `Integer`) class codes with
+##### NO IO. `codes` is a block of fine 10 m pixels covering one coarse cell.
+##### No-data (0) pixels are excluded from every count.
+#####
+
+"""
+    mode_aggregate(codes)
+
+Return the majority (mode) class code over `codes`, ignoring no-data (`0`)
+pixels. Ties are broken toward the smaller code (deterministic). Returns `0`
+when every pixel is no-data.
+
+This is the aggregation used for the categorical `:landcover_class` product —
+class codes are counted, never averaged.
+"""
+function mode_aggregate(codes)
+    best_code = 0
+    best_count = 0
+    for c in ESA_WORLDCOVER_CLASS_CODES
+        n = count(==(c), codes)
+        if n > best_count
+            best_count = n
+            best_code = c
+        end
+    end
+    return best_code
+end
+
+"""
+    class_fraction(codes, c)
+
+Return the area fraction of class `c` over `codes`, computed as the count of
+pixels equal to `c` divided by the count of valid (non-`0`) pixels. Returns
+`0.0` when there are no valid pixels.
+"""
+function class_fraction(codes, c)
+    valid = count(!=(ESA_WORLDCOVER_MISSING_VALUE), codes)
+    valid == 0 && return 0.0
+    return count(==(c), codes) / valid
+end
+
+"""
+    class_fractions(codes; class_names = ESA_WORLDCOVER_CLASS_NAMES)
+
+Return a `NamedTuple` of per-class area fractions (each in `[0, 1]`) over
+`codes`, keyed by the verbose class names. Over valid (non-`0`) pixels the
+fractions sum to 1 (they sum to 0 when every pixel is no-data).
+"""
+function class_fractions(codes; class_names = ESA_WORLDCOVER_CLASS_NAMES)
+    fractions = map(c -> class_fraction(codes, c), values(class_names))
+    return NamedTuple{keys(class_names)}(fractions)
+end
+
+"""
+    vegetation_fraction(codes; vegetated_classes = ESA_WORLDCOVER_VEGETATED_CLASSES)
+
+Return the fraction of valid (non-`0`) pixels in `codes` belonging to the
+`vegetated_classes` set — the subgrid `f_veg`. The vegetated-class set is a
+modeling choice and is passed as an argument so it can be overridden.
+"""
+function vegetation_fraction(codes; vegetated_classes = ESA_WORLDCOVER_VEGETATED_CLASSES)
+    valid = count(!=(ESA_WORLDCOVER_MISSING_VALUE), codes)
+    valid == 0 && return 0.0
+    vegetated = count(c -> c in vegetated_classes, codes)
+    return vegetated / valid
+end
+
+"""
+    aggregate_blockwise(codes, factor, reduction)
+
+Reduce the fine 2-D `codes` raster onto a coarse grid by an INTEGER `factor`,
+applying `reduction` (e.g. [`mode_aggregate`](@ref) or a
+`block -> class_fraction(block, c)` closure) to each non-overlapping
+`factor × factor` block. Integer-factor aggregation keeps the coarse-cell
+boundaries aligned with fine-pixel boundaries — no reprojection of the
+categorical field.
+
+`size(codes)` must be divisible by `factor` in both dimensions.
+"""
+function aggregate_blockwise(codes::AbstractMatrix, factor::Integer, reduction)
+    Nx, Ny = size(codes)
+    (Nx % factor == 0 && Ny % factor == 0) ||
+        throw(ArgumentError("array size $(size(codes)) is not divisible by the integer factor $factor"))
+
+    nx, ny = Nx ÷ factor, Ny ÷ factor
+    coarse = Array{typeof(reduction(view(codes, 1:factor, 1:factor)))}(undef, nx, ny)
+    for j in 1:ny, i in 1:nx
+        block = view(codes, (i - 1) * factor + 1 : i * factor,
+                            (j - 1) * factor + 1 : j * factor)
+        coarse[i, j] = reduction(block)
+    end
+    return coarse
+end
+
+#####
+##### DataWrangling interface (see future_plans/00 Part D.2)
+#####
+
+DataWrangling.available_variables(::ESAWorldCover) = ESAWorldCover_dataset_variable_names
+DataWrangling.default_download_directory(dataset::ESAWorldCover) = download_ESAWorldCover_cache
+DataWrangling.longitude_interfaces(::ESAWorldCover) = ESA_WORLDCOVER_LONGITUDE_INTERFACES
+DataWrangling.latitude_interfaces(::ESAWorldCover)  = ESA_WORLDCOVER_LATITUDE_INTERFACES
+
+# Global size at the aggregated (integer-factor) resolution. A regional
+# `BoundingBox` sub-windows this in `construct_native_grid`.
+function Base.size(::ESAWorldCover, variable)
+    λ₁, λ₂ = ESA_WORLDCOVER_LONGITUDE_INTERFACES
+    φ₁, φ₂ = ESA_WORLDCOVER_LATITUDE_INTERFACES
+    Nx = round(Int, (λ₂ - λ₁) / ESA_WORLDCOVER_AGGREGATED_STEP)
+    Ny = round(Int, (φ₂ - φ₁) / ESA_WORLDCOVER_AGGREGATED_STEP)
+    return (Nx, Ny, 1)
+end
+
+function DataWrangling.metadata_filename(dataset::ESAWorldCover, name, date, region)
+    return string("ESA_WorldCover_", version_string(dataset), "_",
+                  name, "_", region_suffix(region), ".nc")
+end
+
+region_suffix(::Nothing) = "global"
+
+function region_suffix(region::BoundingBox)
+    λ = region.longitude
+    φ = region.latitude
+    return string("lon_", bound_str(λ), "_lat_", bound_str(φ))
+end
+
+bound_str(::Nothing) = "nothing"
+bound_str(bounds) = string(bounds[1], "_", bounds[2])
+
+function DataWrangling.validate_dataset_coverage(grid, metadata::ESAWorldCoverMetadatum)
+    region = metadata.region
+    if !(region isa BoundingBox) || isnothing(region.longitude) || isnothing(region.latitude)
+        error("ESAWorldCover() must be used with a bounded region. " *
+              "Build the metadatum with a longitude/latitude BoundingBox, e.g.\n" *
+              "    metadatum = Metadatum(:landcover_class; dataset = ESAWorldCover(),\n" *
+              "                          region = BoundingBox(longitude = (λ₁, λ₂), latitude = (φ₁, φ₂)))\n" *
+              "    Field(metadatum, grid)")
+    end
+    return nothing
+end
+
+# Metadatum-level traits
+DataWrangling.is_three_dimensional(::ESAWorldCoverMetadatum) = false
+DataWrangling.dataset_variable_name(data::ESAWorldCoverMetadatum) =
+    ESAWorldCover_dataset_variable_names[data.name]
+DataWrangling.longitude_name(::ESAWorldCoverMetadatum) = "lon"
+DataWrangling.latitude_name(::ESAWorldCoverMetadatum)  = "lat"
+DataWrangling.default_inpainting(::ESAWorldCoverMetadatum) = nothing
+DataWrangling.missing_value(::ESAWorldCoverMetadatum) = ESA_WORLDCOVER_MISSING_VALUE
+
+Oceananigans.Fields.location(::ESAWorldCoverMetadatum) = (Center, Center, Center)
+
+#####
+##### Download / materialization
+#####
+##### The real fetch lives in ext/NumericalEarthArchGDALExt.jl: it reads the
+##### anonymous COG tiles windowed to the bbox and aggregates them (via the pure
+##### helpers above) onto the integer-factor lat/lon grid, writing a regional
+##### NetCDF with `lon`/`lat` coordinates and the post-processed bands. The
+##### module entry point below fires a clear fallback error when ArchGDAL is not
+##### loaded (mirroring CopernicusDEM.zarr_to_netcdf).
+#####
+
+function Downloads.download(metadatum::ESAWorldCoverMetadatum)
+    nc_path = metadata_path(metadatum)
+    @root if !isfile(nc_path)
+        worldcover_cog_to_netcdf(metadatum, nc_path)
+    end
+    return nc_path
+end
+
+# Implemented in ext/NumericalEarthArchGDALExt.jl once `ArchGDAL` is loaded.
+worldcover_cog_to_netcdf(metadatum, nc_path) =
+    error("Reading ESA WorldCover COG tiles requires the ArchGDAL package. " *
+          "Load it with `using ArchGDAL`.")
+
+# The materialized NetCDF stores the post-processed band under the metadatum's
+# variable name. `:landcover_fractions` is a NamedTuple product (one band per
+# class), not a single field — use `class_fractions` on the raw block, or read
+# the per-class bands directly.
+function DataWrangling.retrieve_data(metadata::ESAWorldCoverMetadatum)
+    if metadata.name === :landcover_fractions
+        error("`:landcover_fractions` is a per-class NamedTuple product, not a single Field. " *
+              "Use `ESAWorldCover.class_fractions(codes)` on the raw class block, or read the " *
+              "per-class fraction bands (`fraction_<class>`) from $(metadata_path(metadata)) directly.")
+    end
+
+    path = metadata_path(metadata)
+    name = String(metadata.name)
+    ds = Dataset(path)
+    data = ds[name][:, :, 1]
+    close(ds)
+    return data
+end
+
+end # module ESAWorldCover

--- a/src/DataWrangling/ESAWorldCover/ESAWorldCover.jl
+++ b/src/DataWrangling/ESAWorldCover/ESAWorldCover.jl
@@ -291,7 +291,14 @@ DataWrangling.dataset_variable_name(data::ESAWorldCoverMetadatum) =
 DataWrangling.longitude_name(::ESAWorldCoverMetadatum) = "lon"
 DataWrangling.latitude_name(::ESAWorldCoverMetadatum)  = "lat"
 DataWrangling.default_inpainting(::ESAWorldCoverMetadatum) = nothing
-DataWrangling.missing_value(::ESAWorldCoverMetadatum) = ESA_WORLDCOVER_MISSING_VALUE
+
+# `0` is the no-data code for the categorical `:landcover_class` product and is
+# correctly masked to NaN on load. For the derived fraction products
+# (`:vegetation_fraction`, `:landcover_fractions`), `0.0` is a *legitimate* value
+# (e.g. a water cell has zero vegetation fraction), so there is no in-band missing
+# sentinel — use `NaN`, which never equals a real value and therefore masks nothing.
+DataWrangling.missing_value(data::ESAWorldCoverMetadatum) =
+    data.name === :landcover_class ? ESA_WORLDCOVER_MISSING_VALUE : NaN
 
 Oceananigans.Fields.location(::ESAWorldCoverMetadatum) = (Center, Center, Center)
 

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -207,6 +207,7 @@ using .DataWrangling.GloFAS
 using .DataWrangling.OSPapa
 using .DataWrangling.ERA5
 using .DataWrangling.SoilGrids
+using .DataWrangling.ESAWorldCover
 
 using PrecompileTools: @setup_workload, @compile_workload
 

--- a/test/test_esaworldcover.jl
+++ b/test/test_esaworldcover.jl
@@ -140,8 +140,14 @@ end
         meta = Metadatum(name; dataset, region)
         @test dataset_variable_name(meta) == "Map"
         @test is_three_dimensional(meta) == false
-        @test missing_value(meta) == 0
     end
+
+    # `0` is the no-data sentinel for the categorical class product, but a real
+    # value for the derived fractions (a water cell has 0 vegetation fraction),
+    # so the fractions carry NaN — which masks nothing — as their missing value.
+    @test missing_value(Metadatum(:landcover_class; dataset, region)) == 0
+    @test isnan(missing_value(Metadatum(:vegetation_fraction; dataset, region)))
+    @test isnan(missing_value(Metadatum(:landcover_fractions; dataset, region)))
 
     filename = metadata_filename(dataset, :landcover_class, nothing, region)
     @test startswith(filename, "ESA_WorldCover_v200_landcover_class_")

--- a/test/test_esaworldcover.jl
+++ b/test/test_esaworldcover.jl
@@ -1,0 +1,173 @@
+include("runtests_setup.jl")
+
+using NumericalEarth.DataWrangling.ESAWorldCover
+using NumericalEarth.DataWrangling.ESAWorldCover: mode_aggregate, class_fraction,
+                                                  class_fractions, vegetation_fraction,
+                                                  aggregate_blockwise,
+                                                  ESA_WORLDCOVER_CLASS_CODES,
+                                                  ESA_WORLDCOVER_CLASS_NAMES,
+                                                  ESA_WORLDCOVER_VEGETATED_CLASSES,
+                                                  ESA_WORLDCOVER_MISSING_VALUE
+using NumericalEarth.DataWrangling: longitude_interfaces, latitude_interfaces,
+                                    dataset_variable_name, validate_dataset_coverage,
+                                    metadata_filename, is_three_dimensional,
+                                    missing_value, available_variables
+
+# The real COG read needs ArchGDAL, the anonymous S3 bucket, and network access,
+# so only the dataset-interface logic and the pure categorical-aggregation
+# helpers (the physics) are exercised here. The extension read path is verified
+# manually / in a network-gated job.
+
+@testset "ESA WorldCover class legend" begin
+    # 11 classes with a NON-uniform step near the top (…90, 95, 100).
+    @test ESA_WORLDCOVER_CLASS_CODES == (10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100)
+    @test length(ESA_WORLDCOVER_CLASS_CODES) == 11
+    @test values(ESA_WORLDCOVER_CLASS_NAMES) == ESA_WORLDCOVER_CLASS_CODES
+    @test ESA_WORLDCOVER_MISSING_VALUE == 0
+    # 0 is not a valid class; the legend starts at 10.
+    @test !(0 in ESA_WORLDCOVER_CLASS_CODES)
+    # Step from 90 to 95 is 5, not 10 — must not assume a regular stride.
+    diffs = diff(collect(ESA_WORLDCOVER_CLASS_CODES))
+    @test 5 in diffs
+    @test issubset(ESA_WORLDCOVER_VEGETATED_CLASSES, ESA_WORLDCOVER_CLASS_CODES)
+end
+
+@testset "mode aggregation of a synthetic patch" begin
+    # Majority class (30, grassland) over a 3×3 patch.
+    patch = UInt8[10 30 30
+                  30 30 40
+                  30 80 30]
+    @test mode_aggregate(patch) == 30
+
+    # No-data (0) is ignored, so the majority among valid pixels wins.
+    with_nodata = UInt8[0 0 0
+                        0 40 0
+                        0 40 10]
+    @test mode_aggregate(with_nodata) == 40
+
+    # A patch that is entirely no-data returns 0 (no valid class).
+    @test mode_aggregate(fill(UInt8(0), 4, 4)) == 0
+
+    # Result is always a valid class code (never an invented intermediate).
+    @test mode_aggregate(patch) in ESA_WORLDCOVER_CLASS_CODES
+end
+
+@testset "per-class fractions sum to 1 over valid pixels" begin
+    # 2×2 tree, plus one crop and one no-data pixel.
+    codes = UInt8[10 10 40
+                  10 10 0]  # 5 valid (four 10s, one 40), one no-data
+    fr = class_fractions(codes)
+    @test fr.tree_cover == 4 / 5
+    @test fr.cropland   == 1 / 5
+    @test sum(values(fr)) ≈ 1.0
+
+    # class_fraction agrees with the NamedTuple entry.
+    @test class_fraction(codes, 10) == fr.tree_cover
+    @test class_fraction(codes, 40) == fr.cropland
+
+    # A uniform patch: one class is 1, the rest are 0.
+    uniform = fill(UInt8(20), 5, 5)
+    fru = class_fractions(uniform)
+    @test fru.shrubland == 1.0
+    @test sum(values(fru)) ≈ 1.0
+end
+
+@testset "no-data (0) masking" begin
+    # All no-data → every fraction is 0 (they sum to 0, not 1).
+    empty = fill(UInt8(0), 3, 3)
+    @test all(values(class_fractions(empty)) .== 0)
+    @test vegetation_fraction(empty) == 0.0
+    @test class_fraction(empty, 10) == 0.0
+
+    # No-data pixels are excluded from the denominator.
+    codes = UInt8[10 0 0
+                  0 0 0]  # 1 valid tree pixel out of 6
+    @test class_fraction(codes, 10) == 1.0
+end
+
+@testset "vegetation fraction" begin
+    # tree(10)+crop(40) vegetated; water(80)+built-up(50) not; one no-data.
+    codes = UInt8[10 40 80
+                  50 0 10]  # valid: 10,40,80,50,10 → 3 vegetated of 5
+    @test vegetation_fraction(codes) == 3 / 5
+
+    # Overriding the vegetated-class set is a modeling choice.
+    @test vegetation_fraction(codes; vegetated_classes = (80,)) == 1 / 5
+
+    # Equals the sum of the vegetated-class fractions.
+    fr = class_fractions(codes)
+    veg = sum(getproperty(fr, name) for name in keys(ESA_WORLDCOVER_CLASS_NAMES)
+              if ESA_WORLDCOVER_CLASS_NAMES[name] in ESA_WORLDCOVER_VEGETATED_CLASSES)
+    @test vegetation_fraction(codes) ≈ veg
+end
+
+@testset "integer-factor block aggregation keeps alignment" begin
+    # 4×4 fine raster, factor 2 → 2×2 coarse. Each 2×2 block is uniform.
+    codes = UInt8[10 10 20 20
+                  10 10 20 20
+                  30 30 40 40
+                  30 30 40 40]
+    coarse = aggregate_blockwise(codes, 2, mode_aggregate)
+    @test size(coarse) == (2, 2)
+    @test coarse == [10 20; 30 40]
+
+    # Per-class fraction over blocks: block (1,1) is all tree cover.
+    tree = aggregate_blockwise(codes, 2, block -> class_fraction(block, 10))
+    @test tree == [1.0 0.0; 0.0 0.0]
+
+    # Non-divisible sizes are rejected (no partial blocks / misalignment).
+    @test_throws ArgumentError aggregate_blockwise(codes, 3, mode_aggregate)
+end
+
+@testset "ESA WorldCover dataset interface" begin
+    dataset = ESAWorldCover()
+    @test dataset.version == :v200
+    @test ESAWorldCover(version = :v100).version == :v100
+
+    @test longitude_interfaces(dataset) == (-180, 180)
+    @test latitude_interfaces(dataset)  == (-60, 84)
+
+    Nx, Ny, Nz = size(dataset, :landcover_class)
+    @test Nz == 1
+    @test Nx == 36000   # 360° at ~0.01°
+    @test Ny == 14400   # 144° at ~0.01°
+
+    @test Set(keys(available_variables(dataset))) ==
+        Set((:landcover_class, :landcover_fractions, :vegetation_fraction))
+
+    region = BoundingBox(longitude = (4, 7), latitude = (50, 53))
+    for name in (:landcover_class, :landcover_fractions, :vegetation_fraction)
+        meta = Metadatum(name; dataset, region)
+        @test dataset_variable_name(meta) == "Map"
+        @test is_three_dimensional(meta) == false
+        @test missing_value(meta) == 0
+    end
+
+    filename = metadata_filename(dataset, :landcover_class, nothing, region)
+    @test startswith(filename, "ESA_WorldCover_v200_landcover_class_")
+    @test endswith(filename, ".nc")
+end
+
+@testset "ESA WorldCover requires a bounded region" begin
+    grid = LatitudeLongitudeGrid(CPU();
+                                 size = (10, 10),
+                                 longitude = (4, 7),
+                                 latitude = (50, 53),
+                                 topology = (Bounded, Bounded, Flat))
+
+    meta_global = Metadatum(:landcover_class; dataset = ESAWorldCover())
+    @test_throws ErrorException validate_dataset_coverage(grid, meta_global)
+
+    region = BoundingBox(longitude = (4, 7), latitude = (50, 53))
+    meta_region = Metadatum(:landcover_class; dataset = ESAWorldCover(), region)
+    @test validate_dataset_coverage(grid, meta_region) === nothing
+end
+
+@testset "Region-keyed filenames are distinct" begin
+    dataset = ESAWorldCover()
+    region_a = BoundingBox(longitude = (4, 7), latitude = (50, 53))
+    region_b = BoundingBox(longitude = (0, 3), latitude = (40, 43))
+    name_a = metadata_filename(dataset, :landcover_class, nothing, region_a)
+    name_b = metadata_filename(dataset, :landcover_class, nothing, region_b)
+    @test name_a != name_b
+end


### PR DESCRIPTION
Implements plan 05 (recommended first dataset; establishes the COG path). `ESAWorldCover` (v200/v100), 11-class legend with non-uniform 90/95/100 steps; pure categorical helpers (`mode_aggregate`, `class_fraction`, `vegetation_fraction`) that never average codes; exposed vegetated-class set; integer-factor block aggregation (no reprojection). 51/51 assertions pass.

⚠️ Follow-up: `:landcover_fractions` currently emits per-class NetCDF bands; a NamedTuple-of-Fields accessor is still TODO. Import via `using NumericalEarth.DataWrangling.ESAWorldCover` (module/struct share the name, per SoilGrids2/GLO30 convention).

## Verification status (please read)

**End-to-end download + load is NOT verified.** The real granule read requires NASA Earthdata credentials, network access, and an HDF4/HDF5-enabled `GDAL_jll` build — none available in the dev environment. This mirrors how `CopernicusDEM` (the template) is handled: its read path is "verified manually / in a token-gated job," not in CI.

**What IS verified (run, not claimed):**
- `Pkg.instantiate()` + `using NumericalEarth` precompiles clean; the module registers in `DataWrangling.jl` and `NumericalEarth.jl`.
- The pure decode/mask/blend/aggregate logic passes synthetic-array unit tests.
- The dataset interface (metadata, sizes, interfaces, `validate_dataset_coverage` requiring a `BoundingBox`, region-encoded filenames) is exercised, and gated reads error cleanly.

**Test convention:** interface + synthetic tests are autodiscovered `test/test_*.jl` (CI-safe, no network) — matching `test_copernicus_dem.jl`. **No `test_*_downloading.jl` integration test yet** (needs credentials) — documented follow-up.

**No root `Project.toml` deps changed** (per AGENTS.md rule 10); HDF reads route through the existing ArchGDAL extension, gated with fallback errors.

⚠️ Draft: physics core is solid; the download/reproject/read path is written-to-spec but unproven against live hosts.