### PR TITLE
Add ECOSTRESS land surface temperature ingestion

### DIFF
--- a/docs/src/appendix/notation.md
+++ b/docs/src/appendix/notation.md
@@ -114,6 +114,7 @@ Superscripts generally denote the _type_ or _phase_ of a quantity, while subscri
 | Math | Code | Property | Description |
 |:----:|:----:|:---------|:------------|
 | ``T`` | `temperature` | ground temperature | Prognostic land-column temperature (K) |
+| ``T^{\mathrm{la}}`` | `land_surface_temperature` | land surface temperature | Observed skin/radiometric temperature (e.g. ECOSTRESS); a supervision target for the surface `Tˡᵃ` (K) |
 | ``M^{\mathrm{la}}`` | `water_storage` | land water | Prognostic land water mass per area (kg m⁻²) |
 | ``M^{\mathrm{la}\!+}`` | `maximum_water_storage` | maximum land water | Bucket capacity; soil-science "field capacity" (kg m⁻²) |
 | ``𝒮`` | `saturation` | surface saturation | Continuous land surface saturation ``\mathrm{clamp}(Mˡᵃ/Mˡᵃ⁺, 0, 1)``; the interface humidity models derive their availability ``β`` from it (–) |

--- a/ext/NumericalEarthArchGDALExt.jl
+++ b/ext/NumericalEarthArchGDALExt.jl
@@ -3,6 +3,12 @@ module NumericalEarthArchGDALExt
 using ArchGDAL: ArchGDAL
 using NCDatasets: NCDataset, defDim, defVar
 using NumericalEarth: NumericalEarth
+using NumericalEarth.DataWrangling: BoundingBox
+using NumericalEarth.DataWrangling.ECOSTRESS: ECOSTRESS, ecostress_lst,
+                                              ecostress_cmr_granules, earthdata_download,
+                                              ECOSTRESS_RESOLUTION
+
+using Dates: Dates, Day, Second
 
 function NumericalEarth.DataWrangling.IBCAO.reproject_ibcao_to_netcdf(tiff_path, nc_path)
     ArchGDAL.read(tiff_path) do src
@@ -42,6 +48,111 @@ function NumericalEarth.DataWrangling.IBCAO.reproject_ibcao_to_netcdf(tiff_path,
         end
     end
 
+    return nothing
+end
+
+#####
+##### ECOSTRESS ECO_L2G_LSTE — Earthdata CMR discovery + GDAL HDF5 read
+#####
+##### Fetch the overpass nearest the requested date, clip its (already EPSG:4326)
+##### LST / LST_err / cloud subdatasets to the region, decode via the pure
+##### `ecostress_lst` core, and write a clean regional lon/lat NetCDF so the generic
+##### `Field` / `set_region_data!` machinery brackets it onto the native grid.
+#####
+
+# Write a regional lon/lat NetCDF of decoded Kelvin layers. Each `layers` entry maps
+# a NetCDF variable name to a south→north-ordered `(Nx, Ny)` array; `gt` is the
+# (north→south) GDAL geotransform of the clip.
+function write_ecostress_netcdf(nc_path, layers, gt)
+    first_layer = first(values(layers))
+    Nx, Ny = size(first_layer)
+    Δφ = gt[6]  # negative (north→south)
+    longitude = collect(range(gt[1] + gt[2] / 2; step = gt[2], length = Nx))
+    latitude  = collect(range(gt[4] + Δφ / 2; step = Δφ, length = Ny))
+    reverse!(latitude)  # match the reversed (south→north) data
+
+    staging_path = nc_path * ".tmp"
+    NCDataset(staging_path, "c") do ds
+        defDim(ds, "lon", Nx)
+        defDim(ds, "lat", Ny)
+        lon_var = defVar(ds, "lon", Float64, ("lon",);
+                         attrib = ["units" => "degrees_east", "long_name" => "longitude"])
+        lat_var = defVar(ds, "lat", Float64, ("lat",);
+                         attrib = ["units" => "degrees_north", "long_name" => "latitude"])
+        lon_var[:] = longitude
+        lat_var[:] = latitude
+        for (name, data) in pairs(layers)
+            var = defVar(ds, String(name), Float32, ("lon", "lat");
+                         attrib = ["units" => "K", "long_name" => "land surface temperature"],
+                         deflatelevel = 2, shuffle = true)
+            var[:, :] = data
+        end
+    end
+    mv(staging_path, nc_path; force = true)
+    return nothing
+end
+
+# Locate the `HDF5:"…"://…/<field>` subdataset without hardcoding the per-resolution
+# grid group name.
+function ecostress_subdataset(h5_path, field)
+    ArchGDAL.read(h5_path) do ds
+        for entry in ArchGDAL.metadata(ds; domain = "SUBDATASETS")
+            occursin("_NAME=", entry) || continue
+            name = split(entry, "_NAME="; limit = 2)[2]
+            endswith(name, "/" * field) && return name
+        end
+        error("Field $(field) not found among the ECO_L2G_LSTE HDF5 subdatasets of $(h5_path).")
+    end
+end
+
+function ECOSTRESS.ecostress_granule_to_netcdf(metadatum::ECOSTRESS.ECOSTRESSMetadatum, nc_path)
+    region = metadatum.region
+    (region isa BoundingBox && !isnothing(region.longitude) && !isnothing(region.latitude)) ||
+        error("ecostress_granule_to_netcdf requires a bounded BoundingBox region.")
+
+    version = metadatum.dataset.version
+    date = metadatum.dates
+
+    # Search a ±1-day window around the requested overpass and pick the nearest.
+    granules = ecostress_cmr_granules(version, region, date - Day(1), date + Day(1))
+    isempty(granules) &&
+        error("CMR returned no ECO_L2G_LSTE.$(version) granules for region $(region) near $(date).")
+    gaps = [abs(Dates.value(Second(t - date))) for (t, _) in granules]
+    _, url = granules[argmin(gaps)]
+
+    λ = region.longitude
+    φ = region.latitude
+    Δ = ECOSTRESS_RESOLUTION
+
+    mktempdir() do tmp
+        h5 = joinpath(tmp, "ecostress.h5")
+        earthdata_download(url, h5)
+
+        # Nearest-neighbour resampling so the 0 fill (off-swath / no-retrieval) is
+        # never blended into a spurious intermediate temperature; source ≈ target Δ.
+        clip(field) = ArchGDAL.read(ecostress_subdataset(h5, field)) do src
+            ArchGDAL.gdalwarp([src],
+                ["-t_srs", "EPSG:4326",
+                 "-te", string(λ[1]), string(φ[1]), string(λ[2]), string(φ[2]),
+                 "-tr", string(Δ), string(Δ),
+                 "-r", "near"]) do w
+                (ArchGDAL.read(w, 1), ArchGDAL.getgeotransform(w))
+            end
+        end
+
+        lst,   gt = clip("LST")
+        err,   _  = clip("LST_err")
+        cloud, _  = clip("cloud")
+
+        cloud_i = round.(Int, cloud)
+        # Decode LST (cloud/fill → NaN); mask LST_err wherever LST is invalid.
+        LST     = ecostress_lst.(Float32.(lst), cloud_i)
+        LST_err = ifelse.(isnan.(LST) .| .!(Float32.(err) .> 0), NaN32, Float32.(err))
+
+        # Flip GDAL's north→south rows to south→north to match the NetCDF lat axis.
+        layers = (LST = reverse(LST, dims = 2), LST_err = reverse(LST_err, dims = 2))
+        write_ecostress_netcdf(nc_path, layers, gt)
+    end
     return nothing
 end
 

--- a/ext/NumericalEarthArchGDALExt.jl
+++ b/ext/NumericalEarthArchGDALExt.jl
@@ -113,12 +113,16 @@ function ECOSTRESS.ecostress_granule_to_netcdf(metadatum::ECOSTRESS.ECOSTRESSMet
     version = metadatum.dataset.version
     date = metadatum.dates
 
-    # Search a ±1-day window around the requested overpass and pick the nearest.
+    # Search a ±1-day window around the requested overpass. Prefer granules that actually
+    # cover the region (CMR's spatial search over-reports); among those, pick the nearest
+    # in time. Fall back to all candidates only if none clear the coverage threshold.
     granules = ecostress_cmr_granules(version, region, date - Day(1), date + Day(1))
     isempty(granules) &&
         error("CMR returned no ECO_L2G_LSTE.$(version) granules for region $(region) near $(date).")
-    gaps = [abs(Dates.value(Second(t - date))) for (t, _) in granules]
-    _, url = granules[argmin(gaps)]
+    covered = filter(g -> g.coverage ≥ ECOSTRESS.ECOSTRESS_MIN_COVERAGE, granules)
+    candidates = isempty(covered) ? granules : covered
+    gaps = [abs(Dates.value(Second(g.time - date))) for g in candidates]
+    url = candidates[argmin(gaps)].url
 
     λ = region.longitude
     φ = region.latitude

--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -362,6 +362,7 @@ include("GEBCO/GEBCO.jl")
 include("IBCAO/IBCAO.jl")
 include("CopernicusDEM/CopernicusDEM.jl")
 include("CopernicusLandAlbedo/CopernicusLandAlbedo.jl")
+include("ECOSTRESS/ECOSTRESS.jl")
 
 using .ETOPO
 using .ECCO
@@ -378,6 +379,7 @@ using .GEBCO
 using .IBCAO
 using .CopernicusDEM
 using .CopernicusLandAlbedo
+using .ECOSTRESS
 
 function dataset_modules()
     modules = Module[]

--- a/src/DataWrangling/ECOSTRESS/ECOSTRESS.jl
+++ b/src/DataWrangling/ECOSTRESS/ECOSTRESS.jl
@@ -1,0 +1,331 @@
+module ECOSTRESS
+
+# ECOSTRESS land surface temperature (LST) ingestion.
+#
+# ECOSTRESS is a thermal-infrared radiometer on the ISS; its ECO_L2G_LSTE product
+# gives ~70 m gridded skin temperature — the high-resolution, all-hours diurnal
+# `Tˡᵃ` supervision target a ~100 m coupled LES needs. Because it is a *training
+# target* (not a boundary-condition grab like albedo or porosity), cloud/no-
+# retrieval gaps are the operator's valid mask, so they are never inpainted
+# (`default_inpainting = nothing`, `missing_value = NaN`).
+#
+# The ISS orbit precesses, so overpasses are opportunistic: there is no regular
+# `all_dates` range. Overpass timestamps intersecting a region and time window are
+# discovered from NASA's Common Metadata Repository (CMR) with
+# [`ecostress_overpasses`](@ref); those explicit dates then drive `Metadata`.
+#
+# The pure decode/parse core (`ecostress_lst`, `granule_timestamp`) and the CMR
+# discovery need neither credentials nor GDAL. The granule read is HDF5, routed
+# through GDAL's HDF5 driver in `ext/NumericalEarthArchGDALExt.jl` (HDF5.jl is not
+# a project dependency); the module keeps a fallback `error` mirroring
+# `CopernicusDEM.zarr_to_netcdf`.
+
+export ECOSTRESSL2G, ecostress_lst, granule_timestamp, ecostress_overpasses
+
+using Dates: Dates, DateTime
+using Downloads: Downloads
+using Oceananigans: Center
+using Oceananigans.DistributedComputations: @root
+
+using ..DataWrangling: DataWrangling, Metadata, Metadatum, BoundingBox, Dataset,
+                       metadata_path, netrc_downloader
+
+import Oceananigans
+
+download_ECOSTRESS_cache::String = ""
+function __init__()
+    global download_ECOSTRESS_cache = DataWrangling.download_cache("ECOSTRESS")
+    return nothing
+end
+
+#####
+##### Pure decode / parse core (no IO, no credentials)
+#####
+
+"""
+    ecostress_lst(LST, cloud)
+
+Decode a single ECOSTRESS ECO_L2G_LSTE pixel. The gridded product stores `LST`
+directly in Kelvin (no scale/offset). The pixel decodes to `NaN` — the operator's
+cloud/no-retrieval gap, never inpainted — when the `cloud` mask flag is nonzero,
+when `LST` is the `0` fill (or otherwise non-positive), or when `LST` is `NaN`;
+otherwise the Kelvin value passes through unchanged.
+"""
+@inline function ecostress_lst(LST::Real, cloud::Integer)
+    K = float(LST)
+    invalid = (cloud != 0) | !(K > 0)
+    return ifelse(invalid, oftype(K, NaN), K)
+end
+
+"""
+    granule_timestamp(name)
+
+Parse the acquisition time embedded in an ECOSTRESS granule name of the form
+`…YYYYMMDDThhmmss…` (e.g. `ECOv002_L2G_LSTE_16928_005_20210701T082749_0710_01`),
+returning a `DateTime`. Every LST slice carries its acquisition time so the
+observation operator can sample the model at the observation's local time of day.
+"""
+function granule_timestamp(name::AbstractString)
+    m = match(r"(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})", name)
+    m === nothing &&
+        throw(ArgumentError("could not parse a YYYYMMDDThhmmss timestamp from granule name \"$name\""))
+    return DateTime(parse.(Int, m.captures)...)
+end
+
+#####
+##### Dataset type
+#####
+
+abstract type AbstractECOSTRESSDataset end
+
+"""
+    ECOSTRESSL2G(; version = "002")
+
+ECOSTRESS ECO_L2G_LSTE gridded Land Surface Temperature — a ~70 m, all-hours skin
+temperature (`Tˡᵃ`) supervision target for atmosphere-coupled LES.
+
+- HDF5 on a geographic lon/lat grid; `LST` and `LST_err` are Kelvin and `cloud` is
+  a mask flag. Decoded by [`ecostress_lst`](@ref).
+- NASA Earthdata Login required (`EARTHDATA_USERNAME` / `EARTHDATA_PASSWORD`, the
+  variables the `earthaccess` library also honours — see this module's README).
+  Granules are discovered from CMR (short name `ECO_L2G_LSTE`), so the time axis is
+  *irregular*: [`ecostress_overpasses`](@ref) returns the actual overpass times.
+- Must be used with a lon/lat [`BoundingBox`](@ref) region; the swath footprint is
+  windowed at download time.
+- Cloud/no-retrieval gaps are the operator's valid mask: `default_inpainting =
+  nothing`, `missing_value = NaN`.
+
+The HDF5 read is gated behind `ArchGDAL.jl` (GDAL HDF5 driver); the pure
+`ecostress_lst` decode and the CMR discovery need neither ArchGDAL nor credentials.
+
+```jldoctest
+julia> using NumericalEarth
+
+julia> ECOSTRESSL2G()
+ECOSTRESSL2G(version="002")
+```
+"""
+Base.@kwdef struct ECOSTRESSL2G <: AbstractECOSTRESSDataset
+    version :: String = "002"
+end
+
+Base.show(io::IO, dataset::ECOSTRESSL2G) = print(io, "ECOSTRESSL2G(version=\"", dataset.version, "\")")
+
+const ECOSTRESSMetadata{D} = Metadata{<:AbstractECOSTRESSDataset, D}
+const ECOSTRESSMetadatum   = Metadatum{<:AbstractECOSTRESSDataset}
+
+#####
+##### Variables
+#####
+
+# NumericalEarth names → the layers written into the local regional NetCDF at
+# download time (the ECO_L2G_LSTE `SDS/LST` and `SDS/LST_err` fields). The `cloud`
+# mask is applied to `LST` at decode time, so it is not a separately read variable.
+const ECOSTRESS_variable_names = Dict(:land_surface_temperature => "LST",
+                                      :lst_uncertainty          => "LST_err")
+
+DataWrangling.available_variables(::AbstractECOSTRESSDataset) = ECOSTRESS_variable_names
+DataWrangling.dataset_variable_name(metadata::ECOSTRESSMetadatum) = ECOSTRESS_variable_names[metadata.name]
+
+#####
+##### Grid traits
+#####
+
+DataWrangling.default_download_directory(::AbstractECOSTRESSDataset) = download_ECOSTRESS_cache
+DataWrangling.reversed_latitude_axis(::AbstractECOSTRESSDataset) = false
+DataWrangling.is_three_dimensional(::ECOSTRESSMetadatum) = false
+DataWrangling.default_inpainting(::ECOSTRESSMetadatum) = nothing
+DataWrangling.missing_value(::ECOSTRESSMetadatum) = NaN
+Base.eltype(::ECOSTRESSMetadatum) = Float32
+
+# The regional NetCDF written at download time stores its coordinates as `lon`/`lat`.
+DataWrangling.longitude_name(::ECOSTRESSMetadatum) = "lon"
+DataWrangling.latitude_name(::ECOSTRESSMetadatum)  = "lat"
+
+Oceananigans.Fields.location(::ECOSTRESSMetadatum) = (Center, Center, Center)
+
+# ECO_L2G_LSTE is posted on a 0.0006° (~70 m) geographic grid; the ISS covers land
+# out to ≈±52° latitude. These hulls and the nominal size just declare the maximal
+# coverage at native resolution — `construct_native_grid` clips them to the region's
+# `BoundingBox`, and only the windowed portion is ever materialized.
+const ECOSTRESS_RESOLUTION = 0.0006
+
+DataWrangling.longitude_interfaces(::AbstractECOSTRESSDataset) = (-180, 180)
+DataWrangling.latitude_interfaces(::AbstractECOSTRESSDataset)  = (-52, 52)
+DataWrangling.z_interfaces(::AbstractECOSTRESSDataset) = (0, 1)
+
+Base.size(::AbstractECOSTRESSDataset, variable) =
+    (round(Int, 360 / ECOSTRESS_RESOLUTION), round(Int, 104 / ECOSTRESS_RESOLUTION), 1)
+
+#####
+##### Dates — irregular overpasses discovered from CMR
+#####
+
+function DataWrangling.all_dates(::AbstractECOSTRESSDataset, variable)
+    error("ECOSTRESS overpasses are irregular (the ISS orbit precesses), so there is no " *
+          "dataset-wide date range. Discover the overpasses intersecting your region and " *
+          "time window with `ecostress_overpasses(region, start_date, end_date)` and pass " *
+          "them as explicit `dates` to `Metadata` (or a single `date` to `Metadatum`).")
+end
+
+cmr_time(date::DateTime) = string(Dates.format(date, "yyyy-mm-ddTHH:MM:SS"), "Z")
+
+"""
+    ecostress_cmr_url(version, region, start_date, end_date; page_size = 200)
+
+Build the NASA CMR granule-search URL (JSON) for `ECO_L2G_LSTE.<version>` granules
+intersecting the lon/lat [`BoundingBox`](@ref) `region` over `[start_date, end_date]`.
+Pure — constructs the query string only.
+"""
+function ecostress_cmr_url(version, region::BoundingBox, start_date, end_date; page_size = 200)
+    (!isnothing(region.longitude) && !isnothing(region.latitude)) ||
+        throw(ArgumentError("ecostress_cmr_url requires a bounded (longitude, latitude) BoundingBox."))
+    west, east = region.longitude
+    south, north = region.latitude
+    return string("https://cmr.earthdata.nasa.gov/search/granules.json",
+                  "?short_name=ECO_L2G_LSTE",
+                  "&version=", version,
+                  "&bounding_box=", west, ",", south, ",", east, ",", north,
+                  "&temporal=", cmr_time(start_date), ",", cmr_time(end_date),
+                  "&page_size=", page_size)
+end
+
+"""
+    ecostress_cmr_granules(version, region, start_date, end_date)
+
+Query CMR and return the `(timestamp, download_url)` pairs of the `ECO_L2G_LSTE`
+granules intersecting `region` over `[start_date, end_date]`, sorted by time.
+Requires network access. The granule `.h5` URLs and their `YYYYMMDDThhmmss`
+acquisition tags are read straight out of the JSON response text.
+"""
+function ecostress_cmr_granules(version, region::BoundingBox, start_date, end_date)
+    url = ecostress_cmr_url(version, region, start_date, end_date)
+    prefix = "ECOv" * version * "_L2G_LSTE_"
+    granules = Tuple{DateTime, String}[]
+
+    mktempdir() do tmp
+        json = joinpath(tmp, "cmr.json")
+        Downloads.download(url, json)
+        text = read(json, String)
+        pattern = Regex("https://[^\"]+/(" * prefix * "[^\"/]+)\\.h5")
+        for m in eachmatch(pattern, text)
+            granule = m.captures[1]
+            occursin("_mvs", granule) && continue   # skip the median-view quicklook aux
+            t = granule_timestamp(granule)
+            push!(granules, (t, m.match))
+        end
+    end
+
+    unique!(granules)
+    sort!(granules; by = first)
+    return granules
+end
+
+"""
+    ecostress_overpasses(region, start_date, end_date; version = "002")
+
+Discover the actual (irregular) ECOSTRESS ECO_L2G_LSTE overpass times intersecting
+the lon/lat [`BoundingBox`](@ref) `region` over `[start_date, end_date]`, by querying
+NASA's Common Metadata Repository. Returns a sorted `Vector{DateTime}`; pass it as
+`dates` to [`Metadata`](@ref) to build an irregular-time series. Requires network
+access.
+"""
+ecostress_overpasses(region::BoundingBox, start_date, end_date; version = "002") =
+    first.(ecostress_cmr_granules(version, region, start_date, end_date))
+
+#####
+##### Region-encoded filenames + coverage validation (per CopernicusDEM)
+#####
+
+region_suffix(::Nothing) = "global"
+
+function region_suffix(region::BoundingBox)
+    λ = region.longitude
+    φ = region.latitude
+    return string("lon_", bound_str(λ), "_lat_", bound_str(φ))
+end
+
+bound_str(::Nothing) = "nothing"
+bound_str(bounds) = string(bounds[1], "_", bounds[2])
+
+date_suffix(::Nothing) = "alldates"
+date_suffix(date::DateTime) = string("s", Dates.format(date, "yyyymmddTHHMMSS"))
+
+# One local file per overpass and region holds every variable (LST, LST_err), so the
+# filename is keyed by date and region but not by variable — mirroring the shared-file
+# scheme in CopernicusLandAlbedo.
+DataWrangling.metadata_filename(dataset::ECOSTRESSL2G, name, date, region) =
+    string("ECOSTRESS_L2G_LSTE_v", dataset.version, "_",
+           date_suffix(date), "_", region_suffix(region), ".nc")
+
+function DataWrangling.validate_dataset_coverage(grid, metadata::ECOSTRESSMetadatum)
+    region = metadata.region
+    if !(region isa BoundingBox) || isnothing(region.longitude) || isnothing(region.latitude)
+        error("ECOSTRESSL2G must be used with a bounded region. Build the metadatum with a " *
+              "longitude/latitude BoundingBox, e.g.\n" *
+              "    metadatum = Metadatum(:land_surface_temperature; dataset = ECOSTRESSL2G(),\n" *
+              "                          region = BoundingBox(longitude = (λ₁, λ₂), latitude = (φ₁, φ₂)),\n" *
+              "                          date = DateTime(2021, 7, 1, 8, 27, 49))")
+    end
+    return nothing
+end
+
+#####
+##### Download + read
+#####
+##### Each overpass is fetched, decoded (via the pure `ecostress_lst` core), and
+##### clipped to a clean regional lon/lat NetCDF (`lon`, `lat`, `LST`/`LST_err` in
+##### Kelvin with `NaN` gaps) at download time — mirroring the CopernicusLandAlbedo /
+##### MODIS-style ingest — so the generic `Field` / `set_region_data!` machinery
+##### brackets that raster onto the native grid. The real fetch (Earthdata download +
+##### GDAL HDF5 read) lives in `ext/NumericalEarthArchGDALExt.jl`; the fallback below
+##### fires only when `ArchGDAL` is not loaded, mirroring `CopernicusDEM.zarr_to_netcdf`.
+#####
+
+function Downloads.download(metadatum::ECOSTRESSMetadatum)
+    path = metadata_path(metadatum)
+    @root if !isfile(path)
+        ecostress_granule_to_netcdf(metadatum, path)
+    end
+    return path
+end
+
+# Implemented in ext/NumericalEarthArchGDALExt.jl once `ArchGDAL` is loaded.
+ecostress_granule_to_netcdf(metadatum, path) =
+    error("Fetching ECOSTRESS ECO_L2G_LSTE granules requires ArchGDAL.jl (for the GDAL " *
+          "HDF5 driver), NASA Earthdata credentials (EARTHDATA_USERNAME / EARTHDATA_PASSWORD), " *
+          "and CMR discovery of overpasses. Load ArchGDAL with `using ArchGDAL`.")
+
+"""
+    earthdata_download(url, path)
+
+Download `url` to `path` through a temporary `.netrc` authenticated against
+`urs.earthdata.nasa.gov`, using the `EARTHDATA_USERNAME` / `EARTHDATA_PASSWORD`
+environment variables. Errors if the credentials are unset.
+"""
+function earthdata_download(url, path)
+    username = get(ENV, "EARTHDATA_USERNAME", nothing)
+    password = get(ENV, "EARTHDATA_PASSWORD", nothing)
+    (isnothing(username) || isnothing(password)) &&
+        error("NASA Earthdata credentials not found. Set EARTHDATA_USERNAME and " *
+              "EARTHDATA_PASSWORD (register free at https://urs.earthdata.nasa.gov). " *
+              "See NumericalEarth.jl/src/DataWrangling/ECOSTRESS/README.md for instructions.")
+    mktempdir() do tmp
+        downloader = netrc_downloader(username, password, "urs.earthdata.nasa.gov", tmp)
+        Downloads.download(url, path; downloader)
+    end
+    return path
+end
+
+# The download step decodes each layer into Kelvin (with `NaN` gaps) at write time,
+# so the read is the generic 2-D NetCDF slurp — no scale/offset, no vertical axis.
+function DataWrangling.retrieve_data(metadata::ECOSTRESSMetadatum)
+    path = metadata_path(metadata)
+    name = DataWrangling.dataset_variable_name(metadata)
+    data = Dataset(path) do ds
+        Float32.(ds[name][:, :])
+    end
+    return reshape(data, size(data, 1), size(data, 2), 1)
+end
+
+end # module ECOSTRESS

--- a/src/DataWrangling/ECOSTRESS/ECOSTRESS.jl
+++ b/src/DataWrangling/ECOSTRESS/ECOSTRESS.jl
@@ -190,48 +190,120 @@ function ecostress_cmr_url(version, region::BoundingBox, start_date, end_date; p
                   "&page_size=", page_size)
 end
 
+# Default fraction of the region a granule's footprint box must cover to be treated as
+# an overpass "over" the region. CMR's `bounding_box` search returns every granule whose
+# footprint merely *touches* the region, so many candidates barely clip it (their valid
+# swath is elsewhere) and read back as all-NaN. Filtering by box coverage rejects those.
+const ECOSTRESS_MIN_COVERAGE = 0.5
+
+"""
+    region_box_coverage(box, region)
+
+Fraction of `region`'s area covered by a CMR granule footprint `box`, the string
+`"S W N E"` (`lat_min lon_min lat_max lon_max`). This is an over-estimate of the valid-
+pixel coverage (the box bounds the whole scene footprint), but it is enough to reject
+the candidate granules whose footprint only clips the region.
+"""
+function region_box_coverage(box::AbstractString, region::BoundingBox)
+    s, w, n, e = parse.(Float64, split(box))
+    west, east = region.longitude
+    south, north = region.latitude
+    Δλ = max(0.0, min(e, east) - max(w, west))
+    Δφ = max(0.0, min(n, north) - max(s, south))
+    area = (east - west) * (north - south)
+    return area > 0 ? clamp(Δλ * Δφ / area, 0, 1) : 0.0
+end
+
+# Split the CMR feed's `entry` array into per-granule JSON-object substrings by brace
+# matching (string/escape aware), keeping each granule's box, links, and time together.
+# Avoids a JSON dependency for the small, regular CMR response.
+function cmr_entries(text::AbstractString)
+    entries = SubString{String}[]
+    key = findfirst("\"entry\":[", text)
+    key === nothing && return entries
+    tail = SubString(text, nextind(text, last(key)))
+    depth = 0
+    start = firstindex(tail)
+    in_string = false
+    escaped = false
+    for i in eachindex(tail)
+        c = tail[i]
+        if in_string
+            if escaped
+                escaped = false
+            elseif c == '\\'
+                escaped = true
+            elseif c == '"'
+                in_string = false
+            end
+        elseif c == '"'
+            in_string = true
+        elseif c == '{'
+            depth += 1
+            depth == 1 && (start = i)
+        elseif c == '}'
+            depth -= 1
+            depth == 0 && push!(entries, SubString(tail, start, i))
+        elseif c == ']' && depth == 0
+            break
+        end
+    end
+    return entries
+end
+
+# Parse one CMR entry into `(time, url, coverage)`, or `nothing` if it carries no
+# matching protected `.h5` granule. `region` is used only for the coverage estimate.
+function parse_cmr_granule(entry, prefix, region)
+    m = match(Regex("\"(https://[^\"]+/(" * prefix * "[^\"/]+)\\.h5)\""), entry)
+    m === nothing && return nothing
+    granule_url, granule_id = m.captures
+    occursin("_mvs", granule_id) && return nothing   # skip the median-view quicklook aux
+    box = match(r"\"boxes\":\[\"([^\"]+)\"\]", entry)
+    coverage = isnothing(box) ? 1.0 : region_box_coverage(box.captures[1], region)
+    return (; time = granule_timestamp(granule_id), url = String(granule_url), coverage)
+end
+
 """
     ecostress_cmr_granules(version, region, start_date, end_date)
 
-Query CMR and return the `(timestamp, download_url)` pairs of the `ECO_L2G_LSTE`
-granules intersecting `region` over `[start_date, end_date]`, sorted by time.
-Requires network access. The granule `.h5` URLs and their `YYYYMMDDThhmmss`
-acquisition tags are read straight out of the JSON response text.
+Query CMR and return, sorted by time, the `ECO_L2G_LSTE` granules intersecting `region`
+over `[start_date, end_date]` as `(; time, url, coverage)` named tuples, where `coverage`
+is [`region_box_coverage`](@ref) of the granule footprint. Requires network access.
 """
 function ecostress_cmr_granules(version, region::BoundingBox, start_date, end_date)
     url = ecostress_cmr_url(version, region, start_date, end_date)
     prefix = "ECOv" * version * "_L2G_LSTE_"
-    granules = Tuple{DateTime, String}[]
 
-    mktempdir() do tmp
+    granules = mktempdir() do tmp
         json = joinpath(tmp, "cmr.json")
         Downloads.download(url, json)
         text = read(json, String)
-        pattern = Regex("https://[^\"]+/(" * prefix * "[^\"/]+)\\.h5")
-        for m in eachmatch(pattern, text)
-            granule = m.captures[1]
-            occursin("_mvs", granule) && continue   # skip the median-view quicklook aux
-            t = granule_timestamp(granule)
-            push!(granules, (t, m.match))
-        end
+        parsed = [parse_cmr_granule(entry, prefix, region) for entry in cmr_entries(text)]
+        filter(!isnothing, parsed)
     end
 
-    unique!(granules)
-    sort!(granules; by = first)
+    sort!(granules; by = g -> g.time)
     return granules
 end
 
 """
-    ecostress_overpasses(region, start_date, end_date; version = "002")
+    ecostress_overpasses(region, start_date, end_date; version = "002", min_coverage = $(ECOSTRESS_MIN_COVERAGE))
 
-Discover the actual (irregular) ECOSTRESS ECO_L2G_LSTE overpass times intersecting
-the lon/lat [`BoundingBox`](@ref) `region` over `[start_date, end_date]`, by querying
-NASA's Common Metadata Repository. Returns a sorted `Vector{DateTime}`; pass it as
-`dates` to [`Metadata`](@ref) to build an irregular-time series. Requires network
-access.
+Discover the actual (irregular) ECOSTRESS ECO_L2G_LSTE overpass times intersecting the
+lon/lat [`BoundingBox`](@ref) `region` over `[start_date, end_date]`, by querying NASA's
+Common Metadata Repository. Returns a sorted `Vector{DateTime}`; pass it as `dates` to
+[`Metadata`](@ref) to build an irregular-time series. Requires network access.
+
+Only overpasses whose footprint covers at least `min_coverage` of the region are
+returned (see [`region_box_coverage`](@ref)) — CMR's spatial search over-reports, so the
+unfiltered candidates include scenes whose valid swath misses the region and read back
+as all-NaN. Lower `min_coverage` (e.g. `0`) to keep every candidate.
 """
-ecostress_overpasses(region::BoundingBox, start_date, end_date; version = "002") =
-    first.(ecostress_cmr_granules(version, region, start_date, end_date))
+function ecostress_overpasses(region::BoundingBox, start_date, end_date;
+                              version = "002", min_coverage = ECOSTRESS_MIN_COVERAGE)
+    granules = ecostress_cmr_granules(version, region, start_date, end_date)
+    return [g.time for g in granules if g.coverage ≥ min_coverage]
+end
 
 #####
 ##### Region-encoded filenames + coverage validation (per CopernicusDEM)

--- a/src/DataWrangling/ECOSTRESS/README.md
+++ b/src/DataWrangling/ECOSTRESS/README.md
@@ -78,7 +78,9 @@ lst_series = FieldTimeSeries(metadata)
   windowed at download time.
 - `:land_surface_temperature` (`LST`) and `:lst_uncertainty` (`LST_err`) are read
   from one downloaded file per overpass; both are in Kelvin with `NaN` gaps.
-- `ecostress_overpasses` returns *candidate* overpasses: CMR intersects the region
-  against each granule's bounding polygon, which over-reports — a returned overpass
-  can still have no valid retrieval over the exact window (all `NaN`, off-swath or
-  fully cloudy). Check that a slice actually has finite cells before relying on it.
+- `ecostress_overpasses` filters to overpasses whose footprint covers at least
+  `min_coverage` of the region (default `0.5`), because CMR's spatial search returns
+  every granule that merely *touches* the region — many barely clip it and read back
+  all-`NaN`. Pass `min_coverage = 0` to keep every candidate. The footprint box is
+  still an over-estimate of valid pixels, so a returned scene can occasionally be
+  cloud-only; check for finite cells if that matters.

--- a/src/DataWrangling/ECOSTRESS/README.md
+++ b/src/DataWrangling/ECOSTRESS/README.md
@@ -78,3 +78,7 @@ lst_series = FieldTimeSeries(metadata)
   windowed at download time.
 - `:land_surface_temperature` (`LST`) and `:lst_uncertainty` (`LST_err`) are read
   from one downloaded file per overpass; both are in Kelvin with `NaN` gaps.
+- `ecostress_overpasses` returns *candidate* overpasses: CMR intersects the region
+  against each granule's bounding polygon, which over-reports — a returned overpass
+  can still have no valid retrieval over the exact window (all `NaN`, off-swath or
+  fully cloudy). Check that a slice actually has finite cells before relying on it.

--- a/src/DataWrangling/ECOSTRESS/README.md
+++ b/src/DataWrangling/ECOSTRESS/README.md
@@ -1,0 +1,80 @@
+# ECOSTRESS land surface temperature
+
+This module ingests the ECOSTRESS `ECO_L2G_LSTE` gridded Land Surface Temperature
+product: ~70 m thermal-infrared skin temperature from the radiometer on the ISS,
+distributed as HDF5 on a geographic (EPSG:4326) lon/lat grid. It supplies the
+high-resolution, all-hours diurnal `Tˡᵃ` supervision target a ~100 m
+atmosphere-coupled LES needs.
+
+LST is a *training target*, not a boundary-condition grab, so cloud and
+no-retrieval gaps are the observation operator's valid mask and are never
+inpainted (`default_inpainting = nothing`, `missing_value = NaN`).
+
+## Irregular overpasses
+
+The ISS orbit precesses, so ECOSTRESS overpasses are opportunistic — there is no
+regular date range. Discover the overpasses intersecting a region and time window
+from NASA's Common Metadata Repository (no credentials needed), then pass them as
+explicit dates:
+
+```julia
+using NumericalEarth
+using Dates
+
+region = BoundingBox(longitude = (-101, -100), latitude = (33.5, 34.5))
+dates = ecostress_overpasses(region, DateTime(2021, 7, 1), DateTime(2021, 7, 3))
+```
+
+## Credentials
+
+The granule download is authenticated against NASA Earthdata Login. Set the
+`EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` environment variables (the same ones
+the `earthaccess` library uses):
+
+1. Register (free) at https://urs.earthdata.nasa.gov
+2. Approve the *LP DAAC Data Pool* / *LP CLOUD* application in your Earthdata profile
+3. Export the credentials before launching Julia:
+
+```bash
+export EARTHDATA_USERNAME=your_username
+export EARTHDATA_PASSWORD=your_password
+```
+
+or within Julia:
+
+```julia
+ENV["EARTHDATA_USERNAME"] = "your_username"
+ENV["EARTHDATA_PASSWORD"] = "your_password"
+```
+
+## Usage
+
+The HDF5 read routes through GDAL's HDF5 driver, so `ArchGDAL` must be loaded.
+Each overpass is fetched, decoded to Kelvin (with `NaN` cloud/no-retrieval gaps),
+and clipped to a compact regional lon/lat NetCDF at download time; the generic
+`Field` / `FieldTimeSeries` machinery then windows it onto your grid.
+
+```julia
+using NumericalEarth
+using ArchGDAL
+using Dates
+
+region = BoundingBox(longitude = (-101, -100), latitude = (33.5, 34.5))
+
+# Single overpass
+metadatum = Metadatum(:land_surface_temperature; dataset = ECOSTRESSL2G(),
+                      region, date = DateTime(2021, 7, 1, 8, 27, 49))
+lst = Field(metadatum)
+
+# Irregular-time series over all overpasses in a window
+dates = ecostress_overpasses(region, DateTime(2021, 7, 1), DateTime(2021, 7, 8))
+metadata = Metadata(:land_surface_temperature; dataset = ECOSTRESSL2G(), dates, region)
+lst_series = FieldTimeSeries(metadata)
+```
+
+## Notes
+
+- Must be used with a longitude/latitude `BoundingBox`; the swath footprint is
+  windowed at download time.
+- `:land_surface_temperature` (`LST`) and `:lst_uncertainty` (`LST_err`) are read
+  from one downloaded file per overpass; both are in Kelvin with `NaN` gaps.

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -261,6 +261,7 @@ using .DataWrangling.OSPapa
 using .DataWrangling.ERA5
 using .DataWrangling.SoilGrids
 using .DataWrangling.CopernicusLandAlbedo
+using .DataWrangling.ECOSTRESS
 
 using PrecompileTools: @setup_workload, @compile_workload
 

--- a/test/test_ecostress.jl
+++ b/test/test_ecostress.jl
@@ -1,0 +1,175 @@
+include("runtests_setup.jl")
+
+using NumericalEarth.DataWrangling.ECOSTRESS: ECOSTRESSL2G, ecostress_lst,
+                                              granule_timestamp, ecostress_overpasses,
+                                              ecostress_cmr_url, ECOSTRESS_RESOLUTION
+using NumericalEarth.DataWrangling: BoundingBox, Metadatum, Metadata, native_grid,
+                                    retrieve_data,
+                                    dataset_variable_name, metadata_filename,
+                                    available_variables, is_three_dimensional,
+                                    all_dates, missing_value, default_inpainting,
+                                    longitude_name, latitude_name,
+                                    longitude_interfaces, latitude_interfaces,
+                                    validate_dataset_coverage
+
+using Oceananigans.Grids: λnodes, φnodes
+using NCDatasets: NCDataset, defDim, defVar
+using Dates: DateTime
+
+@testset "ECOSTRESS LST decode" begin
+    # Kelvin passes through unchanged when clear-sky and physical.
+    @test ecostress_lst(300.0f0, 0) === 300.0f0
+    @test ecostress_lst(213.5f0, 0) === 213.5f0
+
+    # Cloud mask (nonzero) → NaN.
+    @test isnan(ecostress_lst(300.0f0, 1))
+    @test isnan(ecostress_lst(300.0f0, 2))
+
+    # 0-fill / non-positive → NaN (off-swath / no-retrieval).
+    @test isnan(ecostress_lst(0.0f0, 0))
+    @test isnan(ecostress_lst(-5.0f0, 0))
+
+    # NaN passes through as NaN.
+    @test isnan(ecostress_lst(NaN32, 0))
+end
+
+@testset "ECOSTRESS granule timestamp parse" begin
+    dt = granule_timestamp("ECOv002_L2G_LSTE_16928_005_20210701T082749_0710_01")
+    @test dt == DateTime(2021, 7, 1, 8, 27, 49)
+
+    @test_throws ArgumentError granule_timestamp("no_timestamp_here")
+end
+
+@testset "ECOSTRESS CMR request URL (network-free)" begin
+    region = BoundingBox(longitude = (-101, -100), latitude = (33.5, 34.5))
+    url = ecostress_cmr_url("002", region, DateTime(2021, 7, 1), DateTime(2021, 7, 3))
+    @test occursin("short_name=ECO_L2G_LSTE", url)
+    @test occursin("version=002", url)
+    @test occursin("bounding_box=-101,33.5,-100,34.5", url)
+    @test occursin("temporal=2021-07-01T00:00:00Z,2021-07-03T00:00:00Z", url)
+
+    # An unbounded region cannot be searched.
+    @test_throws ArgumentError ecostress_cmr_url("002", BoundingBox(), DateTime(2021, 7, 1), DateTime(2021, 7, 3))
+end
+
+@testset "ECOSTRESSL2G dataset interface" begin
+    dataset = ECOSTRESSL2G()
+    @test dataset.version == "002"
+    @test ECOSTRESSL2G(version = "001").version == "001"
+    @test occursin("ECOSTRESSL2G", sprint(show, dataset))
+
+    vars = available_variables(dataset)
+    @test vars[:land_surface_temperature] == "LST"
+    @test vars[:lst_uncertainty] == "LST_err"
+
+    @test longitude_interfaces(dataset) == (-180, 180)
+    @test latitude_interfaces(dataset) == (-52, 52)
+
+    region = BoundingBox(longitude = (-101, -100), latitude = (33.5, 34.5))
+    metadatum = Metadatum(:land_surface_temperature; dataset, region,
+                          date = DateTime(2021, 7, 1, 8, 27, 49))
+    @test dataset_variable_name(metadatum) == "LST"
+    @test is_three_dimensional(metadatum) == false
+    @test isnan(missing_value(metadatum))
+    @test default_inpainting(metadatum) === nothing
+    @test longitude_name(metadatum) == "lon"
+    @test latitude_name(metadatum) == "lat"
+    @test location(metadatum) == (Center, Center, Center)
+    @test eltype(metadatum) == Float32
+
+    # The uncertainty shares the dataset but maps to its own layer name.
+    err = Metadatum(:lst_uncertainty; dataset, region, date = DateTime(2021, 7, 1, 8, 27, 49))
+    @test dataset_variable_name(err) == "LST_err"
+end
+
+@testset "ECOSTRESS irregular dates require explicit discovery" begin
+    @test_throws ErrorException all_dates(ECOSTRESSL2G(), :land_surface_temperature)
+end
+
+@testset "ECOSTRESS filenames + coverage validation" begin
+    dataset = ECOSTRESSL2G()
+    date = DateTime(2021, 7, 1, 8, 27, 49)
+    region_a = BoundingBox(longitude = (-101, -100), latitude = (33.5, 34.5))
+    region_b = BoundingBox(longitude = (10, 11), latitude = (45, 46))
+
+    # One local file per overpass+region holds every variable — the filename is keyed
+    # by date and region but not by variable name.
+    @test metadata_filename(dataset, :land_surface_temperature, date, region_a) ==
+          metadata_filename(dataset, :lst_uncertainty, date, region_a)
+
+    # Distinct per region and per date.
+    @test metadata_filename(dataset, :land_surface_temperature, date, region_a) !=
+          metadata_filename(dataset, :land_surface_temperature, date, region_b)
+    @test metadata_filename(dataset, :land_surface_temperature, date, region_a) !=
+          metadata_filename(dataset, :land_surface_temperature, DateTime(2021, 7, 2), region_a)
+
+    grid = LatitudeLongitudeGrid(CPU(); size = (8, 8, 1),
+                                 longitude = (-101, -100), latitude = (33.5, 34.5),
+                                 z = (0, 1))
+    # Global (unbounded) metadatum is rejected; a BoundingBox is accepted.
+    global_md = Metadatum(:land_surface_temperature; dataset)
+    @test_throws ErrorException validate_dataset_coverage(grid, global_md)
+    region_md = Metadatum(:land_surface_temperature; dataset, region = region_a)
+    @test validate_dataset_coverage(grid, region_md) === nothing
+end
+
+# The real fetch (Earthdata download + GDAL HDF5 read) is credential/ArchGDAL-gated,
+# so here we synthesize the regional lon/lat NetCDF the download step would write and
+# exercise the generic read + windowing machinery end-to-end. Placing the file at the
+# metadatum's path makes `Downloads.download` a no-op (the file already exists).
+@testset "ECOSTRESS reads a regional LST raster onto its grid" begin
+    dataset = ECOSTRESSL2G()
+    region = BoundingBox(longitude = (-100.03, -100.0), latitude = (34.0, 34.03))
+    date = DateTime(2021, 7, 1, 8, 27, 49)
+
+    mktempdir() do dir
+        metadatum = Metadatum(:land_surface_temperature; dataset, region, date, dir)
+
+        # Build the file exactly on the native-grid cell centers so the raster maps
+        # one-to-one onto the grid the reader reconstructs.
+        grid = native_grid(metadatum)
+        Nx, Ny = grid.Nx, grid.Ny
+        @test Nx > 20 && Ny > 20   # the 0.03° window resolves at ECOSTRESS_RESOLUTION
+        λc = Array(λnodes(grid, Center(), Center(), Center()))
+        φc = Array(φnodes(grid, Center(), Center(), Center()))
+
+        LST = Float32[290 + 0.1f0 * i + 0.05f0 * j for i in 1:Nx, j in 1:Ny]
+        LST[3, 3] = NaN32          # interior cloud/no-retrieval gaps, clear of the interp box
+        LST[Nx - 2, Ny - 2] = NaN32
+        LST_err = fill(1.5f0, Nx, Ny)
+
+        NCDataset(metadata_path(metadatum), "c") do ds
+            defDim(ds, "lon", Nx)
+            defDim(ds, "lat", Ny)
+            defVar(ds, "lon", Float64, ("lon",))[:] = λc
+            defVar(ds, "lat", Float64, ("lat",))[:] = φc
+            defVar(ds, "LST", Float32, ("lon", "lat"))[:, :] = LST
+            defVar(ds, "LST_err", Float32, ("lon", "lat"))[:, :] = LST_err
+        end
+
+        # retrieve_data returns the decoded 2-D raster with a singleton 3rd dim.
+        raw = retrieve_data(metadatum)
+        @test size(raw) == (Nx, Ny, 1)
+
+        field = Field(metadatum)
+        interior_data = Array(interior(field))
+        @test size(interior_data) == (Nx, Ny, 1)
+
+        # Cloud gaps survive as NaN (never inpainted); the rest matches the raster.
+        @test isequal(interior_data[:, :, 1], LST)
+        @test count(isnan, interior_data) == 2
+        finite = filter(isfinite, interior_data)
+        @test all(f -> 280 < f < 320, finite)
+
+        # And it interpolates onto a coarser LES-like grid over a clear-sky central box.
+        target = LatitudeLongitudeGrid(CPU(); size = (12, 12),
+                                       longitude = (-100.018, -100.012),
+                                       latitude = (34.012, 34.018),
+                                       topology = (Bounded, Bounded, Flat))
+        les_field = Field(metadatum, target)
+        les_data = Array(interior(les_field))
+        @test size(les_data) == (12, 12, 1)
+        @test all(isfinite, les_data)
+        @test all(f -> 280 < f < 320, les_data)
+    end
+end

--- a/test/test_ecostress.jl
+++ b/test/test_ecostress.jl
@@ -2,7 +2,9 @@ include("runtests_setup.jl")
 
 using NumericalEarth.DataWrangling.ECOSTRESS: ECOSTRESSL2G, ecostress_lst,
                                               granule_timestamp, ecostress_overpasses,
-                                              ecostress_cmr_url, ECOSTRESS_RESOLUTION
+                                              ecostress_cmr_url, ECOSTRESS_RESOLUTION,
+                                              region_box_coverage, cmr_entries,
+                                              parse_cmr_granule
 using NumericalEarth.DataWrangling: BoundingBox, Metadatum, Metadata, native_grid,
                                     retrieve_data,
                                     dataset_variable_name, metadata_filename,
@@ -50,6 +52,40 @@ end
 
     # An unbounded region cannot be searched.
     @test_throws ArgumentError ecostress_cmr_url("002", BoundingBox(), DateTime(2021, 7, 1), DateTime(2021, 7, 3))
+end
+
+@testset "ECOSTRESS CMR coverage filtering (network-free)" begin
+    region = BoundingBox(longitude = (-101, -100), latitude = (33.5, 34.5))
+
+    # Boxes are "S W N E". A box fully containing the region → full coverage.
+    @test region_box_coverage("32.2546 -104.0781 37.2155 -97.9209", region) ≈ 1.0
+    # The empty first overpass from the live test: box east edge -100.7692 only clips
+    # the region's west sliver → low coverage (rejected by the 0.5 default).
+    @test region_box_coverage("30.0104 -106.7752 34.9601 -100.7692", region) < 0.5
+    # A box entirely elsewhere → no coverage.
+    @test region_box_coverage("10.0 20.0 12.0 22.0", region) == 0.0
+
+    # Entry splitting + per-granule parse, exercised on a synthetic 2-entry feed.
+    feed = """
+    {"feed":{"entry":[
+      {"boxes":["32.2546 -104.0781 37.2155 -97.9209"],
+       "links":[{"href":"https://data.lpdaac.earthdatacloud.nasa.gov/x/ECOv002_L2G_LSTE_16928_005_20210701T082749_0712_01.h5"},
+                {"href":"s3://lp/ECOv002_L2G_LSTE_16928_005_20210701T082749_0712_01.h5"}]},
+      {"boxes":["30.0104 -106.7752 34.9601 -100.7692"],
+       "links":[{"href":"https://data.lpdaac.earthdatacloud.nasa.gov/x/ECOv002_L2G_LSTE_16928_004_20210701T082657_0712_01.h5"}]}
+    ]}}
+    """
+    entries = cmr_entries(feed)
+    @test length(entries) == 2
+
+    g1 = parse_cmr_granule(entries[1], "ECOv002_L2G_LSTE_", region)
+    @test g1.time == DateTime(2021, 7, 1, 8, 27, 49)
+    @test startswith(g1.url, "https://") && endswith(g1.url, ".h5")   # https link, not s3
+    @test g1.coverage ≈ 1.0
+
+    g2 = parse_cmr_granule(entries[2], "ECOv002_L2G_LSTE_", region)
+    @test g2.time == DateTime(2021, 7, 1, 8, 26, 57)
+    @test g2.coverage < 0.5   # the barely-clipping scene
 end
 
 @testset "ECOSTRESSL2G dataset interface" begin


### PR DESCRIPTION
Adds a DataWrangling adapter for the ECOSTRESS `ECO_L2G_LSTE` gridded ~70 m land surface temperature product — a high-resolution diurnal skin-temperature target for atmosphere-coupled LES. Cloud/no-retrieval gaps are kept as `NaN` (never inpainted). Reuses the existing `ArchGDAL` extension for the HDF5 read; no dependency changes.

Public API (surfaced via `using NumericalEarth`):
- `ECOSTRESSL2G(; version="002")` — the dataset; variables `:land_surface_temperature`, `:lst_uncertainty`
- `ecostress_overpasses(region, start_date, end_date)` — CMR discovery of the irregular ISS overpass times

```julia
using NumericalEarth, ArchGDAL, Dates
region = BoundingBox(longitude = (-101, -100), latitude = (33.5, 34.5))
dates = ecostress_overpasses(region, DateTime(2021, 7, 1), DateTime(2021, 7, 8))
lst = FieldTimeSeries(Metadata(:land_surface_temperature; dataset = ECOSTRESSL2G(), dates, region))
```

Requires NASA Earthdata credentials (`EARTHDATA_USERNAME`/`EARTHDATA_PASSWORD`); see `src/DataWrangling/ECOSTRESS/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
