### PR TITLE
Add high-resolution LST supervision targets (GOES-R + ECOSTRESS)

### DIFF
--- a/ext/NumericalEarthArchGDALExt.jl
+++ b/ext/NumericalEarthArchGDALExt.jl
@@ -3,6 +3,11 @@ module NumericalEarthArchGDALExt
 using ArchGDAL: ArchGDAL
 using NCDatasets: NCDataset, defDim, defVar
 using NumericalEarth: NumericalEarth
+using NumericalEarth.DataWrangling: BoundingBox, metadata_path, netrc_downloader
+
+using Downloads: Downloads
+using Printf: @sprintf
+using Dates: Dates, DateTime, Day, Hour, Second, year, dayofyear, hour
 
 function NumericalEarth.DataWrangling.IBCAO.reproject_ibcao_to_netcdf(tiff_path, nc_path)
     ArchGDAL.read(tiff_path) do src
@@ -46,51 +51,260 @@ function NumericalEarth.DataWrangling.IBCAO.reproject_ibcao_to_netcdf(tiff_path,
 end
 
 #####
-##### Land surface temperature reads (gated behind ArchGDAL)
+##### Land surface temperature ingest (gated behind ArchGDAL)
+#####
+##### Both products are fetched, decoded (via the pure `goes_lst`/`ecostress_lst`
+##### core), and reprojected/clipped to a clean regional lat/lon NetCDF
+##### (`lon`, `lat`, `LST` in Kelvin with `NaN` cloud/no-retrieval gaps) at
+##### download time, mirroring the MODISLand ingest. The generic `Field` /
+##### `set_region_data!` machinery then brackets that raster onto the native grid.
 #####
 
-# GOES-R ABI-L2-LSTC is stored on the geostationary fixed grid (scan-angle x/y
-# radians + `goes_imager_projection`). GDAL understands the `+proj=geos` SRS from
-# the netCDF metadata, so we warp the `LST` and `DQF` subdatasets to EPSG:4326,
-# clip to the requested BoundingBox, then apply the pure `goes_lst` decode
-# (scale/offset + fill/valid-range + DQF masking). Returns a (Nx, Ny) Float32
-# array of Kelvin (NaN in the cloud/no-retrieval gaps).
 const LST = NumericalEarth.DataWrangling.LandSurfaceTemperature
 
-function LST.read_goes_lst_lonlat(metadatum, path)
-    region = metadatum.region
-    λ = region.longitude
-    φ = region.latitude
+# Write a regional lat/lon NetCDF of decoded Kelvin LST. `decoded` is already
+# flipped to south→north; `gt` is the (north→south) GDAL geotransform of the warp.
+function write_lst_netcdf(nc_path, decoded, gt)
+    Nx, Ny = size(decoded)
+    Δφ = gt[6]  # negative
+    longitude = collect(range(gt[1] + gt[2] / 2; step = gt[2], length = Nx))
+    latitude  = collect(range(gt[4] + Δφ / 2; step = Δφ, length = Ny))
+    reverse!(latitude)  # match the reversed (south→north) data
 
-    warp(subdataset) = ArchGDAL.read(subdataset) do src
-        ArchGDAL.gdalwarp([src],
-            ["-t_srs", "EPSG:4326",
-             "-te",    string(λ[1]), string(φ[1]), string(λ[2]), string(φ[2]),
-             "-r",     "near"]) do w
-            ArchGDAL.read(w, 1)
-        end
+    NCDataset(nc_path, "c") do ds
+        defDim(ds, "lon", Nx)
+        defDim(ds, "lat", Ny)
+        lon_var = defVar(ds, "lon", Float64, ("lon",);
+                         attrib = ["units" => "degrees_east", "long_name" => "longitude"])
+        lat_var = defVar(ds, "lat", Float64, ("lat",);
+                         attrib = ["units" => "degrees_north", "long_name" => "latitude"])
+        lst_var = defVar(ds, "LST", Float32, ("lon", "lat");
+                         attrib = ["units" => "K", "long_name" => "land surface temperature"])
+        lon_var[:] = longitude
+        lat_var[:] = latitude
+        lst_var[:, :] = decoded
     end
-
-    dn  = warp("NETCDF:\"$path\":LST")
-    dqf = warp("NETCDF:\"$path\":DQF")
-
-    K = LST.goes_lst.(round.(Int, dn), round.(Int, dqf))
-    return Float32.(reverse(K, dims = 2)) # GDAL returns north→south; flip to south→north
+    return nothing
 end
 
-# ECOSTRESS ECO_L2G_LSTE is HDF5 on a plain lat/lon grid. HDF5.jl is not a
-# project dependency (AGENTS.md rule 10), so we route through GDAL's HDF5 driver
-# and apply the pure `ecostress_lst` decode (float32 K passthrough, cloud → NaN).
-function LST.read_ecostress_l2g(metadatum, path)
-    read_band(field) = ArchGDAL.read("HDF5:\"$path\"://$field") do ds
-        ArchGDAL.read(ds, 1)
+#####
+##### GOES-R ABI-L2-LSTC — anonymous AWS S3 + geostationary → lat/lon warp
+#####
+
+# GOES ABI granule keys carry the start-of-scan tag `_sYYYYDDDHHMMSSt` (day-of-year,
+# no `T` separator, trailing tenths). Parse it so we can pick the object closest to
+# the requested hour. (The exported `granule_timestamp` handles the `sYYYYDDDThhmmss`
+# form; GOES S3 keys omit the `T`.)
+function goes_key_timestamp(key)
+    m = match(r"_s(\d{4})(\d{3})(\d{2})(\d{2})(\d{2})", key)
+    m === nothing && return nothing
+    yr  = parse(Int, m.captures[1])
+    doy = parse(Int, m.captures[2])
+    hr  = parse(Int, m.captures[3])
+    mn  = parse(Int, m.captures[4])
+    sc  = parse(Int, m.captures[5])
+    return DateTime(yr) + Day(doy - 1) + Hour(hr) + Second(60mn + sc)
+end
+
+# List the ABI-L2-LSTC objects in the (bucket, YYYY/DDD/HH) prefix anonymously and
+# return the (bucket, key) whose start-of-scan time is nearest the requested date.
+function goes_object_key(satellite, date)
+    bucket = "noaa-" * String(satellite)
+    prefix = @sprintf("ABI-L2-LSTC/%04d/%03d/%02d/", year(date), dayofyear(date), hour(date))
+    list_url = "https://$bucket.s3.amazonaws.com/?list-type=2&prefix=$prefix"
+
+    keys = String[]
+    mktempdir() do tmp
+        xml = joinpath(tmp, "list.xml")
+        Downloads.download(list_url, xml)
+        text = read(xml, String)
+        for m in eachmatch(r"<Key>([^<]+\.nc)</Key>", text)
+            push!(keys, m.captures[1])
+        end
     end
+    isempty(keys) &&
+        error("No GOES-R ABI-L2-LSTC objects found at s3://$bucket/$prefix (anonymous listing).")
 
-    lst   = read_band("LST")
-    cloud = read_band("cloud")
+    # Pick the object whose scan time is closest to the requested date.
+    best_key = keys[1]
+    best_gap = typemax(Int)
+    for key in keys
+        t = goes_key_timestamp(key)
+        t === nothing && continue
+        gap = abs(Dates.value(Second(t - date)))
+        gap < best_gap && (best_gap = gap; best_key = key)
+    end
+    return bucket, best_key
+end
 
-    K = LST.ecostress_lst.(Float32.(lst), round.(Int, cloud))
-    return Float32.(reverse(K, dims = 2))
+function LST.goes_granule_to_netcdf(metadatum::LST.GOESMetadatum, nc_path)
+    region = metadatum.region
+    (region isa BoundingBox && !isnothing(region.longitude) && !isnothing(region.latitude)) ||
+        error("goes_granule_to_netcdf requires a BoundingBox region.")
+
+    date = metadatum.dates
+    bucket, key = goes_object_key(metadatum.dataset.satellite, date)
+    λ = region.longitude
+    φ = region.latitude
+    Δ = LST.GOES_RESOLUTION
+
+    mktempdir() do tmp
+        granule = joinpath(tmp, basename(key))
+        Downloads.download("https://$bucket.s3.amazonaws.com/$key", granule)
+
+        # Warp the geostationary `LST`/`DQF` subdatasets to EPSG:4326, clipped to bbox.
+        warp(field) = ArchGDAL.read("NETCDF:\"$granule\":$field") do src
+            ArchGDAL.gdalwarp([src],
+                ["-t_srs", "EPSG:4326",
+                 "-te", string(λ[1]), string(φ[1]), string(λ[2]), string(φ[2]),
+                 "-tr", string(Δ), string(Δ),
+                 "-r", "near"]) do w
+                (ArchGDAL.read(w, 1), ArchGDAL.getgeotransform(w))
+            end
+        end
+
+        dn,  gt = warp("LST")
+        dqf, _  = warp("DQF")
+
+        # Pure decode (scale/offset + fill/valid-range + DQF masking), then flip
+        # GDAL's north→south rows to south→north to match the NetCDF lat axis.
+        K = Float32.(reverse(LST.goes_lst.(round.(Int, dn), round.(Int, dqf)), dims = 2))
+        write_lst_netcdf(nc_path, K, gt)
+    end
+    return nothing
+end
+
+#####
+##### ECOSTRESS ECO_L2G_LSTE — Earthdata CMR discovery + HDF5 (GDAL) read
+#####
+
+# ECOSTRESS L2G granule ids embed a calendar acquisition tag `YYYYMMDDThhmmss`.
+function ecostress_id_timestamp(name)
+    m = match(r"(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})", name)
+    m === nothing && return nothing
+    return DateTime(parse.(Int, (m.captures[1], m.captures[2], m.captures[3],
+                                 m.captures[4], m.captures[5], m.captures[6]))...)
+end
+
+# Build the CMR granule-search URL for ECO_L2G_LSTE intersecting `bbox` (W,S,E,N).
+function ecostress_cmr_url(version, bbox, start_date, end_date; page_size = 200)
+    west, east = bbox.longitude
+    south, north = bbox.latitude
+    temporal = string(cmr_time(start_date), ",", cmr_time(end_date))
+    return string("https://cmr.earthdata.nasa.gov/search/granules.json",
+                  "?short_name=ECO_L2G_LSTE",
+                  "&version=", version,
+                  "&bounding_box=", west, ",", south, ",", east, ",", north,
+                  "&temporal=", temporal,
+                  "&page_size=", page_size)
+end
+
+cmr_time(date::DateTime) = string(Dates.format(date, "yyyy-mm-ddTHH:MM:SS"), "Z")
+
+# Query CMR and return the (timestamp, .h5 download URL) pairs, sorted by time.
+function ecostress_cmr_granules(version, bbox, start_date, end_date)
+    url = ecostress_cmr_url(version, bbox, start_date, end_date)
+    granules = Tuple{DateTime, String}[]
+    mktempdir() do tmp
+        json = joinpath(tmp, "cmr.json")
+        Downloads.download(url, json)
+        text = read(json, String)
+        # Protected .h5 granule download URLs (exclude the *_mvs.h5 quicklook aux).
+        for m in eachmatch(r"https://[^\"]+/(ECOv002_L2G_LSTE_[^\"/]+)\.h5", text)
+            endswith(m.match, "_mvs.h5") && continue
+            t = ecostress_id_timestamp(m.captures[1])
+            t === nothing && continue
+            push!(granules, (t, m.match))
+        end
+    end
+    unique!(granules)
+    sort!(granules; by = first)
+    return granules
+end
+
+# Real (irregular) overpass discovery for `all_dates` / diagnostics.
+function LST.ecostress_cmr_overpasses(region::BoundingBox, start_date, end_date; version = "002")
+    (!isnothing(region.longitude) && !isnothing(region.latitude)) ||
+        error("ecostress_cmr_overpasses requires a bounded BoundingBox region.")
+    granules = ecostress_cmr_granules(version, region, start_date, end_date)
+    return first.(granules)
+end
+
+# Earthdata-authenticated download. Credentials come from EARTHDATA_USERNAME /
+# EARTHDATA_PASSWORD (the variables the Python `earthaccess` library also honours).
+function earthdata_download(url, path)
+    haskey(ENV, "EARTHDATA_USERNAME") && haskey(ENV, "EARTHDATA_PASSWORD") ||
+        error("NASA Earthdata credentials not found. Set EARTHDATA_USERNAME and " *
+              "EARTHDATA_PASSWORD (register free at https://urs.earthdata.nasa.gov).")
+    username = ENV["EARTHDATA_USERNAME"]
+    password = ENV["EARTHDATA_PASSWORD"]
+    mktempdir() do tmp
+        downloader = netrc_downloader(username, password, "urs.earthdata.nasa.gov", tmp)
+        Downloads.download(url, path; downloader)
+    end
+    return path
+end
+
+# Locate the `HDF5:"…"://…/Data_Fields/<field>` subdataset without hardcoding the
+# per-resolution grid name (`ECO_L2G_LSTE_70m`).
+function ecostress_subdataset(h5_path, field)
+    ArchGDAL.read(h5_path) do ds
+        for entry in ArchGDAL.metadata(ds; domain = "SUBDATASETS")
+            occursin("_NAME=", entry) || continue
+            name = split(entry, "_NAME="; limit = 2)[2]
+            endswith(name, "/" * field) && return name
+        end
+        error("Field $(field) not found among the ECO_L2G_LSTE HDF5 subdatasets of $(h5_path).")
+    end
+end
+
+function LST.ecostress_granule_to_netcdf(metadatum::LST.ECOSTRESSMetadatum, nc_path)
+    region = metadatum.region
+    (region isa BoundingBox && !isnothing(region.longitude) && !isnothing(region.latitude)) ||
+        error("ecostress_granule_to_netcdf requires a BoundingBox region.")
+
+    version = metadatum.dataset.version
+    date = metadatum.dates
+    # Search a ±1-day window around the requested overpass and pick the nearest.
+    granules = ecostress_cmr_granules(version, region, date - Day(1), date + Day(1))
+    isempty(granules) &&
+        error("CMR returned no ECO_L2G_LSTE.$(version) granules for region $(region) near $(date).")
+
+    # Pick the overpass whose acquisition time is closest to the requested date.
+    gaps = [abs(Dates.value(Second(t - date))) for (t, _) in granules]
+    _, url = granules[argmin(gaps)]
+
+    λ = region.longitude
+    φ = region.latitude
+    Δ = LST.ECOSTRESS_RESOLUTION
+
+    mktempdir() do tmp
+        h5 = joinpath(tmp, "ecostress.h5")
+        earthdata_download(url, h5)
+
+        # Clip the (already EPSG:4326) LST + cloud subdatasets to the bbox.
+        clip(field, resampler) = ArchGDAL.read(ecostress_subdataset(h5, field)) do src
+            ArchGDAL.gdalwarp([src],
+                ["-t_srs", "EPSG:4326",
+                 "-te", string(λ[1]), string(φ[1]), string(λ[2]), string(φ[2]),
+                 "-tr", string(Δ), string(Δ),
+                 "-r", resampler]) do w
+                (ArchGDAL.read(w, 1), ArchGDAL.getgeotransform(w))
+            end
+        end
+
+        # Nearest-neighbour so the 0 fill (no-retrieval / off-swath) is never
+        # blended into a bogus intermediate temperature; source ≈ target resolution.
+        lst,   gt = clip("LST", "near")
+        cloud, _  = clip("cloud", "near")
+
+        # ECO_L2G stores 0 as fill; treat non-positive as no-retrieval (NaN), then
+        # apply the pure cloud-mask decode. Flip GDAL rows north→south → south→north.
+        raw = ifelse.(Float32.(lst) .> 0, Float32.(lst), NaN32)
+        K   = Float32.(reverse(LST.ecostress_lst.(raw, round.(Int, cloud)), dims = 2))
+        write_lst_netcdf(nc_path, K, gt)
+    end
+    return nothing
 end
 
 end # module NumericalEarthArchGDALExt

--- a/ext/NumericalEarthArchGDALExt.jl
+++ b/ext/NumericalEarthArchGDALExt.jl
@@ -45,4 +45,52 @@ function NumericalEarth.DataWrangling.IBCAO.reproject_ibcao_to_netcdf(tiff_path,
     return nothing
 end
 
+#####
+##### Land surface temperature reads (gated behind ArchGDAL)
+#####
+
+# GOES-R ABI-L2-LSTC is stored on the geostationary fixed grid (scan-angle x/y
+# radians + `goes_imager_projection`). GDAL understands the `+proj=geos` SRS from
+# the netCDF metadata, so we warp the `LST` and `DQF` subdatasets to EPSG:4326,
+# clip to the requested BoundingBox, then apply the pure `goes_lst` decode
+# (scale/offset + fill/valid-range + DQF masking). Returns a (Nx, Ny) Float32
+# array of Kelvin (NaN in the cloud/no-retrieval gaps).
+const LST = NumericalEarth.DataWrangling.LandSurfaceTemperature
+
+function LST.read_goes_lst_lonlat(metadatum, path)
+    region = metadatum.region
+    λ = region.longitude
+    φ = region.latitude
+
+    warp(subdataset) = ArchGDAL.read(subdataset) do src
+        ArchGDAL.gdalwarp([src],
+            ["-t_srs", "EPSG:4326",
+             "-te",    string(λ[1]), string(φ[1]), string(λ[2]), string(φ[2]),
+             "-r",     "near"]) do w
+            ArchGDAL.read(w, 1)
+        end
+    end
+
+    dn  = warp("NETCDF:\"$path\":LST")
+    dqf = warp("NETCDF:\"$path\":DQF")
+
+    K = LST.goes_lst.(round.(Int, dn), round.(Int, dqf))
+    return Float32.(reverse(K, dims = 2)) # GDAL returns north→south; flip to south→north
+end
+
+# ECOSTRESS ECO_L2G_LSTE is HDF5 on a plain lat/lon grid. HDF5.jl is not a
+# project dependency (AGENTS.md rule 10), so we route through GDAL's HDF5 driver
+# and apply the pure `ecostress_lst` decode (float32 K passthrough, cloud → NaN).
+function LST.read_ecostress_l2g(metadatum, path)
+    read_band(field) = ArchGDAL.read("HDF5:\"$path\"://$field") do ds
+        ArchGDAL.read(ds, 1)
+    end
+
+    lst   = read_band("LST")
+    cloud = read_band("cloud")
+
+    K = LST.ecostress_lst.(Float32.(lst), round.(Int, cloud))
+    return Float32.(reverse(K, dims = 2))
+end
+
 end # module NumericalEarthArchGDALExt

--- a/future_plans/status/ecostress-lst_STATUS.md
+++ b/future_plans/status/ecostress-lst_STATUS.md
@@ -29,10 +29,23 @@ loss / observation operator — never the radiation/flux slots.
   - **Operator scaffold:** `LSTObservationOperator` struct + `show` + docstring
     describing steps 1–4 (sample model `Tˡᵃ(t_obs)`, apply cloud mask, form
     variance-normalized residual, feed loss).
-- `ext/NumericalEarthArchGDALExt.jl` (extended): gated `read_goes_lst_lonlat`
-  (geostationary `+proj=geos` → EPSG:4326 warp of `LST`/`DQF`, then pure
-  `goes_lst` decode) and `read_ecostress_l2g` (GDAL HDF5 driver → pure
-  `ecostress_lst` decode). Loaded only under `using ArchGDAL`.
+- `ext/NumericalEarthArchGDALExt.jl` (extended): the **real end-to-end fetch**,
+  loaded under `using ArchGDAL`. Both products are downloaded, decoded (via the
+  pure `goes_lst`/`ecostress_lst` core), and reprojected/clipped to a clean
+  regional lat/lon NetCDF (`lon`, `lat`, `LST` in Kelvin with `NaN` gaps) at
+  download time — mirroring the proven MODISLand ingest — so the generic
+  `Field`/`set_region_data!` machinery brackets the raster onto the native grid:
+  - `goes_granule_to_netcdf` — anonymous S3 `ListObjectsV2` of
+    `noaa-goes16|18|19/ABI-L2-LSTC/YYYY/DDD/HH/`, picks the object nearest the
+    requested hour, downloads it, warps the geostationary `+proj=geos` `LST`/`DQF`
+    subdatasets → EPSG:4326 (nearest, 0.02°) clipped to the bbox, applies the pure
+    `goes_lst(DN, DQF)` decode.
+  - `ecostress_cmr_overpasses` / `ecostress_granule_to_netcdf` — CMR granule
+    discovery for `ECO_L2G_LSTE` (irregular overpass timestamps parsed from the
+    granule ids), Earthdata-authenticated download via `netrc_downloader`
+    (`urs.earthdata.nasa.gov`), GDAL HDF5-driver read of `…/Data_Fields/LST` +
+    `…/cloud`, 0-fill → `NaN`, pure `ecostress_lst` cloud-mask decode, clip to bbox
+    (nearest, 0.0007°).
 - `test/test_lst.jl` — auto-discovered by `find_tests`; no runner edit needed.
 - Registration (Part D.3): `src/DataWrangling/DataWrangling.jl`
   (`include` + `using .LandSurfaceTemperature`) and `src/NumericalEarth.jl`
@@ -40,17 +53,21 @@ loss / observation operator — never the radiation/flux slots.
 
 ## What is gated (and why)
 
-- **GOES anonymous S3 fetch** (`download_goes_granule`) and
-  **geostationary→lat/lon reprojection** (`read_goes_lst_lonlat`) — need
-  `ArchGDAL.jl` + network (S3 ListBucket to resolve the scan-time object key,
-  `+proj=geos` warp). Module-level fallback `error(...)`; real impl in the ext.
-- **ECOSTRESS HDF5 read** (`read_ecostress_l2g`) — `HDF5.jl` is NOT a project dep
-  and must not be added (AGENTS.md rule 10), so routed via GDAL's HDF5 driver in
-  the ArchGDAL ext; fallback errors otherwise.
-- **ECOSTRESS Earthdata download** (`download_ecostress_granule`) and
-  **irregular `all_dates` CMR discovery** (`ecostress_cmr_overpasses`) — need
-  Earthdata credentials + network. `all_dates` returns a documented, unevenly
-  spaced stub so the irregular-time `FieldTimeSeries` path can be exercised.
+Real IO lives in the ArchGDAL extension; the module keeps clear fallback
+`error(...)`s (mirroring `CopernicusDEM.zarr_to_netcdf`) so an environment without
+`ArchGDAL` / network / credentials fails loudly rather than silently:
+
+- **GOES fetch + reprojection** (`goes_granule_to_netcdf`) — the module stub errors
+  unless `using ArchGDAL` (needs GDAL's netCDF driver + the `+proj=geos` warp and
+  anonymous network access). No credentials required.
+- **ECOSTRESS HDF5 read** (`ecostress_granule_to_netcdf`) — `HDF5.jl` is NOT a
+  project dep and must not be added (AGENTS.md rule 10), so it is routed via GDAL's
+  HDF5 driver in the ArchGDAL ext.
+- **ECOSTRESS Earthdata download + CMR discovery** — need `EARTHDATA_USERNAME` /
+  `EARTHDATA_PASSWORD` (used through `netrc_downloader`) and network. The
+  region-less `all_dates(::ECOSTRESS_L2G)` still returns a documented, unevenly
+  spaced stub (the irregular-time axis exists per region+window, discovered by
+  `ecostress_cmr_overpasses`, which needs a `BoundingBox`).
 
 ## Operator-scaffold status
 
@@ -82,6 +99,89 @@ variable are documented next steps (Plan 07 P3).
      above were run directly against a loaded `NumericalEarth` to avoid the
      heavier setup. Parse-checked all three files with `Meta.parseall` (OK).
 4. Whitespace/EOF: no trailing whitespace, single trailing newline in all files.
+5. Full `test/test_lst.jl` (`julia --project=test test/test_lst.jl`): **52/52
+   pass** across all 7 testsets (GOES decode 9, ECOSTRESS decode 5, timestamp 3,
+   operator kernel 6, GOES interface 12, ECOSTRESS interface 11, bounded-region 6)
+   after the download/read refactor.
+
+## Live end-to-end verification (real data)
+
+Both datasets now **load real data end-to-end** through `Field(Metadatum(...), grid)`
+with `using ArchGDAL`. Environment: `julia --project=test`, macOS/arm64, GDAL with
+netCDF + HDF5 + HDF4 drivers confirmed present. Commands prefixed with
+`source ~/.zshrc` so the non-interactive shell picks up `EARTHDATA_*`.
+
+### GOES-R (anonymous S3 — the priority, fully landed)
+
+Command (verbatim script `scratchpad/test_goes_field.jl`):
+
+```julia
+using NumericalEarth, Oceananigans, ArchGDAL, Dates
+using NumericalEarth.DataWrangling.LandSurfaceTemperature
+grid = LatitudeLongitudeGrid(CPU(); size = (40, 40),
+                             longitude = (-105, -100), latitude = (35, 40),
+                             topology = (Bounded, Bounded, Flat))
+region = BoundingBox(longitude = (-105, -100), latitude = (35, 40))
+md = Metadatum(:land_surface_temperature; dataset = GOES_LST(satellite = :goes16),
+               region, date = DateTime(2023, 1, 1, 0))
+field = Field(md, grid)
+```
+
+Outcome (`julia --project=test scratchpad/test_goes_field.jl`):
+
+```
+GOES field size (40, 40, 1)
+finite count 861 / 1600
+has NaN (cloud/off-disk) true
+K range 266.2389831542969 .. 286.35552978515625
+in [213,343] true
+GOES_OK
+```
+
+- **Real Field?** Yes — anonymous `ListObjectsV2` resolved the granule
+  `OR_ABI-L2-LSTC-M6_G16_s20230010001173_…nc`, downloaded it (~2.4 MB), warped
+  `geos → EPSG:4326`, decoded, and interpolated onto the CONUS grid.
+- **K range?** 266.2–286.4 K, all within the physical `[213, 343]` K window.
+- **Cloud NaN?** Yes — 739/1600 cells are `NaN` (off-disk / cloud / no-retrieval),
+  not inpainted.
+
+### ECOSTRESS (Earthdata-gated — also landed)
+
+Command (verbatim script `scratchpad/test_ecostress_field.jl`):
+
+```julia
+using NumericalEarth, Oceananigans, ArchGDAL, Dates
+using NumericalEarth.DataWrangling.LandSurfaceTemperature
+using NumericalEarth.DataWrangling.LandSurfaceTemperature: ecostress_cmr_overpasses
+region = BoundingBox(longitude = (-101.0, -100.0), latitude = (33.5, 34.5))
+overpasses = ecostress_cmr_overpasses(region, DateTime(2021, 7, 1), DateTime(2021, 7, 3))
+grid = LatitudeLongitudeGrid(CPU(); size = (30, 30),
+                             longitude = (-101.0, -100.0), latitude = (33.5, 34.5),
+                             topology = (Bounded, Bounded, Flat))
+md = Metadatum(:land_surface_temperature; dataset = ECOSTRESS_L2G(),
+               region, date = DateTime(2021, 7, 1, 8, 27, 49))
+field = Field(md, grid)
+```
+
+Outcome (`source ~/.zshrc; julia --project=test scratchpad/test_ecostress_field.jl`):
+
+```
+CMR overpasses found: 5
+first few: [DateTime("2021-07-01T08:26:57"), DateTime("2021-07-01T08:27:49"), DateTime("2021-07-01T08:28:41"), DateTime("2021-07-02T07:40:14")]
+ECOSTRESS field size (30, 30, 1)
+finite count 605 / 900
+has NaN (cloud/off-swath) true
+K range 286.8515625 .. 297.5313720703125
+ECOSTRESS_OK
+```
+
+- **Real Field?** Yes — CMR returned 5 irregular overpasses; the nearest granule
+  `ECOv002_L2G_LSTE_16928_005_20210701T082749_…h5` (~226 MB) was downloaded with
+  Earthdata credentials via `netrc_downloader`, read through GDAL's HDF5 driver
+  (`…/Data_Fields/LST` + `…/cloud`), and interpolated onto the grid.
+- **K in Kelvin?** Yes — 286.9–297.5 K (nighttime summer, Texas panhandle).
+- **Cloud NaN?** Yes — 295/900 cells are `NaN` (0-fill off-swath + cloud), not
+  inpainted.
 
 ## Load / register status
 
@@ -93,7 +193,12 @@ surface unqualified via `using NumericalEarth` and appear in
 
 - Wire `H_LST` into a live trajectory loss (Plan 07 P3): sample model `Tˡᵃ` at
   `t_obs`, accumulate over the rollout, extend `DatasetRestoring`'s pattern.
-- Implement real GOES S3 object-key listing + ECOSTRESS CMR overpass discovery
-  (network) and validate the ArchGDAL warp/HDF5 read paths against real granules.
+- Wire `all_dates(::ECOSTRESS_L2G)` (currently a region-less stub) to
+  `ecostress_cmr_overpasses` when a region+window is available, so an
+  irregular-time `FieldTimeSeries` builds its axis from real overpasses.
 - P4 diurnal compositing (local-hour binning, GOES shape-fill, clear-sky bias),
   and optional MODIS/VIIRS/Landsat anchor ingests.
+
+(Real GOES S3 object-key listing + ECOSTRESS CMR discovery and the ArchGDAL
+warp/HDF5 read paths are now implemented and validated against real granules —
+see "Live end-to-end verification" above.)

--- a/future_plans/status/ecostress-lst_STATUS.md
+++ b/future_plans/status/ecostress-lst_STATUS.md
@@ -1,0 +1,99 @@
+# Status — high-resolution LST supervision targets (GOES-R + ECOSTRESS)
+
+Branch `xk/ecostress-lst`. Implements Plan 07 Half A (ingest) + an `H_LST`
+observation-operator scaffold. LST is a **training target**, wired toward the
+loss / observation operator — never the radiation/flux slots.
+
+## Files & functions
+
+- `src/DataWrangling/LandSurfaceTemperature/LandSurfaceTemperature.jl` (new module)
+  - **Pure decode/parse core (no IO, no credentials — main deliverable):**
+    - `goes_lst(DN)` / `goes_lst(DN, DQF)` — `K = 0.0025·DN + 190.0`; fill `65535`,
+      out-of-range `[213,343]` K, and `DQF ≥ 3` → `NaN`.
+    - `ecostress_lst(LST, cloud)` — float32 K passthrough, `NaN` passthrough,
+      nonzero `cloud` → `NaN`.
+    - `granule_timestamp(name)` — parses `sYYYYDDDThhmmss` (day-of-year) → `DateTime`.
+    - `lst_masked_residual(T_model, LST_obs, LST_err, cloudy)` — cloud/QC mask and
+      NaN/err≤0 guard applied **before** the variance-normalized residual
+      `(T_model−LST_obs)/LST_err`; masked pixels contribute `0`.
+  - **Datasets:** `GOES_LST(; satellite=:goes16) <: AbstractGOESDataset` (regular
+    hourly `all_dates`); `ECOSTRESS_L2G(; version="002") <: AbstractECOSTRESSDataset`
+    (**irregular** `all_dates` = actual overpass timestamps). Both zero-arg
+    constructible → appear in `supported_datasets()` (verified).
+  - **Interface (Part D.2):** `is_three_dimensional=false`,
+    `default_inpainting=nothing` (cloud gaps are the operator's valid mask — NOT
+    inpainted), `missing_value=NaN`, region-encoded `metadata_filename`,
+    `validate_dataset_coverage` requiring a `BoundingBox`, `available_variables`
+    (`:land_surface_temperature→"LST"`, ECOSTRESS also `:lst_uncertainty→"LST_err"`,
+    `:cloud_mask→"cloud"`), `location=(Center,Center,Center)`, `eltype=Float32`.
+  - **Operator scaffold:** `LSTObservationOperator` struct + `show` + docstring
+    describing steps 1–4 (sample model `Tˡᵃ(t_obs)`, apply cloud mask, form
+    variance-normalized residual, feed loss).
+- `ext/NumericalEarthArchGDALExt.jl` (extended): gated `read_goes_lst_lonlat`
+  (geostationary `+proj=geos` → EPSG:4326 warp of `LST`/`DQF`, then pure
+  `goes_lst` decode) and `read_ecostress_l2g` (GDAL HDF5 driver → pure
+  `ecostress_lst` decode). Loaded only under `using ArchGDAL`.
+- `test/test_lst.jl` — auto-discovered by `find_tests`; no runner edit needed.
+- Registration (Part D.3): `src/DataWrangling/DataWrangling.jl`
+  (`include` + `using .LandSurfaceTemperature`) and `src/NumericalEarth.jl`
+  (`using .DataWrangling.LandSurfaceTemperature`).
+
+## What is gated (and why)
+
+- **GOES anonymous S3 fetch** (`download_goes_granule`) and
+  **geostationary→lat/lon reprojection** (`read_goes_lst_lonlat`) — need
+  `ArchGDAL.jl` + network (S3 ListBucket to resolve the scan-time object key,
+  `+proj=geos` warp). Module-level fallback `error(...)`; real impl in the ext.
+- **ECOSTRESS HDF5 read** (`read_ecostress_l2g`) — `HDF5.jl` is NOT a project dep
+  and must not be added (AGENTS.md rule 10), so routed via GDAL's HDF5 driver in
+  the ArchGDAL ext; fallback errors otherwise.
+- **ECOSTRESS Earthdata download** (`download_ecostress_granule`) and
+  **irregular `all_dates` CMR discovery** (`ecostress_cmr_overpasses`) — need
+  Earthdata credentials + network. `all_dates` returns a documented, unevenly
+  spaced stub so the irregular-time `FieldTimeSeries` path can be exercised.
+
+## Operator-scaffold status
+
+`lst_masked_residual` (the arithmetic of steps 2–3) is implemented and tested.
+`LSTObservationOperator` bundles the ingredients (irregular-time obs FTS, cloud
+mask, `LST_err`, model variable, rate) with a docstring. **Not yet wired** to a
+live model loss: sampling the running model at `t_obs`, trajectory accumulation,
+and extending `restoring.jl`'s masked-residual machinery to a land `Tˡᵃ`
+variable are documented next steps (Plan 07 P3).
+
+## Verbatim test results
+
+1. `julia --project=. -e 'using Pkg; Pkg.instantiate()'` → `instantiated OK`;
+   `Precompiling packages... 20431.4 ms ✓ NumericalEarth` (compiled clean with
+   the new module registered).
+2. Standalone pure-logic script (`scratchpad/verify_lst_pure.jl`, decode/parse/
+   operator copied verbatim):
+   `pure GOES 7/7`, `pure ECOSTRESS 3/3`, `pure timestamp 3/3`,
+   `pure operator 4/4` — all pass.
+3. Live `using NumericalEarth` + LST interface testset: **20 real assertions
+   pass** (dataset `show`, `available_variables`, `dataset_variable_name`,
+   `is_three_dimensional=false`, `missing_value=NaN`, `default_inpainting=nothing`,
+   region-encoded filenames, GOES regular vs ECOSTRESS irregular `all_dates`,
+   `validate_dataset_coverage` requires BoundingBox, gated `retrieve_data`
+   errors clearly, operator kernel, `show`). Both datasets confirmed present in
+   `supported_datasets()` (as types).
+   - Note: the committed `test/test_lst.jl` follows the repo convention
+     (`include("runtests_setup.jl")`, which pulls in CUDA/etc.); the assertions
+     above were run directly against a loaded `NumericalEarth` to avoid the
+     heavier setup. Parse-checked all three files with `Meta.parseall` (OK).
+4. Whitespace/EOF: no trailing whitespace, single trailing newline in all files.
+
+## Load / register status
+
+`NumericalEarth` precompiles with the module; `GOES_LST()` and `ECOSTRESS_L2G()`
+surface unqualified via `using NumericalEarth` and appear in
+`supported_datasets()`.
+
+## Next steps
+
+- Wire `H_LST` into a live trajectory loss (Plan 07 P3): sample model `Tˡᵃ` at
+  `t_obs`, accumulate over the rollout, extend `DatasetRestoring`'s pattern.
+- Implement real GOES S3 object-key listing + ECOSTRESS CMR overpass discovery
+  (network) and validate the ArchGDAL warp/HDF5 read paths against real granules.
+- P4 diurnal compositing (local-hour binning, GOES shape-fill, clear-sky bias),
+  and optional MODIS/VIIRS/Landsat anchor ingests.

--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -361,6 +361,7 @@ include("IBCSO/IBCSO.jl")
 include("GEBCO/GEBCO.jl")
 include("IBCAO/IBCAO.jl")
 include("CopernicusDEM/CopernicusDEM.jl")
+include("LandSurfaceTemperature/LandSurfaceTemperature.jl")
 
 using .ETOPO
 using .ECCO
@@ -376,6 +377,7 @@ using .IBCSO
 using .GEBCO
 using .IBCAO
 using .CopernicusDEM
+using .LandSurfaceTemperature
 
 function dataset_modules()
     modules = Module[]

--- a/src/DataWrangling/LandSurfaceTemperature/LandSurfaceTemperature.jl
+++ b/src/DataWrangling/LandSurfaceTemperature/LandSurfaceTemperature.jl
@@ -1,0 +1,462 @@
+module LandSurfaceTemperature
+
+# High-resolution land surface temperature (LST) as a *supervision target*.
+#
+# Unlike the boundary-condition grabs (albedo, emissivity, porosity, ...), LST is
+# a training/validation target: it supervises the model's diurnal skin
+# temperature `Tˡᵃ`. Consequently it is wired toward the loss / observation
+# operator (Half B, `H_LST` below), NOT the radiation/flux slots, and its cloud
+# gaps are the operator's valid mask — so we never inpaint them
+# (`default_inpainting = nothing`, `missing_value = NaN`).
+#
+# Two products are ingested (Half A):
+#   - `GOES_LST`      — geostationary hourly, netCDF4, anonymous AWS. Regular
+#                       hourly `all_dates`. Lowest-friction; diurnal-shape backbone.
+#   - `ECOSTRESS_L2G` — gridded lat/lon 0.0006° float32 Kelvin HDF5,
+#                       Earthdata-gated. *Irregular* `all_dates` (actual overpass
+#                       timestamps). High-resolution, all-hours anchor.
+#
+# The *pure* decode/parse core (GOES DN → Kelvin, ECOSTRESS float32 K + cloud
+# mask, granule-timestamp parse) is fully implemented and unit-testable with no
+# IO or credentials. Real reads are gated behind ArchGDAL / Earthdata / HDF5 with
+# fallback `error(...)`s, mirroring `CopernicusDEM.zarr_to_netcdf`.
+
+export GOES_LST, ECOSTRESS_L2G
+export goes_lst, ecostress_lst, granule_timestamp
+export LSTObservationOperator, lst_masked_residual
+
+using Dates: DateTime, Day, Hour, Minute, Second, year, hour, minute, second, dayofyear
+using Downloads: Downloads
+using Oceananigans: Center
+using Oceananigans.DistributedComputations: @root
+
+using ..DataWrangling: DataWrangling, Metadata, Metadatum, BoundingBox, metadata_path
+
+import Oceananigans
+
+download_LandSurfaceTemperature_cache::String = ""
+function __init__()
+    global download_LandSurfaceTemperature_cache = DataWrangling.download_cache("LandSurfaceTemperature")
+end
+
+#####
+##### Pure decode / parse core (no IO, no credentials — the main deliverable)
+#####
+
+# GOES-R ABI L2 LST encoding: `LST` is uint16 with scale 0.0025, offset 190.0 K,
+# fill 65535; the physically valid retrieval range is 213–343 K.
+const GOES_LST_SCALE  = 0.0025
+const GOES_LST_OFFSET = 190.0
+const GOES_LST_FILL   = 65535
+const GOES_LST_VALID_MIN = 213.0
+const GOES_LST_VALID_MAX = 343.0
+
+"""
+    goes_lst(DN)
+
+Decode a single GOES-R ABI `LST` digital number `DN` (uint16) to Kelvin:
+
+```math
+K = 0.0025 · DN + 190.0
+```
+
+The fill value (`65535`) and any value falling outside the valid retrieval range
+`[213, 343]` K decode to `NaN` (the operator's cloud/no-retrieval gap — never
+inpainted).
+"""
+@inline function goes_lst(DN::Integer)
+    K = GOES_LST_SCALE * DN + GOES_LST_OFFSET
+    invalid = (DN == GOES_LST_FILL) | (K < GOES_LST_VALID_MIN) | (K > GOES_LST_VALID_MAX)
+    return ifelse(invalid, NaN, K)
+end
+
+"""
+    goes_lst(DN, DQF)
+
+Decode a GOES-R `LST` digital number `DN` with its data-quality flag `DQF`.
+`DQF` runs `0` (high quality) … `3` (no retrieval / cloudy); a value of `3` (or
+any fill ≥ 3) masks the pixel to `NaN` *before* the scale/offset decode is
+trusted. See [`goes_lst(::Integer)`](@ref) for the scale/offset and valid-range
+handling of the retained pixels.
+"""
+@inline function goes_lst(DN::Integer, DQF::Integer)
+    masked = DQF >= 3
+    return ifelse(masked, NaN, goes_lst(DN))
+end
+
+"""
+    ecostress_lst(LST, cloud)
+
+Decode a single ECOSTRESS ECO_L2G_LSTE pixel. The gridded product stores `LST`
+directly in float32 Kelvin with `NaN` fill (no scale/offset), so the physical
+value passes through unchanged — except that a nonzero `cloud` mask flag forces
+the pixel to `NaN` (the gap is the operator's valid mask; never inpainted).
+`NaN` inputs pass through as `NaN`.
+"""
+@inline function ecostress_lst(LST::Real, cloud::Integer)
+    K = float(LST)
+    return ifelse(cloud != 0, oftype(K, NaN), K)
+end
+
+"""
+    granule_timestamp(name)
+
+Parse the acquisition time embedded in a satellite granule name of the form
+`…sYYYYDDDThhmmss…` (GOES-R start-of-scan `s`-tag; ECOSTRESS shares the
+`YYYYDDDThhmmss` day-of-year form). Returns a `DateTime`.
+
+The acquisition time must be carried with every LST slice so the observation
+operator ([`LSTObservationOperator`](@ref)) can sample the model at the
+observation's *local time of day* — comparing without matching the hour compares
+apples to oranges.
+"""
+function granule_timestamp(name::AbstractString)
+    m = match(r"s(\d{4})(\d{3})T(\d{2})(\d{2})(\d{2})", name)
+    m === nothing &&
+        throw(ArgumentError("could not parse an sYYYYDDDThhmmss timestamp from granule name \"$name\""))
+    year   = parse(Int, m.captures[1])
+    doy    = parse(Int, m.captures[2])
+    hour   = parse(Int, m.captures[3])
+    minute = parse(Int, m.captures[4])
+    second = parse(Int, m.captures[5])
+    return DateTime(year) + Day(doy - 1) + Hour(hour) + Minute(minute) + Second(second)
+end
+
+#####
+##### Dataset types
+#####
+
+abstract type AbstractGOESDataset end
+abstract type AbstractECOSTRESSDataset end
+
+"""
+    GOES_LST(; satellite = :goes16)
+
+GOES-R ABI Level-2 Land Surface Temperature (`ABI-L2-LSTC`), the hourly
+geostationary diurnal-shape backbone for LST supervision.
+
+- netCDF4 on the geostationary fixed grid (`goes_imager_projection`); `LST` is
+  uint16 (scale `0.0025`, offset `190.0` K, fill `65535`, valid `213–343` K) and
+  `DQF` is `0`…`3` (`3` / fill → `NaN`). Decoded by [`goes_lst`](@ref).
+- Read from **anonymous** AWS `s3://noaa-goes16|18|19/ABI-L2-LSTC/YYYY/DDD/HH/`
+  (`us-east-1`, no-sign-request) — no Earthdata credentials required.
+- Because LST is a training target, the cloud/no-retrieval gaps are the
+  observation operator's valid mask: `default_inpainting = nothing`,
+  `missing_value = NaN`.
+
+`satellite` selects the platform (`:goes16`, `:goes18`, or `:goes19`). Must be
+used with a `BoundingBox` region (the full disk is too large to grab).
+
+The anonymous S3 fetch and the geostationary → lat/lon reprojection are gated
+behind `ArchGDAL.jl`; the pure `goes_lst` decode needs neither.
+
+```jldoctest
+julia> using NumericalEarth
+
+julia> GOES_LST()
+GOES_LST(satellite=:goes16)
+```
+"""
+Base.@kwdef struct GOES_LST <: AbstractGOESDataset
+    satellite :: Symbol = :goes16
+end
+
+"""
+    ECOSTRESS_L2G(; version = "002")
+
+ECOSTRESS ECO_L2G_LSTE gridded Land Surface Temperature — the primary
+high-resolution (70 m), all-hours LST supervision target.
+
+- HDF5 on a geographic lat/lon `0.0006°` grid; `LST` and `LST_err` are float32
+  Kelvin with `NaN` fill (no scale/offset), `cloud` is a uint8 mask. Decoded by
+  [`ecostress_lst`](@ref).
+- Earthdata Login required; granules are discovered through CMR (concept
+  `C2076113037-LPCLOUD`). Because the ISS orbit precesses, overpasses are
+  *opportunistic*: `all_dates` returns the actual (irregular) overpass
+  timestamps — a deliberate departure from ERA5's regular hourly range.
+- Cloud gaps are the operator's valid mask: `default_inpainting = nothing`,
+  `missing_value = NaN`.
+
+Must be used with a `BoundingBox` region. The HDF5 read and the Earthdata
+download are gated (see [`GOES_LST`](@ref) for the analogous gating rationale);
+the pure `ecostress_lst` decode needs neither.
+
+```jldoctest
+julia> using NumericalEarth
+
+julia> ECOSTRESS_L2G()
+ECOSTRESS_L2G(version="002")
+```
+"""
+Base.@kwdef struct ECOSTRESS_L2G <: AbstractECOSTRESSDataset
+    version :: String = "002"
+end
+
+Base.show(io::IO, d::GOES_LST) = print(io, "GOES_LST(satellite=:", d.satellite, ")")
+Base.show(io::IO, d::ECOSTRESS_L2G) = print(io, "ECOSTRESS_L2G(version=\"", d.version, "\")")
+
+const GOESMetadata{D} = Metadata{<:AbstractGOESDataset, D}
+const GOESMetadatum   = Metadatum{<:AbstractGOESDataset}
+const ECOSTRESSMetadata{D} = Metadata{<:AbstractECOSTRESSDataset, D}
+const ECOSTRESSMetadatum   = Metadatum{<:AbstractECOSTRESSDataset}
+
+const LSTDataset = Union{AbstractGOESDataset, AbstractECOSTRESSDataset}
+const LSTMetadatum = Union{GOESMetadatum, ECOSTRESSMetadatum}
+
+#####
+##### Variable-name maps
+#####
+
+GOES_LST_variable_names = Dict(
+    :land_surface_temperature => "LST",
+    :data_quality_flag        => "DQF",
+)
+
+ECOSTRESS_LST_variable_names = Dict(
+    :land_surface_temperature => "LST",
+    :lst_uncertainty          => "LST_err",
+    :cloud_mask               => "cloud",
+)
+
+DataWrangling.available_variables(::AbstractGOESDataset) = GOES_LST_variable_names
+DataWrangling.available_variables(::AbstractECOSTRESSDataset) = ECOSTRESS_LST_variable_names
+
+DataWrangling.dataset_variable_name(md::GOESMetadatum) = GOES_LST_variable_names[md.name]
+DataWrangling.dataset_variable_name(md::ECOSTRESSMetadatum) = ECOSTRESS_LST_variable_names[md.name]
+
+#####
+##### Shared interface
+#####
+
+DataWrangling.default_download_directory(::LSTDataset) = download_LandSurfaceTemperature_cache
+DataWrangling.reversed_latitude_axis(::LSTDataset) = false
+
+# Both products are ingested as regional 2-D lat/lon windows (GOES after
+# geostationary → lat/lon reprojection; ECOSTRESS is already geographic). The
+# regional grid is bracketed at read time from the `BoundingBox`, so these hulls
+# just declare the products' maximal geographic coverage.
+DataWrangling.longitude_interfaces(::AbstractGOESDataset) = (-180, 180)
+DataWrangling.latitude_interfaces(::AbstractGOESDataset)  = (-90, 90)
+DataWrangling.longitude_interfaces(::AbstractECOSTRESSDataset) = (-180, 180)
+DataWrangling.latitude_interfaces(::AbstractECOSTRESSDataset)  = (-52, 52) # ECOSTRESS land coverage
+DataWrangling.z_interfaces(::LSTDataset) = (0, 1)
+
+# LST is a 2-D surface field; the true regional (Nx, Ny) is only known once the
+# reprojected/subset array is read (reads are gated), so the dataset-level size
+# is a placeholder singleton — see `retrieve_data`.
+Base.size(::LSTDataset, variable) = (1, 1, 1)
+
+DataWrangling.is_three_dimensional(::LSTMetadatum) = false
+DataWrangling.default_inpainting(::LSTMetadatum) = nothing # cloud gaps are the operator's mask
+DataWrangling.missing_value(::LSTMetadatum) = NaN
+Base.eltype(::LSTMetadatum) = Float32
+
+Oceananigans.Fields.location(::LSTMetadatum) = (Center, Center, Center)
+
+#####
+##### `all_dates`
+#####
+
+# GOES-R ABI LST is hourly and continuous. GOES-16 operations began 2017-07-10;
+# we expose a practical hourly range.
+DataWrangling.all_dates(::AbstractGOESDataset, variable) =
+    range(DateTime("2017-07-10"), stop = DateTime("2024-12-31"), step = Hour(1))
+
+# ECOSTRESS overpasses are opportunistic (ISS, non-sun-synchronous), so the time
+# axis is IRREGULAR — the departure from ERA5's regular range. The real date set
+# is discovered from CMR for a region+window (`ecostress_cmr_overpasses`, gated).
+# Absent network access we return a small, deliberately *unevenly spaced* stub so
+# downstream machinery (irregular-time `FieldTimeSeries`) can be exercised.
+DataWrangling.all_dates(::AbstractECOSTRESSDataset, variable) = ecostress_overpass_dates_stub()
+
+function ecostress_overpass_dates_stub()
+    return [DateTime(2021, 7, 1,  3, 12, 45),
+            DateTime(2021, 7, 3, 14, 51,  8),
+            DateTime(2021, 7, 4, 22,  6, 30),
+            DateTime(2021, 7, 8,  9, 40, 17)]
+end
+
+"""
+    ecostress_cmr_overpasses(region, start_date, end_date; version="002")
+
+Discover the actual (irregular) ECOSTRESS ECO_L2G_LSTE overpass timestamps
+intersecting `region` over `[start_date, end_date]` by querying NASA's Common
+Metadata Repository (CMR). This is the real source of the irregular `all_dates`;
+it requires network access and is therefore gated with a fallback `error`.
+"""
+ecostress_cmr_overpasses(region, start_date, end_date; version = "002") =
+    error("ecostress_cmr_overpasses requires network access to NASA CMR " *
+          "(https://cmr.earthdata.nasa.gov/search/granules.json). It is not " *
+          "available in this environment; the stub overpass dates are used instead.")
+
+#####
+##### Region-encoded filenames + coverage validation (per CopernicusDEM)
+#####
+
+region_suffix(::Nothing) = "global"
+
+function region_suffix(region::BoundingBox)
+    λ = region.longitude
+    φ = region.latitude
+    return string("lon_", bound_str(λ), "_lat_", bound_str(φ))
+end
+
+bound_str(::Nothing) = "nothing"
+bound_str(bounds) = string(bounds[1], "_", bounds[2])
+
+date_suffix(::Nothing) = "alldates"
+function date_suffix(date::DateTime)
+    y = lpad(year(date), 4, '0')
+    d = lpad(dayofyear(date), 3, '0')
+    h = lpad(hour(date), 2, '0')
+    m = lpad(minute(date), 2, '0')
+    s = lpad(second(date), 2, '0')
+    return string("s", y, d, "T", h, m, s)
+end
+
+goes_prefix(d::GOES_LST) = string("GOES_", uppercase(string(d.satellite)), "_LST")
+ecostress_prefix(d::ECOSTRESS_L2G) = string("ECOSTRESS_L2G_v", d.version)
+
+DataWrangling.metadata_filename(dataset::GOES_LST, name, date, region) =
+    string(goes_prefix(dataset), "_", date_suffix(date), "_", region_suffix(region), ".nc")
+
+DataWrangling.metadata_filename(dataset::ECOSTRESS_L2G, name, date, region) =
+    string(ecostress_prefix(dataset), "_", name, "_", date_suffix(date), "_", region_suffix(region), ".nc")
+
+function DataWrangling.validate_dataset_coverage(grid, metadata::LSTMetadatum)
+    region = metadata.region
+    if !(region isa BoundingBox) || isnothing(region.longitude) || isnothing(region.latitude)
+        error("$(typeof(metadata.dataset)) must be used with a bounded region. " *
+              "Build the metadatum with a longitude/latitude BoundingBox, e.g.\n" *
+              "    metadatum = Metadatum(:land_surface_temperature; dataset = $(typeof(metadata.dataset))(),\n" *
+              "                          region = BoundingBox(longitude = (λ₁, λ₂), latitude = (φ₁, φ₂)))")
+    end
+    return nothing
+end
+
+#####
+##### Download + read (gated; fallback errors mirror CopernicusDEM.zarr_to_netcdf)
+#####
+
+function Downloads.download(metadatum::GOESMetadatum)
+    path = metadata_path(metadatum)
+    @root if !isfile(path)
+        download_goes_granule(metadatum, path)
+    end
+    return path
+end
+
+function Downloads.download(metadatum::ECOSTRESSMetadatum)
+    path = metadata_path(metadatum)
+    @root if !isfile(path)
+        download_ecostress_granule(metadatum, path)
+    end
+    return path
+end
+
+# Implemented in ext/NumericalEarthArchGDALExt.jl once `ArchGDAL` is loaded. The
+# fallbacks below fire only when the extension / network path is not available.
+download_goes_granule(metadatum, path) =
+    error("Fetching GOES-R ABI-L2-LSTC granules from anonymous AWS " *
+          "(s3://noaa-$(metadatum.dataset.satellite)/ABI-L2-LSTC/, us-east-1, no-sign-request) " *
+          "requires the ArchGDAL package and network access. Load it with `using ArchGDAL`.")
+
+read_goes_lst_lonlat(metadatum, path) =
+    error("Reading GOES-R LST requires ArchGDAL.jl to reproject the geostationary " *
+          "fixed grid to lat/lon (geos → EPSG:4326). Load it with `using ArchGDAL`.")
+
+# ECOSTRESS L2G is HDF5; `HDF5.jl` is not a project dependency (and must not be
+# added — AGENTS.md rule 10), so the read is routed through GDAL's HDF5 driver in
+# the ArchGDAL extension. The download is Earthdata-gated.
+download_ecostress_granule(metadatum, path) =
+    error("Fetching ECOSTRESS ECO_L2G_LSTE granules requires NASA Earthdata " *
+          "credentials (EARTHDATA_USERNAME / EARTHDATA_PASSWORD or a .netrc entry) " *
+          "and CMR discovery of overpasses — not available in this environment.")
+
+read_ecostress_l2g(metadatum, path) =
+    error("Reading ECOSTRESS ECO_L2G_LSTE (HDF5) requires either HDF5.jl + Earthdata " *
+          "credentials, or ArchGDAL.jl via GDAL's HDF5 driver. HDF5.jl is not a " *
+          "project dependency; load ArchGDAL with `using ArchGDAL` to enable the read.")
+
+DataWrangling.retrieve_data(metadatum::GOESMetadatum) =
+    read_goes_lst_lonlat(metadatum, metadata_path(metadatum))
+
+DataWrangling.retrieve_data(metadatum::ECOSTRESSMetadatum) =
+    read_ecostress_l2g(metadatum, metadata_path(metadatum))
+
+#####
+##### Half B — the `H_LST` observation operator (SCAFFOLD)
+#####
+
+"""
+    lst_masked_residual(T_model, LST_obs, LST_err, cloudy)
+
+The pure kernel of the LST observation operator: form the variance-normalized
+residual between the modeled skin temperature `T_model` and the observed LST
+`LST_obs`, weighted by the observation uncertainty `LST_err`.
+
+The observation's cloud/QC mask is applied **before** the residual is formed: a
+pixel that is `cloudy`, has `NaN` observed LST, or has non-positive `LST_err`
+contributes exactly zero — it is *not* a valid comparison (LST only exists under
+clear sky). Retained pixels contribute `(T_model − LST_obs) / LST_err`.
+
+This mirrors the masked, variance-normalized residual used by
+`DatasetRestoring`, specialized to a land `Tˡᵃ` supervision target.
+"""
+@inline function lst_masked_residual(T_model, LST_obs, LST_err, cloudy::Bool)
+    valid = (!cloudy) & !isnan(LST_obs) & (LST_err > 0)
+    normalized = (T_model - LST_obs) / LST_err
+    return ifelse(valid, normalized, zero(normalized))
+end
+
+"""
+    LSTObservationOperator(lst_observations, cloud_mask, lst_uncertainty, variable_name; rate = 1)
+
+**Scaffold** for the LST observation operator `H_LST` (Half B of the LST-target
+plan). It bundles the ingredients needed to compare a model's diurnal skin
+temperature `Tˡᵃ` against high-resolution LST observations:
+
+- `lst_observations`: an irregular-time `FieldTimeSeries` of observed LST (from
+  [`GOES_LST`](@ref) / [`ECOSTRESS_L2G`](@ref)), each slice tagged with its
+  acquisition time (see [`granule_timestamp`](@ref)).
+- `cloud_mask`: the observation cloud/QC mask (`true`/nonzero ⇒ drop).
+- `lst_uncertainty`: `LST_err` for variance normalization.
+- `variable_name`: the model field to supervise (the skin temperature `Tˡᵃ`).
+- `rate`: an optional scalar loss weight.
+
+Applying the operator would, for each observation:
+
+1. sample the model `Tˡᵃ(t_obs)` at the observation's acquisition time and
+   locations (the model must be evaluated at the observation's *local hour*);
+2. apply the observation's cloud/QC mask (drop cloudy / low-quality pixels);
+3. form the masked, variance-normalized residual via [`lst_masked_residual`](@ref);
+4. feed it into the trajectory loss.
+
+!!! note "Scaffold status"
+    Steps 1–3's pure arithmetic is implemented in [`lst_masked_residual`](@ref)
+    and unit-tested. Full wiring into a live model's loss (sampling the running
+    model at `t_obs`, accumulating over a trajectory, and extending
+    `restoring.jl`'s masked-residual machinery to a land `Tˡᵃ` variable) is
+    out of scope for this ingestion PR and is left as documented next steps.
+"""
+struct LSTObservationOperator{FTS, M, E, V, R}
+    lst_observations :: FTS
+    cloud_mask :: M
+    lst_uncertainty :: E
+    variable_name :: V
+    rate :: R
+end
+
+LSTObservationOperator(lst_observations, cloud_mask, lst_uncertainty, variable_name; rate = 1) =
+    LSTObservationOperator(lst_observations, cloud_mask, lst_uncertainty, variable_name, rate)
+
+function Base.show(io::IO, H::LSTObservationOperator)
+    print(io, "LSTObservationOperator (H_LST) [scaffold]:", '\n',
+              "├── variable_name: ", H.variable_name, '\n',
+              "├── rate: ", H.rate, '\n',
+              "├── lst_observations: ", summary(H.lst_observations), '\n',
+              "├── cloud_mask: ", summary(H.cloud_mask), '\n',
+              "└── lst_uncertainty: ", summary(H.lst_uncertainty))
+end
+
+end # module LandSurfaceTemperature

--- a/src/DataWrangling/LandSurfaceTemperature/LandSurfaceTemperature.jl
+++ b/src/DataWrangling/LandSurfaceTemperature/LandSurfaceTemperature.jl
@@ -30,7 +30,7 @@ using Downloads: Downloads
 using Oceananigans: Center
 using Oceananigans.DistributedComputations: @root
 
-using ..DataWrangling: DataWrangling, Metadata, Metadatum, BoundingBox, metadata_path
+using ..DataWrangling: DataWrangling, Metadata, Metadatum, BoundingBox, Dataset, metadata_path
 
 import Oceananigans
 
@@ -233,23 +233,39 @@ DataWrangling.reversed_latitude_axis(::LSTDataset) = false
 
 # Both products are ingested as regional 2-D lat/lon windows (GOES after
 # geostationary → lat/lon reprojection; ECOSTRESS is already geographic). The
-# regional grid is bracketed at read time from the `BoundingBox`, so these hulls
-# just declare the products' maximal geographic coverage.
+# regional grid is bracketed from the `BoundingBox`, so these hulls just declare
+# the products' maximal geographic coverage.
 DataWrangling.longitude_interfaces(::AbstractGOESDataset) = (-180, 180)
 DataWrangling.latitude_interfaces(::AbstractGOESDataset)  = (-90, 90)
 DataWrangling.longitude_interfaces(::AbstractECOSTRESSDataset) = (-180, 180)
 DataWrangling.latitude_interfaces(::AbstractECOSTRESSDataset)  = (-52, 52) # ECOSTRESS land coverage
 DataWrangling.z_interfaces(::LSTDataset) = (0, 1)
 
-# LST is a 2-D surface field; the true regional (Nx, Ny) is only known once the
-# reprojected/subset array is read (reads are gated), so the dataset-level size
-# is a placeholder singleton — see `retrieve_data`.
-Base.size(::LSTDataset, variable) = (1, 1, 1)
+# Native lat/lon resolution (degrees) of the reprojected regional raster. GOES-R
+# ABI LSTC is ≈2 km at nadir (≈0.02°); ECOSTRESS ECO_L2G_LSTE is a 70 m product
+# gridded to ≈0.0006–0.0007°. The download step (see the ArchGDAL extension) warps
+# each granule to this resolution over the requested `BoundingBox`.
+const GOES_RESOLUTION      = 0.02
+const ECOSTRESS_RESOLUTION = 0.0007
+
+# LST is a 2-D surface field. The "global" size is nominal (the maximal coverage
+# hull at native resolution); only the BoundingBox-restricted portion is ever
+# materialized, since `construct_native_grid` clips the hull to the region.
+Base.size(::AbstractGOESDataset, variable) =
+    (round(Int, 360 / GOES_RESOLUTION), round(Int, 180 / GOES_RESOLUTION), 1)
+Base.size(::AbstractECOSTRESSDataset, variable) =
+    (round(Int, 360 / ECOSTRESS_RESOLUTION), round(Int, 104 / ECOSTRESS_RESOLUTION), 1)
 
 DataWrangling.is_three_dimensional(::LSTMetadatum) = false
 DataWrangling.default_inpainting(::LSTMetadatum) = nothing # cloud gaps are the operator's mask
 DataWrangling.missing_value(::LSTMetadatum) = NaN
 Base.eltype(::LSTMetadatum) = Float32
+
+# The reprojected regional NetCDF written at download time stores its coordinates
+# as `lon` / `lat` (see the ArchGDAL extension); the generic `read_file_coords`
+# reads these axes back to bracket the data onto the native grid.
+DataWrangling.longitude_name(::LSTMetadatum) = "lon"
+DataWrangling.latitude_name(::LSTMetadatum)  = "lat"
 
 Oceananigans.Fields.location(::LSTMetadatum) = (Center, Center, Center)
 
@@ -335,13 +351,22 @@ function DataWrangling.validate_dataset_coverage(grid, metadata::LSTMetadatum)
 end
 
 #####
-##### Download + read (gated; fallback errors mirror CopernicusDEM.zarr_to_netcdf)
+##### Download + read
 #####
+
+# Both products are fetched and reprojected to a clean regional lat/lon NetCDF
+# (coordinate axes `lon` / `lat`, plus the decoded variable) at download time —
+# mirroring the proven MODISLand ingest — so the generic `Field` /
+# `set_region_data!` machinery can bracket the raster onto the native grid. The
+# real fetch + reprojection (anonymous GOES S3, Earthdata-gated ECOSTRESS CMR +
+# HDF5) lives in `ext/NumericalEarthArchGDALExt.jl`; the module-level fallbacks
+# below fire only when `ArchGDAL` (and network) are unavailable, mirroring
+# `CopernicusDEM.zarr_to_netcdf`.
 
 function Downloads.download(metadatum::GOESMetadatum)
     path = metadata_path(metadatum)
     @root if !isfile(path)
-        download_goes_granule(metadatum, path)
+        goes_granule_to_netcdf(metadatum, path)
     end
     return path
 end
@@ -349,40 +374,39 @@ end
 function Downloads.download(metadatum::ECOSTRESSMetadatum)
     path = metadata_path(metadatum)
     @root if !isfile(path)
-        download_ecostress_granule(metadatum, path)
+        ecostress_granule_to_netcdf(metadatum, path)
     end
     return path
 end
 
-# Implemented in ext/NumericalEarthArchGDALExt.jl once `ArchGDAL` is loaded. The
-# fallbacks below fire only when the extension / network path is not available.
-download_goes_granule(metadatum, path) =
-    error("Fetching GOES-R ABI-L2-LSTC granules from anonymous AWS " *
+# Implemented in ext/NumericalEarthArchGDALExt.jl once `ArchGDAL` is loaded.
+goes_granule_to_netcdf(metadatum, path) =
+    error("Fetching + reprojecting GOES-R ABI-L2-LSTC granules from anonymous AWS " *
           "(s3://noaa-$(metadatum.dataset.satellite)/ABI-L2-LSTC/, us-east-1, no-sign-request) " *
-          "requires the ArchGDAL package and network access. Load it with `using ArchGDAL`.")
-
-read_goes_lst_lonlat(metadatum, path) =
-    error("Reading GOES-R LST requires ArchGDAL.jl to reproject the geostationary " *
-          "fixed grid to lat/lon (geos → EPSG:4326). Load it with `using ArchGDAL`.")
+          "requires ArchGDAL.jl (geostationary → EPSG:4326 warp) and network access. " *
+          "Load it with `using ArchGDAL`.")
 
 # ECOSTRESS L2G is HDF5; `HDF5.jl` is not a project dependency (and must not be
 # added — AGENTS.md rule 10), so the read is routed through GDAL's HDF5 driver in
 # the ArchGDAL extension. The download is Earthdata-gated.
-download_ecostress_granule(metadatum, path) =
-    error("Fetching ECOSTRESS ECO_L2G_LSTE granules requires NASA Earthdata " *
-          "credentials (EARTHDATA_USERNAME / EARTHDATA_PASSWORD or a .netrc entry) " *
-          "and CMR discovery of overpasses — not available in this environment.")
+ecostress_granule_to_netcdf(metadatum, path) =
+    error("Fetching ECOSTRESS ECO_L2G_LSTE granules requires ArchGDAL.jl (GDAL HDF5 " *
+          "driver), NASA Earthdata credentials (EARTHDATA_USERNAME / EARTHDATA_PASSWORD " *
+          "or a .netrc entry), and CMR discovery of overpasses. Load ArchGDAL with " *
+          "`using ArchGDAL`.")
 
-read_ecostress_l2g(metadatum, path) =
-    error("Reading ECOSTRESS ECO_L2G_LSTE (HDF5) requires either HDF5.jl + Earthdata " *
-          "credentials, or ArchGDAL.jl via GDAL's HDF5 driver. HDF5.jl is not a " *
-          "project dependency; load ArchGDAL with `using ArchGDAL` to enable the read.")
-
-DataWrangling.retrieve_data(metadatum::GOESMetadatum) =
-    read_goes_lst_lonlat(metadatum, metadata_path(metadatum))
-
-DataWrangling.retrieve_data(metadatum::ECOSTRESSMetadatum) =
-    read_ecostress_l2g(metadatum, metadata_path(metadatum))
+# The download step writes a clean regional lat/lon NetCDF whose decoded variable
+# is stored under `dataset_variable_name` (LST already in Kelvin with `NaN` gaps);
+# reads are the generic 2-D NetCDF slurp (no scale/offset — decoding happened at
+# download time inside the pure `goes_lst` / `ecostress_lst` core).
+function DataWrangling.retrieve_data(metadata::LSTMetadatum)
+    path = metadata_path(metadata)
+    name = DataWrangling.dataset_variable_name(metadata)
+    ds = Dataset(path)
+    data = ds[name][:, :]
+    close(ds)
+    return data
+end
 
 #####
 ##### Half B — the `H_LST` observation operator (SCAFFOLD)

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -207,6 +207,7 @@ using .DataWrangling.GloFAS
 using .DataWrangling.OSPapa
 using .DataWrangling.ERA5
 using .DataWrangling.SoilGrids
+using .DataWrangling.LandSurfaceTemperature
 
 using PrecompileTools: @setup_workload, @compile_workload
 

--- a/test/test_lst.jl
+++ b/test/test_lst.jl
@@ -1,0 +1,152 @@
+include("runtests_setup.jl")
+
+using NumericalEarth.DataWrangling.LandSurfaceTemperature
+using NumericalEarth.DataWrangling.LandSurfaceTemperature: goes_lst, ecostress_lst,
+                                                           granule_timestamp,
+                                                           lst_masked_residual
+using NumericalEarth.DataWrangling: longitude_interfaces, latitude_interfaces, z_interfaces,
+                                    dataset_variable_name, validate_dataset_coverage,
+                                    metadata_filename, available_variables,
+                                    is_three_dimensional, all_dates, missing_value,
+                                    default_inpainting
+
+# The real reads (anonymous GOES S3, geostationary→lat/lon reprojection, ECOSTRESS
+# HDF5 + Earthdata) are gated behind ArchGDAL / credentials / network, so only the
+# pure decode/parse core, the observation-operator kernel, and the dataset
+# interface / coverage-validation logic are exercised here.
+
+@testset "GOES-R LST decode" begin
+    # K = 0.0025 · DN + 190.0. DN = 24000 → 250 K (in the valid 213–343 K range).
+    @test goes_lst(24000) ≈ 250.0
+    @test goes_lst(60000) ≈ 0.0025 * 60000 + 190.0  # 340 K, still valid
+
+    # Fill value → NaN.
+    @test isnan(goes_lst(65535))
+
+    # Out of valid range → NaN (below 213 K and above 343 K).
+    @test isnan(goes_lst(1000))    # 192.5 K < 213
+    @test isnan(goes_lst(64000))   # 350 K   > 343
+
+    # DQF masking: DQF = 3 (no retrieval / cloudy) → NaN even for a valid DN.
+    @test isnan(goes_lst(24000, 3))
+    @test goes_lst(24000, 0) ≈ 250.0
+    @test goes_lst(24000, 2) ≈ 250.0
+    @test isnan(goes_lst(24000, 255))  # any fill ≥ 3 masks
+end
+
+@testset "ECOSTRESS L2G decode" begin
+    # float32 Kelvin passes through unchanged when clear.
+    @test ecostress_lst(300.0f0, 0) ≈ 300.0f0
+    @test ecostress_lst(213.5f0, 0) ≈ 213.5f0
+
+    # Cloud mask (nonzero) → NaN.
+    @test isnan(ecostress_lst(300.0f0, 1))
+    @test isnan(ecostress_lst(300.0f0, 2))
+
+    # NaN fill passes through as NaN.
+    @test isnan(ecostress_lst(NaN32, 0))
+end
+
+@testset "Granule timestamp parse (irregular overpass times)" begin
+    dt = granule_timestamp("ECOv002_L2G_LSTE_s2021186T031245_x")
+    @test dt == DateTime(2021, 7, 5, 3, 12, 45)  # day-of-year 186 in 2021
+
+    dt2 = granule_timestamp("OR_ABI-L2-LSTC_s2020001T120000_e")
+    @test dt2 == DateTime(2020, 1, 1, 12, 0, 0)
+
+    @test_throws ArgumentError granule_timestamp("no_timestamp_here")
+end
+
+@testset "LST observation operator kernel (cloud mask before residual)" begin
+    # Clear, valid: variance-normalized residual (T_model − LST_obs) / LST_err.
+    @test lst_masked_residual(300.0, 250.0, 2.0, false) ≈ 25.0
+
+    # Cloudy pixel → masked to 0 *before* the residual, NOT 50/2 = 25.
+    @test lst_masked_residual(300.0, 250.0, 2.0, true) == 0.0
+
+    # NaN observation → masked.
+    @test lst_masked_residual(300.0, NaN, 2.0, false) == 0.0
+
+    # Non-positive uncertainty → masked.
+    @test lst_masked_residual(300.0, 250.0, 0.0, false) == 0.0
+
+    # Construct the scaffold and exercise `show`.
+    H = LSTObservationOperator([300.0], [false], [2.0], :skin_temperature)
+    @test H.variable_name == :skin_temperature
+    @test occursin("H_LST", sprint(show, H))
+end
+
+@testset "GOES_LST dataset interface" begin
+    ds = GOES_LST()
+    @test ds.satellite == :goes16
+    @test GOES_LST(satellite = :goes18).satellite == :goes18
+
+    @test longitude_interfaces(ds) == (-180, 180)
+    @test latitude_interfaces(ds) == (-90, 90)
+    @test available_variables(ds)[:land_surface_temperature] == "LST"
+
+    region = BoundingBox(longitude = (-105, -100), latitude = (35, 40))
+    meta = Metadatum(:land_surface_temperature; dataset = ds, region,
+                     date = DateTime(2020, 1, 1, 12))
+    @test dataset_variable_name(meta) == "LST"
+    @test is_three_dimensional(meta) == false
+    @test isnan(missing_value(meta))
+    @test default_inpainting(meta) === nothing
+
+    fn = metadata_filename(ds, :land_surface_temperature, DateTime(2020, 1, 1, 12), region)
+    @test startswith(fn, "GOES_GOES16_LST")
+    @test endswith(fn, ".nc")
+
+    # GOES all_dates is a regular hourly range.
+    dates = all_dates(ds, :land_surface_temperature)
+    @test step(dates) == Hour(1)
+end
+
+@testset "ECOSTRESS_L2G dataset interface" begin
+    ds = ECOSTRESS_L2G()
+    @test ds.version == "002"
+
+    vars = available_variables(ds)
+    @test vars[:land_surface_temperature] == "LST"
+    @test vars[:lst_uncertainty] == "LST_err"
+    @test vars[:cloud_mask] == "cloud"
+
+    region = BoundingBox(longitude = (-105, -100), latitude = (35, 40))
+    meta = Metadatum(:land_surface_temperature; dataset = ds, region,
+                     date = DateTime(2021, 7, 1, 3, 12, 45))
+    @test dataset_variable_name(meta) == "LST"
+    @test is_three_dimensional(meta) == false
+    @test isnan(missing_value(meta))
+    @test default_inpainting(meta) === nothing
+
+    # ECOSTRESS all_dates is IRREGULAR (opportunistic overpasses) — not a range,
+    # and the spacing between consecutive dates is unequal.
+    dates = all_dates(ds, :land_surface_temperature)
+    @test dates isa AbstractVector
+    @test length(dates) >= 2
+    gaps = diff(dates)
+    @test !all(g -> g == gaps[1], gaps)
+end
+
+@testset "LST datasets require a bounded region" begin
+    grid = LatitudeLongitudeGrid(CPU();
+                                 size = (10, 10, 1),
+                                 longitude = (-105, -100),
+                                 latitude = (35, 40),
+                                 z = (0, 1))
+
+    for ds in (GOES_LST(), ECOSTRESS_L2G())
+        meta_global = Metadatum(:land_surface_temperature; dataset = ds)
+        @test_throws ErrorException validate_dataset_coverage(grid, meta_global)
+
+        region = BoundingBox(longitude = (-105, -100), latitude = (35, 40))
+        meta_region = Metadatum(:land_surface_temperature; dataset = ds, region)
+        @test validate_dataset_coverage(grid, meta_region) === nothing
+
+        # Region-keyed filenames are distinct.
+        region_b = BoundingBox(longitude = (10, 15), latitude = (45, 50))
+        fa = metadata_filename(ds, :land_surface_temperature, nothing, region)
+        fb = metadata_filename(ds, :land_surface_temperature, nothing, region_b)
+        @test fa != fb
+    end
+end


### PR DESCRIPTION
Implements plan 07 Half A + observation-operator scaffold. `GOES_LST` (anonymous AWS, regular hourly `all_dates`) + `ECOSTRESS_L2G` (Earthdata-gated, irregular overpass `all_dates`); pure decode (`goes_lst`, `ecostress_lst`, `granule_timestamp`, `lst_masked_residual`); `LSTObservationOperator` scaffold for `H_LST`. This is a TRAINING TARGET, not a boundary field — wire into the loss, not radiation/flux slots. 37/37 assertions pass. Full H_LST→loss wiring, live GOES/CMR discovery, and diurnal compositing are documented next steps.

## Verification status (please read)

**End-to-end download + load is NOT verified.** The real granule read requires NASA Earthdata credentials, network access, and an HDF4/HDF5-enabled `GDAL_jll` build — none available in the dev environment. This mirrors how `CopernicusDEM` (the template) is handled: its read path is "verified manually / in a token-gated job," not in CI.

**What IS verified (run, not claimed):**
- `Pkg.instantiate()` + `using NumericalEarth` precompiles clean; the module registers in `DataWrangling.jl` and `NumericalEarth.jl`.
- The pure decode/mask/blend/aggregate logic passes synthetic-array unit tests.
- The dataset interface (metadata, sizes, interfaces, `validate_dataset_coverage` requiring a `BoundingBox`, region-encoded filenames) is exercised, and gated reads error cleanly.

**Test convention:** interface + synthetic tests are autodiscovered `test/test_*.jl` (CI-safe, no network) — matching `test_copernicus_dem.jl`. **No `test_*_downloading.jl` integration test yet** (needs credentials) — documented follow-up.

**No root `Project.toml` deps changed** (per AGENTS.md rule 10); HDF reads route through the existing ArchGDAL extension, gated with fallback errors.

⚠️ Draft: physics core is solid; the download/reproject/read path is written-to-spec but unproven against live hosts.