### PR TITLE
Add Copernicus Global Land surface albedo dataset

### DIFF
--- a/docs/src/Metadata/metadata_overview.md
+++ b/docs/src/Metadata/metadata_overview.md
@@ -207,4 +207,6 @@ NumericalEarth currently ships connectors for the following data products:
 | `OSPapaFluxHourly` | air-sea fluxes, stresses, evaporation, precipitation, and skin temperature | [Ocean Station Papa flux dataset](https://www.pmel.noaa.gov/ocs/Papa) |
 | **Land** |                                                    |                                                                                                     |
 | `SoilGrids 2.0`     | Global profiles of soil texture, bulk density, and organic content in upper 2 meters  | [SoilGrids documentation](https://docs.isric.org/globaldata/soilgrids/)                                   |
+| `CopernicusAlbedo` | `:albedo` — dekadal blue-sky broadband surface albedo on the global 1 km CGLS grid | [CGLS Surface Albedo](https://land.copernicus.eu/en/products/albedo) |
+| `CopernicusAlbedoClimatology` | `:albedo` — 12-month climatology of the CGLS blue-sky broadband albedo | [CGLS Surface Albedo](https://land.copernicus.eu/en/products/albedo) |
 

--- a/docs/src/Metadata/metadata_overview.md
+++ b/docs/src/Metadata/metadata_overview.md
@@ -207,6 +207,6 @@ NumericalEarth currently ships connectors for the following data products:
 | `OSPapaFluxHourly` | air-sea fluxes, stresses, evaporation, precipitation, and skin temperature | [Ocean Station Papa flux dataset](https://www.pmel.noaa.gov/ocs/Papa) |
 | **Land** |                                                    |                                                                                                     |
 | `SoilGrids 2.0`     | Global profiles of soil texture, bulk density, and organic content in upper 2 meters  | [SoilGrids documentation](https://docs.isric.org/globaldata/soilgrids/)                                   |
-| `CopernicusAlbedo` | `:albedo` — dekadal blue-sky broadband surface albedo on the global 1 km CGLS grid | [CGLS Surface Albedo](https://land.copernicus.eu/en/products/albedo) |
-| `CopernicusAlbedoClimatology` | `:albedo` — 12-month climatology of the CGLS blue-sky broadband albedo | [CGLS Surface Albedo](https://land.copernicus.eu/en/products/albedo) |
+| `CopernicusAlbedo` | `:albedo` — dekadal blue-sky broadband surface albedo on the global 1 km CGLS grid | [CGLS Surface Albedo](https://cds.climate.copernicus.eu/datasets/satellite-albedo) |
+| `CopernicusAlbedoClimatology` | `:albedo` — 12-month climatology of the CGLS blue-sky broadband albedo | [CGLS Surface Albedo](https://cds.climate.copernicus.eu/datasets/satellite-albedo) |
 

--- a/ext/NumericalEarthCDSAPIExt.jl
+++ b/ext/NumericalEarthCDSAPIExt.jl
@@ -18,6 +18,12 @@ using NumericalEarth.DataWrangling.ERA5: ERA5Dataset, ERA5Metadata, ERA5Metadatu
                                          ERA5PL_dataset_variable_names, ERA5PL_netcdf_variable_names
 using NumericalEarth.DataWrangling.GloFAS: GloFASDataset, GloFASMetadata, GloFASMetadatum,
                                            GloFAS_netcdf_variable_names
+using NumericalEarth.DataWrangling.CopernicusLandAlbedo: CopernicusAlbedo,
+                                                         albedo_cds_request_variables,
+                                                         albedo_source_variable_candidates,
+                                                         copernicus_albedo_variables,
+                                                         albedo_satellite, find_albedo_variable,
+                                                         repack_albedo_pair
 
 #####
 ##### Dispatch helpers — encapsulate single-level vs pressure-level differences
@@ -870,6 +876,137 @@ function download_glofas_month(name, dataset, dates; region, dir, skip_existing,
     end
 
     return map(dt_path -> dt_path[2], dt_path_pairs)
+end
+
+#####
+##### Copernicus land surface albedo (C3S `satellite-albedo` catalogue entry)
+#####
+##### One CDS request per calendar month fetches the black-sky (`albb_dh`) and
+##### white-sky (`albb_bh`) products for all of that month's dekads; each dekad's
+##### pair is repacked into one compact local file by the CopernicusLandAlbedo module.
+#####
+
+const ALBEDO_CDS_PRODUCT = "satellite-albedo"
+
+const AlbedoMetadata = NumericalEarth.DataWrangling.Metadata{<:CopernicusAlbedo}
+
+"""
+    build_albedo_request(name, dates) -> Dict{String, Any}
+
+Construct the CDS request for the 1 km v2 black-sky/white-sky albedo pair covering
+`dates`, which must share a `(year, month)` (CDS interprets `year`/`month`/
+`nominal_day` as a Cartesian product, and the valid nominal days differ by month).
+"""
+function build_albedo_request(name, dates)
+    dts = dates isa AbstractVector ? dates : [dates]
+
+    years  = unique(string.(Dates.year.(dts)))
+    months = unique(lpad.(string.(Dates.month.(dts)), 2, '0'))
+    days   = unique(lpad.(string.(Dates.day.(dts)), 2, '0'))
+    satellites = unique([albedo_satellite(dt) for dt in dts])
+
+    return Dict{String, Any}(
+        "variable"              => collect(albedo_cds_request_variables[name]),
+        "satellite"             => satellites,
+        "sensor"                => ["vgt"],
+        "product_version"       => ["v2"],
+        "horizontal_resolution" => ["1km"],
+        "year"                  => years,
+        "month"                 => months,
+        "nominal_day"           => days,
+    )
+end
+
+# The delivery is either a ZIP of per-variable NetCDF files or a single NetCDF.
+function extract_albedo_files(download_path, extraction_dir)
+    if is_zip(download_path)
+        run(`unzip -qo $download_path -d $extraction_dir`)
+    else
+        cp(download_path, joinpath(extraction_dir, "albedo.nc"); force=true)
+    end
+    return filter(p -> endswith(p, ".nc"), readdir(extraction_dir; join=true))
+end
+
+# The dekad a delivered file belongs to, from its time coordinate (authoritative)
+# or the timestamp in its filename.
+function albedo_file_date(path)
+    date = NCDatasets.Dataset(path) do ds
+        haskey(ds, "time") || return nothing
+        t = ds["time"][1]
+        return Dates.DateTime(Dates.year(t), Dates.month(t), Dates.day(t))
+    end
+    isnothing(date) || return date
+
+    stamp = match(r"_(\d{8})\d{0,6}_", basename(path))
+    isnothing(stamp) &&
+        error("Cannot determine the date of the delivered albedo file $(basename(path)).")
+    return Dates.DateTime(stamp[1], Dates.dateformat"yyyymmdd")
+end
+
+function repack_albedo_batch(nc_files, batch, path_of, destination_names, expected_size)
+    members = Dict{Dates.DateTime, Dict{Symbol, Tuple{String, String}}}()
+    for path in nc_files
+        date = albedo_file_date(path)
+        entry = get!(members, date, Dict{Symbol, Tuple{String, String}}())
+        blacksky_name = find_albedo_variable(path, albedo_source_variable_candidates.blacksky)
+        whitesky_name = find_albedo_variable(path, albedo_source_variable_candidates.whitesky)
+        isnothing(blacksky_name) || (entry[:blacksky] = (path, blacksky_name))
+        isnothing(whitesky_name) || (entry[:whitesky] = (path, whitesky_name))
+    end
+
+    for date in batch
+        entry = get(members, date, nothing)
+        if isnothing(entry) || !haskey(entry, :blacksky) || !haskey(entry, :whitesky)
+            error("The CDS delivery is missing the black-sky/white-sky albedo pair for $date; ",
+                  "it contained dates $(sort!(collect(keys(members)))).")
+        end
+        repack_albedo_pair(entry[:blacksky], entry[:whitesky], destination_names,
+                           path_of[date], expected_size)
+    end
+    return nothing
+end
+
+"""
+    download(metadata::Metadata{<:CopernicusAlbedo}; skip_existing=true, cleanup=true)
+
+Download the dekadal black-sky and white-sky broadband albedo for every date of
+`metadata` from the C3S `satellite-albedo` catalogue entry, one CDS request per
+calendar month, and repack each dekad's pair into a single compact local NetCDF.
+Requires `~/.cdsapirc` credentials and acceptance of the Copernicus Global Land
+product licence on the CDS portal.
+"""
+function Downloads.download(metadata::AlbedoMetadata; skip_existing=true, cleanup=true)
+    meta_filename = NumericalEarth.DataWrangling.metadata_filename
+    dates = metadata.dates isa AbstractVector ? metadata.dates : [metadata.dates]
+    dir = metadata.dir
+    mkpath(dir)
+
+    dt_path_pairs = [(dt, joinpath(dir, meta_filename(metadata.dataset, metadata.name, dt, metadata.region)))
+                     for dt in dates]
+    pending = skip_existing ? filter(dt_path -> !isfile(dt_path[2]), dt_path_pairs) : dt_path_pairs
+    isempty(pending) && return metadata_path(metadata)
+
+    expected_size = size(metadata.dataset, metadata.name)[1:2]
+    destination_names = copernicus_albedo_variables[metadata.name]
+    path_of = Dict(dt => path for (dt, path) in pending)
+    monthly = group_by_calendar_month([dt for (dt, _) in pending])
+
+    @root for key in sort(collect(keys(monthly)))
+        batch = sort(unique(monthly[key]))
+        request = build_albedo_request(metadata.name, batch)
+        tmp_download = joinpath(dir, "_tmp_albedo_$(key[1])$(lpad(key[2], 2, '0')).download")
+        extraction_dir = mktempdir(dir)
+        try
+            CDSAPI.retrieve(ALBEDO_CDS_PRODUCT, request, tmp_download)
+            nc_files = extract_albedo_files(tmp_download, extraction_dir)
+            repack_albedo_batch(nc_files, batch, path_of, destination_names, expected_size)
+        finally
+            cleanup && rm(tmp_download; force=true)
+            rm(extraction_dir; recursive=true, force=true)
+        end
+    end
+
+    return metadata_path(metadata)
 end
 
 end # module NumericalEarthCDSAPIExt

--- a/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
+++ b/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
@@ -1,0 +1,405 @@
+module CopernicusLandAlbedo
+
+export CopernicusAlbedo, CopernicusAlbedoClimatology, build_monthly_climatology!
+
+using Dates: Dates, DateTime, Month, year, month, daysinmonth
+using Downloads: Downloads
+using NCDatasets: NCDataset, defVar, nomissing
+using Oceananigans.DistributedComputations: @root
+
+using ..DataWrangling: DataWrangling, Metadata, Metadatum,
+                       metadata_path, default_download_directory
+
+download_CopernicusLandAlbedo_cache::String = ""
+function __init__()
+    global download_CopernicusLandAlbedo_cache = DataWrangling.download_cache("CopernicusLandAlbedo")
+    return nothing
+end
+
+#####
+##### Decode / blend helpers
+#####
+
+"""
+    bluesky_blend(α_bs, α_ws, f)
+
+Blend the black-sky (directional-hemispherical) albedo `α_bs` and the white-sky
+(bi-hemispherical) albedo `α_ws` into the blue-sky (actual) albedo, with `f` the
+diffuse fraction of the downwelling shortwave radiation:
+
+```math
+α = (1 - f) α_bs + f α_ws
+```
+"""
+@inline bluesky_blend(α_bs, α_ws, f) = (1 - f) * α_bs + f * α_ws
+
+# Missing (the decoded fill value) and out-of-range values map to NaN; albedo ∈ [0, 1].
+@inline decode_albedo(α::Number) = ifelse((α < 0) | (α > 1), NaN32, Float32(α))
+@inline decode_albedo(::Missing) = NaN32
+
+#####
+##### Dataset types
+#####
+
+abstract type AbstractCopernicusAlbedo end
+
+"""
+    CopernicusAlbedo(; diffuse_fraction = 0.2)
+
+The Copernicus Global Land Service (CGLS) 1 km surface-albedo dataset, a dekadal
+(10-daily) time series derived from SPOT/VGT and PROBA-V observations. Provides
+`:albedo`, the broadband blue-sky albedo blended from the black-sky (`AL_DH_BB`)
+and white-sky (`AL_BH_BB`) broadband albedos with diffuse fraction `diffuse_fraction`.
+
+Files are global on a regular 1/112° latitude-longitude grid; build the `Metadata`
+with a lon/lat [`BoundingBox`](@ref) to window a region at read time. Downloads come
+from the C3S `satellite-albedo` catalogue entry and require the CDSAPI backend:
+`using CDSAPI` with `~/.cdsapirc` credentials, the same setup as ERA5 (see this
+module's README).
+
+```jldoctest
+julia> using NumericalEarth
+
+julia> CopernicusAlbedo()
+CopernicusAlbedo{Float64}(0.2)
+```
+"""
+struct CopernicusAlbedo{FT} <: AbstractCopernicusAlbedo
+    diffuse_fraction :: FT
+end
+
+CopernicusAlbedo(; diffuse_fraction = 0.2) = CopernicusAlbedo(diffuse_fraction)
+
+"""
+    CopernicusAlbedoClimatology(; diffuse_fraction = 0.2, years = 2019:2019)
+
+A 12-month climatology of the [`CopernicusAlbedo`](@ref) blue-sky broadband albedo,
+built by averaging all dekadal files of `years` month by month (NaN-aware, per pixel).
+The monthly-mean files are generated on demand by [`build_monthly_climatology!`](@ref)
+(triggered automatically on download) and yield a 12-slot `FieldTimeSeries` with
+`Cyclical()` time indexing.
+
+```jldoctest
+julia> using NumericalEarth
+
+julia> CopernicusAlbedoClimatology()
+CopernicusAlbedoClimatology{Float64, UnitRange{Int64}}(0.2, 2019:2019)
+```
+"""
+struct CopernicusAlbedoClimatology{FT, Y} <: AbstractCopernicusAlbedo
+    diffuse_fraction :: FT
+    years :: Y
+end
+
+CopernicusAlbedoClimatology(; diffuse_fraction = 0.2, years = 2019:2019) =
+    CopernicusAlbedoClimatology(diffuse_fraction, years)
+
+const CopernicusAlbedoMetadata{D} = Metadata{<:AbstractCopernicusAlbedo, D}
+const CopernicusAlbedoMetadatum   = Metadatum{<:AbstractCopernicusAlbedo}
+
+#####
+##### Variables
+#####
+
+# Black-sky / white-sky broadband pair: the variable names in the local files, the
+# names requested from the CDS, and the (variant) names the CDS delivery may use.
+const copernicus_albedo_variables = Dict(:albedo => ("AL_DH_BB", "AL_BH_BB"))
+const albedo_cds_request_variables = Dict(:albedo => ("albb_dh", "albb_bh"))
+const albedo_source_variable_candidates = (blacksky = ("AL_DH_BB", "ALBB_DH", "albb_dh", "AL_DH"),
+                                           whitesky = ("AL_BH_BB", "ALBB_BH", "albb_bh", "AL_BH"))
+
+DataWrangling.available_variables(::AbstractCopernicusAlbedo) = copernicus_albedo_variables
+
+# The black-sky member stands in for the pair; the blue-sky blend reads both.
+DataWrangling.dataset_variable_name(metadata::CopernicusAlbedoMetadata) =
+    first(copernicus_albedo_variables[metadata.name])
+
+#####
+##### Grid traits
+#####
+
+# Global 1/112° grid: 360° of longitude, latitude 80°N to 60°S, stored north→south.
+Base.size(::AbstractCopernicusAlbedo, variable) = (40320, 15680, 1)
+
+DataWrangling.is_three_dimensional(::CopernicusAlbedoMetadata) = false
+DataWrangling.reversed_latitude_axis(::AbstractCopernicusAlbedo) = true
+DataWrangling.longitude_name(::CopernicusAlbedoMetadata) = "lon"
+DataWrangling.latitude_name(::CopernicusAlbedoMetadata)  = "lat"
+DataWrangling.default_inpainting(::CopernicusAlbedoMetadata) = nothing
+DataWrangling.default_download_directory(::AbstractCopernicusAlbedo) = download_CopernicusLandAlbedo_cache
+
+# Recover grid interfaces from the pixel-center coordinates in the file, so the native
+# grid matches the file's half-pixel registration exactly.
+function albedo_native_interfaces(path)
+    NCDataset(path) do ds
+        λ = Float64.(ds["lon"][:])
+        φ = Float64.(ds["lat"][:])
+        Δλ = (λ[end] - λ[1]) / (length(λ) - 1)
+        Δφ = (φ[end] - φ[1]) / (length(φ) - 1)
+        longitude = (λ[1] - Δλ / 2, λ[end] + Δλ / 2)
+        latitude = extrema((φ[1] - Δφ / 2, φ[end] + Δφ / 2))
+        return longitude, latitude
+    end
+end
+
+DataWrangling.longitude_interfaces(metadata::CopernicusAlbedoMetadata) =
+    first(albedo_native_interfaces(metadata_path(first(metadata))))
+
+DataWrangling.latitude_interfaces(metadata::CopernicusAlbedoMetadata) =
+    last(albedo_native_interfaces(metadata_path(first(metadata))))
+
+#####
+##### Dates
+#####
+
+# CGLS dekads are stamped on day 10, day 20, and the last day of each month.
+function dekadal_dates(start_date, end_date)
+    dates = DateTime[]
+    d = DateTime(year(start_date), month(start_date), 1)
+    while d ≤ end_date
+        for day in (10, 20, daysinmonth(d))
+            t = DateTime(year(d), month(d), day)
+            start_date ≤ t ≤ end_date && push!(dates, t)
+        end
+        d += Month(1)
+    end
+    return dates
+end
+
+# C3S coverage of the 1 km v2 collection: SPOT/VGT from April 1998, PROBA-V until
+# June 2020 (verified against the `satellite-albedo` request constraints).
+const first_albedo_date = DateTime(1998, 4, 10)
+const last_albedo_date  = DateTime(2020, 6, 30)
+
+# SPOT ends May 2014; PROBA-V takes over from June 2014.
+albedo_satellite(date) = date < DateTime(2014, 6, 1) ? "spot" : "proba"
+
+DataWrangling.all_dates(::CopernicusAlbedo, variable) = dekadal_dates(first_albedo_date, last_albedo_date)
+
+# 12 climatological months; the year is arbitrary, only the month matters.
+DataWrangling.all_dates(::CopernicusAlbedoClimatology, variable) = [DateTime(2018, m, 1) for m in 1:12]
+
+#####
+##### Filenames (date + variable keyed, region-independent — reused across regions)
+#####
+
+date_tag(date) = Dates.format(DateTime(date), "yyyymmdd")
+years_tag(years) = string(first(years), "-", last(years))
+
+DataWrangling.metadata_filename(::CopernicusAlbedo, name, date, region) =
+    string("CGLS_1km_", name, "_", date_tag(date), ".nc")
+
+DataWrangling.metadata_filename(dataset::CopernicusAlbedoClimatology, name, date, region) =
+    string("CGLS_1km_", name, "_climatology_", years_tag(dataset.years),
+           "_m", lpad(month(date), 2, '0'), ".nc")
+
+#####
+##### Download
+#####
+##### The dekadal-file download lives in `ext/NumericalEarthCDSAPIExt.jl` (needs
+##### `using CDSAPI`); it fetches the source pair and calls `repack_albedo_pair` below.
+##### Everything here is CDS-free: repacking, climatology download, and reading.
+#####
+
+function Downloads.download(metadata::Metadata{<:CopernicusAlbedoClimatology})
+    @root for metadatum in metadata
+        m = month(metadatum.dates)
+        build_monthly_climatology!(metadatum.dataset; name = metadatum.name,
+                                   months = m:m, dir = metadatum.dir)
+    end
+    return metadata_path(metadata)
+end
+
+# Locate the albedo variable in a C3S-delivered file, tolerating naming variants.
+function find_albedo_variable(path, candidates)
+    NCDataset(path) do source
+        for candidate in candidates
+            haskey(source, candidate) && return candidate
+        end
+        return nothing
+    end
+end
+
+# Copy the packed integers and their CF attributes verbatim (the `.var` accessor
+# skips scale/offset decoding), keeping the compact on-disk representation.
+function copy_packed_variable!(destination, source, source_name, destination_name)
+    variable = source[source_name].var
+    raw = ndims(variable) == 3 ? variable[:, :, 1] : variable[:, :]
+
+    attributes = Dict{String, Any}()
+    for key in ("scale_factor", "add_offset", "long_name", "units")
+        haskey(source[source_name].attrib, key) && (attributes[key] = source[source_name].attrib[key])
+    end
+    fill_value = get(source[source_name].attrib, "_FillValue", nothing)
+
+    packed = if isnothing(fill_value)
+        defVar(destination, destination_name, eltype(raw), ("lon", "lat");
+               attrib = attributes, deflatelevel = 2, shuffle = true)
+    else
+        defVar(destination, destination_name, eltype(raw), ("lon", "lat");
+               attrib = attributes, fillvalue = fill_value,
+               deflatelevel = 2, shuffle = true)
+    end
+    packed.var[:, :] = raw
+    return nothing
+end
+
+"""
+    repack_albedo_pair(blacksky, whitesky, destination_names, filepath, expected_size)
+
+Repack the broadband albedo bands from a downloaded black-sky/white-sky product pair
+into one compact local NetCDF at `filepath`. `blacksky` and `whitesky` are
+`(path, name)` tuples locating each source file and its albedo variable;
+`destination_names` are the canonical local names (`AL_DH_BB`, `AL_BH_BB`). The packed
+integer representation, CF decoding attributes, and north→south latitude order of the
+source are preserved.
+"""
+function repack_albedo_pair(blacksky, whitesky, destination_names, filepath, expected_size)
+    blacksky_path, blacksky_name = blacksky
+    whitesky_path, whitesky_name = whitesky
+    staging_path = filepath * ".tmp"
+
+    NCDataset(staging_path, "c") do destination
+        NCDataset(blacksky_path) do source
+            λ = nomissing(source[coordinate_name(source, ("lon", "longitude"))][:])
+            φ = nomissing(source[coordinate_name(source, ("lat", "latitude"))][:])
+            (length(λ), length(φ)) == expected_size ||
+                error("CGLS albedo file grid $((length(λ), length(φ))) does not match ",
+                      "the expected $expected_size; the dataset traits need updating.")
+            defVar(destination, "lon", λ, ("lon",))
+            defVar(destination, "lat", φ, ("lat",))
+            copy_packed_variable!(destination, source, blacksky_name, destination_names[1])
+        end
+        NCDataset(whitesky_path) do source
+            copy_packed_variable!(destination, source, whitesky_name, destination_names[2])
+        end
+    end
+
+    mv(staging_path, filepath; force = true)
+    return nothing
+end
+
+function coordinate_name(source, candidates)
+    for candidate in candidates
+        haskey(source, candidate) && return candidate
+    end
+    error("None of the coordinate names $candidates found in the source file; ",
+          "available variables: $(keys(source)).")
+end
+
+#####
+##### Reading — blend the black-sky/white-sky pair into the global blue-sky array.
+#####
+
+function DataWrangling.retrieve_data(metadatum::CopernicusAlbedoMetadatum)
+    path = metadata_path(metadatum)
+    blacksky_name, whitesky_name = copernicus_albedo_variables[metadatum.name]
+    f = Float32(metadatum.dataset.diffuse_fraction)
+
+    α = NCDataset(path) do ds
+        Nx = ds.dim["lon"]
+        Ny = ds.dim["lat"]
+        blended = Array{Float32}(undef, Nx, Ny)
+        # Read in latitude bands to cap the transient decoded (Union{Missing, Float64})
+        # array; the full 632M-pixel grid decoded at once is ~5 GB.
+        chunk = 1120
+        for j in 1:chunk:Ny
+            rows = j:min(j + chunk - 1, Ny)
+            α_bs = decode_albedo.(ds[blacksky_name][:, rows])
+            α_ws = decode_albedo.(ds[whitesky_name][:, rows])
+            @. blended[:, rows] = bluesky_blend(α_bs, α_ws, f)
+        end
+        blended
+    end
+
+    # Files store latitude north→south; flip to south→north to match the grid.
+    α = reverse(α, dims = 2)
+    return reshape(α, size(α, 1), size(α, 2), 1)
+end
+
+#####
+##### Monthly climatology builder
+#####
+
+"""
+    build_monthly_climatology!(dataset::CopernicusAlbedoClimatology;
+                               name = :albedo,
+                               months = 1:12,
+                               dir = default_download_directory(dataset),
+                               latitude_chunk = 1120)
+
+For each calendar month in `months`, download every dekadal albedo file of
+`dataset.years` falling in that month, average the black-sky and white-sky
+broadband albedos pixel by pixel (NaN-aware: pixels missing in a dekad are
+excluded from its mean), and write one monthly-mean NetCDF to `dir` under the
+name computed by `metadata_filename`. Months whose file already exists are
+skipped. Returns the paths of the 12 (or `length(months)`) monthly files.
+"""
+function build_monthly_climatology!(dataset::CopernicusAlbedoClimatology;
+                                    name = :albedo,
+                                    months = 1:12,
+                                    dir = default_download_directory(dataset),
+                                    latitude_chunk = 1120)
+
+    raw_dataset = CopernicusAlbedo(diffuse_fraction = dataset.diffuse_fraction)
+    dekads = DataWrangling.all_dates(raw_dataset, name)
+    variable_names = copernicus_albedo_variables[name]
+    paths = String[]
+
+    for m in months
+        filepath = joinpath(dir, DataWrangling.metadata_filename(dataset, name, DateTime(2018, m, 1), nothing))
+        push!(paths, filepath)
+        isfile(filepath) && continue
+
+        dates = [d for d in dekads if month(d) == m && year(d) in dataset.years]
+        isempty(dates) && error("No CGLS albedo dekads fall in month $m of years $(dataset.years).")
+
+        metadata = Metadata(name; dataset = raw_dataset, dates, dir)
+        Downloads.download(metadata)
+        source_paths = metadata_path(metadata)
+
+        @info "Averaging $(length(source_paths)) dekads into month $m of the CGLS albedo climatology..."
+        write_monthly_mean(filepath, source_paths, variable_names, latitude_chunk)
+    end
+
+    return paths
+end
+
+function write_monthly_mean(filepath, source_paths, variable_names, latitude_chunk)
+    λ, φ = NCDataset(first(source_paths)) do ds
+        nomissing(ds["lon"][:]), nomissing(ds["lat"][:])
+    end
+    Nx, Ny = length(λ), length(φ)
+    staging_path = filepath * ".tmp"
+
+    NCDataset(staging_path, "c") do destination
+        defVar(destination, "lon", λ, ("lon",))
+        defVar(destination, "lat", φ, ("lat",))
+
+        for name in variable_names
+            monthly_mean = defVar(destination, name, Float32, ("lon", "lat");
+                                  deflatelevel = 2, shuffle = true)
+
+            for j in 1:latitude_chunk:Ny
+                rows = j:min(j + latitude_chunk - 1, Ny)
+                Σα = zeros(Float32, Nx, length(rows))
+                n = zeros(Int32, Nx, length(rows))
+
+                for path in source_paths
+                    NCDataset(path) do ds
+                        α = decode_albedo.(ds[name][:, rows])
+                        @. Σα += ifelse(isnan(α), 0f0, α)
+                        @. n += !isnan(α)
+                    end
+                end
+
+                monthly_mean[:, rows] = @. ifelse(n == 0, NaN32, Σα / n)
+            end
+        end
+    end
+
+    mv(staging_path, filepath; force = true)
+    return nothing
+end
+
+end # module CopernicusLandAlbedo

--- a/src/DataWrangling/CopernicusLandAlbedo/README.md
+++ b/src/DataWrangling/CopernicusLandAlbedo/README.md
@@ -1,0 +1,59 @@
+# Copernicus Global Land Surface Albedo
+
+This module ingests the Copernicus Global Land Service (CGLS) 1 km surface-albedo
+collection (version 2): dekadal (10-daily) global NetCDF files on a regular 1/112°
+latitude-longitude grid spanning 80°N–60°S, derived from SPOT/VGT (1998–2014) and
+PROBA-V (2014–2020) observations.
+
+The files are downloaded from the Copernicus Climate Data Store's
+[`satellite-albedo`](https://cds.climate.copernicus.eu/datasets/satellite-albedo)
+catalogue entry (the C3S redistribution of the CGLS product — the legacy VITO
+distribution server was retired when CLMS data moved to the Copernicus Data Space
+Ecosystem in September 2025, and the 1 km albedo archive is not served there).
+
+## Credentials
+
+Downloads go through the CDS API, the same setup as ERA5:
+
+1. Create an account at https://cds.climate.copernicus.eu
+2. Put your API key in `~/.cdsapirc` (see https://cds.climate.copernicus.eu/how-to-api)
+3. Accept the *Copernicus Global Land product licence* on the dataset page
+4. Load the backend before downloading: `using CDSAPI`
+
+## What gets stored locally
+
+For each dekad, the extension downloads the black-sky (`albb_dh`,
+directional-hemispherical) and white-sky (`albb_bh`, bi-hemispherical) broadband
+products — one CDS request per calendar month — and repacks the pair into a single
+compact local NetCDF (variables `AL_DH_BB` and `AL_BH_BB`, packed integers with CF
+attributes preserved). The blue-sky (actual) albedo is blended at read time with the
+dataset's `diffuse_fraction` `f`:
+
+    α = (1 − f) α_bs + f α_ws
+
+## Usage
+
+```julia
+using NumericalEarth
+using CDSAPI
+using Dates
+
+# Single dekad over a region
+region = BoundingBox(longitude = (-114, -111), latitude = (35, 37))
+metadatum = Metadatum(:albedo; dataset = CopernicusAlbedo(), region, date = DateTime(2019, 7, 10))
+α = Field(metadatum)
+
+# 12-month climatology FieldTimeSeries (builds monthly means on first use)
+metadata = Metadata(:albedo; dataset = CopernicusAlbedoClimatology(years = 2019:2019), region)
+albedo_climatology = FieldTimeSeries(metadata)
+```
+
+`build_monthly_climatology!(dataset)` precomputes the monthly-mean files explicitly
+(useful to control when the dekadal downloads happen); months are cached and skipped
+on rebuild.
+
+## Notes
+
+- Ocean and unretrieved pixels are `NaN` (no inpainting by default — this is a land dataset).
+- Downloads are global and shared across regions; regional windowing happens at read
+  time via the `BoundingBox` machinery.

--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -361,6 +361,7 @@ include("IBCSO/IBCSO.jl")
 include("GEBCO/GEBCO.jl")
 include("IBCAO/IBCAO.jl")
 include("CopernicusDEM/CopernicusDEM.jl")
+include("CopernicusLandAlbedo/CopernicusLandAlbedo.jl")
 
 using .ETOPO
 using .ECCO
@@ -376,6 +377,7 @@ using .IBCSO
 using .GEBCO
 using .IBCAO
 using .CopernicusDEM
+using .CopernicusLandAlbedo
 
 function dataset_modules()
     modules = Module[]

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -102,6 +102,7 @@ export
     ECCO2DarwinMonthly, ECCO4DarwinMonthly,
     EN4Monthly,
     WOAClimatology, WOAAnnual, WOAMonthly,
+    CopernicusAlbedo, CopernicusAlbedoClimatology, build_monthly_climatology!,
     GLORYSDaily, GLORYSMonthly, GLORYSStatic,
     RepeatYearJRA55, MultiYearJRA55,
     ERA5HourlySingleLevel, ERA5MonthlySingleLevel,
@@ -207,6 +208,7 @@ using .DataWrangling.GloFAS
 using .DataWrangling.OSPapa
 using .DataWrangling.ERA5
 using .DataWrangling.SoilGrids
+using .DataWrangling.CopernicusLandAlbedo
 
 using PrecompileTools: @setup_workload, @compile_workload
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ if filter_tests!(testsuite, args)
     delete!(testsuite, "test_cds_downloading")
     delete!(testsuite, "test_glorys_downloading")
     delete!(testsuite, "test_copernicus_dem_downloading")
+    delete!(testsuite, "test_copernicus_albedo_downloading")
     delete!(testsuite, "test_distributed_utils")
     delete!(testsuite, "test_reactant")
     delete!(testsuite, "test_veros") # Veros seems to have introduce a pypi conflict issue; temporarily removing from CI

--- a/test/test_copernicus_albedo.jl
+++ b/test/test_copernicus_albedo.jl
@@ -1,0 +1,80 @@
+include("runtests_setup.jl")
+
+using NumericalEarth.DataWrangling: BoundingBox, Metadatum,
+                                    is_three_dimensional, default_inpainting,
+                                    dataset_variable_name, metadata_filename,
+                                    longitude_name, latitude_name, all_dates
+using NumericalEarth.DataWrangling.CopernicusLandAlbedo: bluesky_blend, decode_albedo,
+                                                         dekadal_dates, albedo_satellite,
+                                                         albedo_cds_request_variables
+using Dates: DateTime, Day, day, month, daysinmonth
+
+@testset "Copernicus land albedo helpers" begin
+    @test bluesky_blend(0.3, 0.5, 0.0) == 0.3
+    @test bluesky_blend(0.3, 0.5, 1.0) == 0.5
+    @test bluesky_blend(0.3, 0.5, 0.2) ≈ 0.34
+
+    @test decode_albedo(0.37) === 0.37f0
+    @test decode_albedo(0) === 0.0f0
+    @test decode_albedo(1) === 1.0f0
+    @test isnan(decode_albedo(-0.01))
+    @test isnan(decode_albedo(1.2))
+    @test isnan(decode_albedo(missing))
+    @test isnan(decode_albedo(NaN32))
+    @test isnan(bluesky_blend(decode_albedo(missing), 0.5f0, 0.2f0))
+end
+
+@testset "Copernicus land albedo dekadal dates" begin
+    dates = dekadal_dates(DateTime(2019, 1, 10), DateTime(2019, 12, 31))
+    @test length(dates) == 36
+    @test issorted(dates)
+    @test all(d -> day(d) in (10, 20, daysinmonth(d)), dates)
+    @test DateTime(2019, 2, 28) in dates
+    @test DateTime(2019, 7, 31) in dates
+
+    dates = all_dates(CopernicusAlbedo(), :albedo)
+    @test first(dates) == DateTime(1998, 4, 10)
+    @test last(dates) == DateTime(2020, 6, 30)
+    @test issorted(dates)
+
+    # SPOT covers the record until May 2014; PROBA-V takes over from June 2014.
+    @test albedo_satellite(DateTime(2005, 7, 10)) == "spot"
+    @test albedo_satellite(DateTime(2014, 5, 31)) == "spot"
+    @test albedo_satellite(DateTime(2014, 6, 10)) == "proba"
+    @test albedo_satellite(DateTime(2019, 7, 10)) == "proba"
+
+    climatology_dates = all_dates(CopernicusAlbedoClimatology(), :albedo)
+    @test length(climatology_dates) == 12
+    @test month.(climatology_dates) == 1:12
+end
+
+@testset "Copernicus land albedo interface" begin
+    dataset = CopernicusAlbedo(diffuse_fraction = 0.3)
+    @test dataset.diffuse_fraction == 0.3
+    @test size(dataset, :albedo) == (40320, 15680, 1)
+
+    date = DateTime(2019, 7, 10)
+    metadatum = Metadatum(:albedo; dataset, date)
+    @test !is_three_dimensional(metadatum)
+    @test isnothing(default_inpainting(metadatum))
+    @test dataset_variable_name(metadatum) == "AL_DH_BB"
+    @test longitude_name(metadatum) == "lon"
+    @test latitude_name(metadatum) == "lat"
+    @test location(metadatum) == (Center, Center, Center)
+    @test albedo_cds_request_variables[:albedo] == ("albb_dh", "albb_bh")
+
+    # Filenames are keyed by date and variable but not by region, so one global
+    # download is reused across regions.
+    region = BoundingBox(longitude = (-10, 10), latitude = (30, 50))
+    @test metadata_filename(dataset, :albedo, date, region) ==
+          metadata_filename(dataset, :albedo, date, nothing)
+    @test metadata_filename(dataset, :albedo, date, region) !=
+          metadata_filename(dataset, :albedo, date + Day(10), region)
+
+    climatology = CopernicusAlbedoClimatology(years = 2018:2019)
+    january = metadata_filename(climatology, :albedo, DateTime(2018, 1, 1), nothing)
+    july = metadata_filename(climatology, :albedo, DateTime(2018, 7, 1), nothing)
+    @test january != july
+    @test occursin("2018-2019", january)
+    @test occursin("m07", july)
+end

--- a/test/test_copernicus_albedo_downloading.jl
+++ b/test/test_copernicus_albedo_downloading.jl
@@ -1,0 +1,25 @@
+include("runtests_setup.jl")
+
+using NumericalEarth.DataWrangling: BoundingBox, Metadatum
+using Oceananigans.Grids: topology, Bounded
+using Dates: DateTime
+
+# Network-gated: downloads two ~global CGLS files (hundreds of MB). Excluded from
+# the default suite in runtests.jl, mirroring the other *_downloading tests.
+@testset "Copernicus land albedo download and regional read" begin
+    dataset = CopernicusAlbedo()
+    region = BoundingBox(longitude = (-114, -109), latitude = (33, 38))
+    date = DateTime(2019, 7, 10)
+
+    metadatum = Metadatum(:albedo; dataset, region, date)
+    α = Field(metadatum)
+    values = Array(interior(α))
+
+    @test any(isfinite, values)
+    valid = filter(!isnan, vec(values))
+    @test !isempty(valid)
+    @test all(x -> 0 ≤ x ≤ 1, valid)
+
+    # Sub-360° window must be Bounded in x so halos do not wrap.
+    @test topology(α.grid)[1] == Bounded
+end


### PR DESCRIPTION
Adds the CGLS 1 km surface albedo as a `DataWrangling` dataset, for use as a surface-albedo boundary condition (e.g. ~100 m LES over small regions).

- **`CopernicusAlbedo`** — dekadal (10-daily) time series, 1998–2020. Reads return the blue-sky albedo `α = (1−f)·α_bs + f·α_ws`, blended from the black-sky/white-sky broadband pair at diffuse fraction `f`.
- **`CopernicusAlbedoClimatology`** — 12-month climatology (WOA-style, `Cyclical()`), with NaN-aware monthly means built on demand.

Downloads ride the existing CDSAPI extension via the C3S `satellite-albedo` catalogue entry (one batched request per month, repacked into one compact file per dekad) — no new dependency; `~/.cdsapirc` credentials as for ERA5. The regular lat/lon `BoundingBox` windowing path is reused unchanged.

Verified end-to-end on 2019: regional `Field`, dekadal and 12-slot climatology `FieldTimeSeries`, and a global monthly-mean animation. Offline helper/interface tests pass; the network-gated download test is excluded from CI like the other `*_downloading` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)