### PR TITLE
Match ERA5/GLOFAS CDS timesteps by valid_time, not request position

### DIFF
--- a/ext/NumericalEarthCDSAPIExt.jl
+++ b/ext/NumericalEarthCDSAPIExt.jl
@@ -311,7 +311,6 @@ function plan_era5_month(name, dataset, dates; region, dir, skip_existing)
     end
 
     sorted_dts = sort(unique([dt for (dt, _) in pending]))
-    dt_to_tidx = Dict(dt => i for (i, dt) in enumerate(sorted_dts))
 
     request = build_era5_request(name, dataset, sorted_dts; region)
 
@@ -322,7 +321,7 @@ function plan_era5_month(name, dataset, dates; region, dir, skip_existing)
 
     tmp_path   = joinpath(dir, "_tmp_$(year)$(month)$(day).nc")
     nc_varname = nc_varnames(dataset)[name]
-    nc_triples = [(nc_varname, dt_to_tidx[dt], path) for (dt, path) in pending]
+    nc_triples = [(nc_varname, dt, path) for (dt, path) in pending]
 
     return (; dt_path_pairs, pending, request, tmp_path, nc_triples)
 end
@@ -528,7 +527,6 @@ function plan_era5_multivar_month(names, dataset, dates; region, dir, skip_exist
 
     pending_names = unique(map(name_dt_path -> name_dt_path[1], pending))
     sorted_dts    = sort(unique(map(name_dt_path -> name_dt_path[2], pending)))
-    dt_to_tidx    = Dict(dt => i for (i, dt) in enumerate(sorted_dts))
 
     request = build_era5_request(pending_names, dataset, sorted_dts; region)
 
@@ -538,7 +536,7 @@ function plan_era5_multivar_month(names, dataset, dates; region, dir, skip_exist
     day   = lpad(string(Dates.day(dt0)),   2, '0')
 
     tmp_path   = joinpath(dir, "_tmp_multi_$(year)$(month)$(day).nc")
-    nc_triples = [(nc_varnames(dataset)[name], dt_to_tidx[dt], path)
+    nc_triples = [(nc_varnames(dataset)[name], dt, path)
                   for (name, dt, path) in pending]
 
     return (; name_dt_paths, pending, request, tmp_path, nc_triples)
@@ -601,15 +599,29 @@ end
     split_era5_nc_multistep(src_path, triples, coord_vars, time_dimnames)
 
 Split a multi-timestep NetCDF into individual per-variable, per-timestep files.
-`triples` is a vector of `(nc_varname, time_index, dst_path)`.
+`triples` is a vector of `(nc_varname, datetime, dst_path)`.
+
+Each `datetime`'s timestep is located by matching it against `src`'s time coordinate, NOT by its
+position in the request. CDS expands `day`/`time` into a Cartesian product, so a request whose
+datetimes span more than one day with differing hours (e.g. a window crossing midnight) comes back
+with extra, sorted timesteps that no longer line up positionally with the requested datetimes.
 """
-function split_era5_nc_multistep(src_path, nc_varname_tidx_path_triples, coord_vars, time_dimnames)
+function split_era5_nc_multistep(src_path, nc_varname_datetime_path_triples, coord_vars, time_dimnames)
     NCDatasets.Dataset(src_path, "r") do src
         src_varnames = Set(keys(src))
         unlimited = NCDatasets.unlimited(src)
 
-        for (nc_varname, tidx, dst_path) in nc_varname_tidx_path_triples
+        # Index this file's timesteps by their valid time (see the note above).
+        time_coord = "valid_time" in src_varnames ? "valid_time" :
+                     "time"       in src_varnames ? "time"       :
+                     error("split_era5_nc_multistep: no time coordinate variable in $src_path")
+        tidx_of = Dict(t => i for (i, t) in enumerate(src[time_coord][:]))
+
+        for (nc_varname, datetime, dst_path) in nc_varname_datetime_path_triples
             nc_varname in src_varnames || continue
+            haskey(tidx_of, datetime) ||
+                error("split_era5_nc_multistep: $datetime absent from $src_path")
+            tidx = tidx_of[datetime]
             NCDatasets.Dataset(dst_path, "c") do dst
                 for (dname, dlen) in src.dim
                     out_len = dname in time_dimnames ? 1 :
@@ -877,13 +889,12 @@ function download_glofas_month(name, dataset, dates; region, dir, skip_existing,
 
     mkpath(dir)
     sorted_dts = sort(unique([dt for (dt, _) in pending]))
-    dt_to_tidx = Dict(dt => i for (i, dt) in enumerate(sorted_dts))
     request = build_glofas_request(dataset, sorted_dts, region)
 
     dt0 = first(sorted_dts)
     tmp_path = joinpath(dir, "_tmp_glofas_$(Dates.year(dt0))$(lpad(Dates.month(dt0), 2, '0')).nc")
     nc_varname = GloFAS_netcdf_variable_names[name]
-    nc_triples = [(nc_varname, dt_to_tidx[dt], path) for (dt, path) in pending]
+    nc_triples = [(nc_varname, dt, path) for (dt, path) in pending]
 
     time_dimnames = Set(["time", "valid_time"])
     @root begin

--- a/test/test_cds_downloading.jl
+++ b/test/test_cds_downloading.jl
@@ -666,8 +666,8 @@ end
             @test length(plan.nc_triples) == 2
             # All triples carry the netcdf short name for :temperature on single-level
             @test all(t -> first(t) == "t2m", plan.nc_triples)
-            # tidx values map sorted_dts to 1-based indices
-            @test Set(t[2] for t in plan.nc_triples) == Set([1, 2])
+            # Triples carry the requested datetime; the timestep is resolved by valid_time at split time
+            @test Set(t[2] for t in plan.nc_triples) == Set([dt1, dt2])
         end
 
         @testset "partial coverage: pending narrows to missing datetime" begin
@@ -732,7 +732,7 @@ end
             @test length(plan.nc_triples) == 4
             # Pressure-level netcdf short names for the two variables
             @test Set(first.(plan.nc_triples)) == Set(["t", "u"])
-            @test Set(t[2] for t in plan.nc_triples) == Set([1, 2])
+            @test Set(t[2] for t in plan.nc_triples) == Set([dt1, dt2])
         end
 
         @testset "partial coverage: pending narrows variables, request reflects subset" begin
@@ -1134,6 +1134,50 @@ end
                     NCDatasets.Dataset(src_path, "r") do src
                         @test dst[vname].var[:, :, 1] == src[vname].var[:, :, tidx]
                     end
+                end
+            end
+        end
+    end
+
+    @testset "split_era5_nc_multistep selects timesteps by valid_time, not request position" begin
+        # Regression: CDS expands `day × time` into a Cartesian product, so a window that
+        # crosses midnight (e.g. requesting [day N 23:00, day N+1 00:00]) comes back with
+        # extra, sorted timesteps. The split must key on valid_time; keying on the request
+        # position silently assigns the wrong hour to each output file.
+        mktempdir() do dir
+            src_path = joinpath(dir, "src.nc")
+            # What CDS returns for day=[16,17] × time=[23:00, 00:00], sorted ascending:
+            times = [DateTime(2005, 2, 16, 0), DateTime(2005, 2, 16, 23),
+                     DateTime(2005, 2, 17, 0), DateTime(2005, 2, 17, 23)]
+            NCDatasets.Dataset(src_path, "c") do ds
+                NCDatasets.defDim(ds, "longitude", 2)
+                NCDatasets.defDim(ds, "latitude",  2)
+                NCDatasets.defDim(ds, "valid_time", length(times))
+                NCDatasets.defVar(ds, "longitude", Float64, ("longitude",))[:] = [-1.0, 1.0]
+                NCDatasets.defVar(ds, "latitude",  Float64, ("latitude",))[:]  = [40.0, 41.0]
+                tv = NCDatasets.defVar(ds, "valid_time", Float64, ("valid_time",);
+                                       attrib = ["units" => "seconds since 1970-01-01"])
+                tv[:] = times
+                u = NCDatasets.defVar(ds, "t", Float32, ("longitude", "latitude", "valid_time"))
+                for k in eachindex(times), j in 1:2, i in 1:2
+                    u[i, j, k] = Float32(k)          # marker == source timestep index
+                end
+            end
+
+            # Request only the two datetimes we actually want (timesteps 2 and 3 of `times`).
+            want = [DateTime(2005, 2, 16, 23), DateTime(2005, 2, 17, 0)]
+            triples = [("t", want[1], joinpath(dir, "a.nc")),
+                       ("t", want[2], joinpath(dir, "b.nc"))]
+            CDSExt.split_era5_nc_multistep(src_path, triples,
+                                           Set(["longitude", "latitude", "valid_time"]),
+                                           Set(["valid_time"]))
+
+            # a.nc must hold valid_time 16T23:00 (marker 2), b.nc 17T00:00 (marker 3).
+            # The old positional split would have written markers 1 and 2.
+            for (want_dt, fname, marker) in [(want[1], "a.nc", 2f0), (want[2], "b.nc", 3f0)]
+                NCDatasets.Dataset(joinpath(dir, fname), "r") do dst
+                    @test dst["valid_time"][1] == want_dt
+                    @test all(==(marker), dst["t"].var[:])
                 end
             end
         end


### PR DESCRIPTION
## Problem

CDS expands `day`/`time` into a Cartesian product, so a datetime window spanning more than one day with differing hours (e.g. one crossing midnight) returns more, sorted timesteps than requested. The download split keyed each output file by the requested datetime's **position** in the request list, which no longer matches the response — writing the wrong hour into each per-datetime file (and thus the wrong initial/forcing time downstream). Fixes NumericalEarth/NumericalEarth.jl#429.

## Fix

`split_era5_nc_multistep` now resolves each timestep by matching the requested datetime against the file's `valid_time` coordinate. The three planners (`plan_era5_month`, `plan_era5_multivar_month`, and the GLOFAS path) pass the datetime through instead of a precomputed positional index.

## Verification

* Reproduced against a live CDS response: a 2-datetime midnight-crossing request returns 4 sorted timesteps, and positional indexing selects the wrong ones.
* Added a regression test (`split_era5_nc_multistep selects timesteps by valid_time, not request position`) that fails on the old positional code and passes with the fix.
* Updated the two `plan_*` tests that asserted `nc_triples` carried positional indices (they now carry the datetime).

Note: this fixes split *correctness*. The request still over-fetches the Cartesian product for such windows (extra timesteps downloaded, now correctly ignored); tightening the request to avoid the over-fetch is a possible follow-up.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)