### PR TITLE
Fix stale ERA5PrescribedAtmosphere callability test

### DIFF
--- a/test/test_cds_downloading.jl
+++ b/test/test_cds_downloading.jl
@@ -193,8 +193,10 @@ start_date = DateTime(2005, 2, 16, 12)
         @test convert_units(3.6, MetersPerHour()) ≈ 1        # 3.6 m/hr → 1 kg/m²/s
 
         # The regional hindcast prescribed components are first-class, top-level API.
-        @test ERA5PrescribedAtmosphere isa Function
-        @test ERA5PrescribedRadiation  isa Function
+        # ERA5PrescribedAtmosphere is a callable type alias (UnionAll), not a Function,
+        # so we check callability via methods rather than `isa Function`.
+        @test !isempty(methods(ERA5PrescribedAtmosphere))
+        @test !isempty(methods(ERA5PrescribedRadiation))
     end
 
     @testset "ERA5 single-level metadata_prefix" begin


### PR DESCRIPTION
Since #386, `ERA5PrescribedAtmosphere` is a type alias (`const ERA5PrescribedAtmosphere = PrescribedAtmosphere{<:ERA5Dataset}`) — a callable `UnionAll`, not a `Function`. The assertion `@test ERA5PrescribedAtmosphere isa Function` (added in #220) therefore fails in the Data Downloading job, as surfaced on #430 (which touches this test file but not these lines).

This checks callability via `!isempty(methods(...))` for both `ERA5PrescribedAtmosphere` and `ERA5PrescribedRadiation`, which works whether the name is a function or a constructor-bearing type alias.

Verified locally: `(ERA5PrescribedAtmosphere isa Function, !isempty(methods(ERA5PrescribedAtmosphere)), !isempty(methods(ERA5PrescribedRadiation))) == (false, true, true)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7Fd3K8ew2hjHWW7edy89Y