### PR TITLE
Add FLUXNET Shuttle flux-tower data ingestion

### DIFF
--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -356,6 +356,7 @@ include("WOA/WOA.jl")
 include("JRA55/JRA55.jl")
 include("GloFAS/GloFAS.jl")
 include("OSPapa/OSPapa.jl")
+include("FLUXNET/FLUXNET.jl")
 include("SoilGrids/SoilGrids.jl")
 include("IBCSO/IBCSO.jl")
 include("GEBCO/GEBCO.jl")
@@ -372,6 +373,7 @@ using .WOA
 using .JRA55
 using .GloFAS
 using .OSPapa
+using .FLUXNET
 using .IBCSO
 using .GEBCO
 using .IBCAO

--- a/src/DataWrangling/FLUXNET/FLUXNET.jl
+++ b/src/DataWrangling/FLUXNET/FLUXNET.jl
@@ -1,0 +1,131 @@
+module FLUXNET
+
+export FLUXNETSite
+export FLUXNETPrescribedAtmosphere
+export FLUXNETPrescribedRadiation
+export fluxnet_flux_observations
+
+using Dates: Dates, DateTime
+using Downloads: Downloads
+using Glob: glob
+using Oceananigans: Oceananigans
+using Oceananigans.Architectures: CPU, on_architecture
+using Oceananigans.DistributedComputations: child_architecture
+using Oceananigans.Fields: Field, interior
+using Oceananigans.Grids: RectilinearGrid, Center, Flat
+using Oceananigans.OutputReaders: FieldTimeSeries
+using Thermodynamics: q_vap_from_RH, saturation_vapor_pressure, Liquid
+
+using ..DataWrangling: DataWrangling, Metadata, Metadatum,
+                       first_date, last_date, fill_gaps!, Celsius
+
+using ...Atmospheres: PrescribedAtmosphere, PrescribedPrecipitationFlux,
+                      AtmosphereThermodynamicsParameters
+using ...Radiations: PrescribedRadiation, SurfaceRadiationProperties,
+                     default_stefan_boltzmann_constant
+
+download_FLUXNET_cache::String = ""
+
+function __init__()
+    global download_FLUXNET_cache = DataWrangling.download_cache("FLUXNET")
+end
+
+#####
+##### Time resolution helpers
+#####
+
+# The FLUXNET2015 filename token and averaging interval (seconds) for each resolution.
+resolution_token(::Val{:halfhourly}) = "HH"
+resolution_token(::Val{:hourly})     = "HR"
+resolution_token(::Val{:daily})      = "DD"
+resolution_token(resolution::Symbol) = resolution_token(Val(resolution))
+
+resolution_seconds(::Val{:halfhourly}) = 1800
+resolution_seconds(::Val{:hourly})     = 3600
+resolution_seconds(::Val{:daily})      = 86400
+resolution_seconds(resolution::Symbol) = resolution_seconds(Val(resolution))
+
+#####
+##### CSV parsing (FLUXNET stores one comma-separated file per site and resolution)
+#####
+
+const FLUXNET_MISSING_VALUE = -9999.0
+const FLUXNET_SUBDAILY_FORMAT = Dates.DateFormat("yyyymmddHHMM")
+const FLUXNET_DAILY_FORMAT    = Dates.DateFormat("yyyymmdd")
+
+# Timestamps are `YYYYMMDDHHMM` (subdaily) or `YYYYMMDD` (daily); use the start of
+# the averaging interval (`TIMESTAMP_START`) as the sample time.
+function parse_fluxnet_timestamp(field)
+    s = strip(field)
+    return length(s) ≥ 12 ? DateTime(s[1:12], FLUXNET_SUBDAILY_FORMAT) :
+                            DateTime(s[1:8],  FLUXNET_DAILY_FORMAT)
+end
+
+parse_fluxnet_value(field) = _clean(tryparse(Float64, field))
+_clean(::Nothing) = NaN
+_clean(value::Float64) = ifelse(value == FLUXNET_MISSING_VALUE, NaN, value)
+
+"""
+    read_fluxnet_csv(path)
+
+Parse a FLUXNET2015 CSV, returning `(timestamps, columns)` where `timestamps` is
+a `Vector{DateTime}` built from `TIMESTAMP_START` (or `TIMESTAMP` for daily data)
+and `columns` maps each remaining column name to a `Vector{Float64}` with the
+`-9999` missing sentinel replaced by `NaN`.
+"""
+function read_fluxnet_csv(path)
+    lines = readlines(path)
+    length(lines) < 2 && error("FLUXNET file \"$path\" has no data rows")
+
+    header = string.(split(strip(lines[1]), ','))
+    time_index = findfirst(==("TIMESTAMP_START"), header)
+    isnothing(time_index) && (time_index = findfirst(==("TIMESTAMP"), header))
+    isnothing(time_index) &&
+        error("FLUXNET file \"$path\" has no TIMESTAMP_START or TIMESTAMP column")
+
+    n = length(lines) - 1
+    timestamps = Vector{DateTime}(undef, n)
+
+    is_data_column = [!(name in ("TIMESTAMP_START", "TIMESTAMP_END", "TIMESTAMP")) for name in header]
+    columns = Dict{String, Vector{Float64}}(header[c] => Vector{Float64}(undef, n)
+                                             for c in eachindex(header) if is_data_column[c])
+
+    for row in 1:n
+        fields = split(strip(lines[row + 1]), ',')
+        timestamps[row] = parse_fluxnet_timestamp(fields[time_index])
+        for c in eachindex(header)
+            is_data_column[c] || continue
+            columns[header[c]][row] = parse_fluxnet_value(fields[c])
+        end
+    end
+
+    return timestamps, columns
+end
+
+#####
+##### File discovery and parsed-file caches (keyed by resolved file path)
+#####
+
+const FLUXNET_FILE_CACHE = Dict{String, Tuple{Vector{DateTime}, Dict{String, Vector{Float64}}}}()
+const FLUXNET_TIME_INDEX_CACHE = Dict{String, Dict{DateTime, Int}}()
+
+include("FLUXNET_metadata.jl")
+
+#####
+##### Shared builder utility
+#####
+
+# Load one variable onto the single-column `grid`, filling short gaps by linear
+# interpolation (FLUXNET `_F` variables are already gap-filled, so this is a safety net).
+function fluxnet_field_time_series(site, name, grid; start_date, end_date, max_gap)
+    md = Metadata(name; dataset = site, start_date, end_date, dir = site.dir)
+    fts = FieldTimeSeries(md, grid; time_indices_in_memory = length(md))
+    max_gap > 0 && fill_gaps!(fts; max_gap)
+    return fts
+end
+
+include("FLUXNET_prescribed_atmosphere.jl")
+include("FLUXNET_prescribed_radiation.jl")
+include("FLUXNET_flux_observations.jl")
+
+end # module FLUXNET

--- a/src/DataWrangling/FLUXNET/FLUXNET.jl
+++ b/src/DataWrangling/FLUXNET/FLUXNET.jl
@@ -10,11 +10,12 @@ using Downloads: Downloads
 using Glob: glob
 using Oceananigans: Oceananigans
 using Oceananigans.Architectures: CPU, on_architecture
-using Oceananigans.DistributedComputations: child_architecture
+using Oceananigans.DistributedComputations: child_architecture, @root
 using Oceananigans.Fields: Field, interior
 using Oceananigans.Grids: RectilinearGrid, Center, Flat
 using Oceananigans.OutputReaders: FieldTimeSeries
 using Thermodynamics: q_vap_from_RH, saturation_vapor_pressure, Liquid
+using ZipFile: ZipFile
 
 using ..DataWrangling: DataWrangling, Metadata, Metadatum,
                        first_date, last_date, fill_gaps!, Celsius
@@ -34,7 +35,7 @@ end
 ##### Time resolution helpers
 #####
 
-# The FLUXNET2015 filename token and averaging interval (seconds) for each resolution.
+# The ONEFlux filename token and averaging interval (seconds) for each resolution.
 resolution_token(::Val{:halfhourly}) = "HH"
 resolution_token(::Val{:hourly})     = "HR"
 resolution_token(::Val{:daily})      = "DD"
@@ -68,7 +69,7 @@ _clean(value::Float64) = ifelse(value == FLUXNET_MISSING_VALUE, NaN, value)
 """
     read_fluxnet_csv(path)
 
-Parse a FLUXNET2015 CSV, returning `(timestamps, columns)` where `timestamps` is
+Parse an ONEFlux FLUXNET CSV, returning `(timestamps, columns)` where `timestamps` is
 a `Vector{DateTime}` built from `TIMESTAMP_START` (or `TIMESTAMP` for daily data)
 and `columns` maps each remaining column name to a `Vector{Float64}` with the
 `-9999` missing sentinel replaced by `NaN`.
@@ -110,6 +111,7 @@ const FLUXNET_FILE_CACHE = Dict{String, Tuple{Vector{DateTime}, Dict{String, Vec
 const FLUXNET_TIME_INDEX_CACHE = Dict{String, Dict{DateTime, Int}}()
 
 include("FLUXNET_metadata.jl")
+include("FLUXNET_shuttle.jl")
 
 #####
 ##### Shared builder utility

--- a/src/DataWrangling/FLUXNET/FLUXNET_flux_observations.jl
+++ b/src/DataWrangling/FLUXNET/FLUXNET_flux_observations.jl
@@ -1,0 +1,66 @@
+# NaN-out samples whose FLUXNET quality flag exceeds `threshold` (0 = measured,
+# 1 = good-quality gap-fill, 2 = medium, 3 = poor). Variables without a `_QC`
+# companion column (e.g. USTAR, NETRAD) are left untouched.
+function mask_low_quality!(fts, site, md, name, threshold)
+    columns = fluxnet_columns(site)
+    qc_name = FLUXNET_variable_names[name] * "_QC"
+    haskey(columns, qc_name) || return fts
+
+    qc = columns[qc_name]
+    data = Array(interior(fts))
+    for (t, datum) in enumerate(md)
+        index = fluxnet_time_index(site, datum.dates)
+        (isnothing(index) || isnan(qc[index]) || qc[index] ≤ threshold) && continue
+        selectdim(data, ndims(data), t) .= NaN
+    end
+    copyto!(interior(fts), data)
+    return fts
+end
+
+"""
+    fluxnet_flux_observations(site::FLUXNETSite, architecture = CPU(), FT = Float64;
+                              start_date = first_date(site, :sensible_heat_flux),
+                              end_date = last_date(site, :sensible_heat_flux),
+                              quality_control = nothing,
+                              max_gap = 0)
+
+Return the measured surface-energy-balance fluxes for a FLUXNET tower as a
+`NamedTuple` of single-column `FieldTimeSeries`, for use as calibration targets:
+
+- `H`: sensible heat flux `H_F_MDS` (W m⁻²)
+- `LE`: latent heat flux `LE_F_MDS` (W m⁻²)
+- `ustar`: friction velocity `USTAR` (m s⁻¹)
+- `Rn`: net radiation `NETRAD` (W m⁻²)
+- `G`: ground heat flux `G_F_MDS` (W m⁻²)
+
+Keyword Arguments
+=================
+- `start_date`, `end_date`: time range to load.
+- `quality_control`: if set to an integer, samples whose `_QC` flag exceeds it are
+  set to `NaN` (e.g. `0` keeps only measured values, `1` also keeps good-quality
+  gap-fill). Defaults to `nothing` (no masking).
+- `max_gap`: maximum gap length (in time steps) to fill by linear interpolation.
+  Defaults to `0` — targets are left with `NaN` gaps so a loss can skip them.
+"""
+function fluxnet_flux_observations(site::FLUXNETSite, architecture = CPU(), FT = Float64;
+                                   start_date = first_date(site, :sensible_heat_flux),
+                                   end_date = last_date(site, :sensible_heat_flux),
+                                   quality_control = nothing,
+                                   max_gap = 0)
+
+    grid = RectilinearGrid(architecture, FT; size=(), topology=(Flat, Flat, Flat))
+
+    function flux_fts(name)
+        md = Metadata(name; dataset = site, start_date, end_date, dir = site.dir)
+        fts = FieldTimeSeries(md, grid; time_indices_in_memory = length(md))
+        isnothing(quality_control) || mask_low_quality!(fts, site, md, name, quality_control)
+        max_gap > 0 && fill_gaps!(fts; max_gap)
+        return fts
+    end
+
+    return (; H     = flux_fts(:sensible_heat_flux),
+              LE    = flux_fts(:latent_heat_flux),
+              ustar = flux_fts(:friction_velocity),
+              Rn    = flux_fts(:net_radiation),
+              G     = flux_fts(:ground_heat_flux))
+end

--- a/src/DataWrangling/FLUXNET/FLUXNET_metadata.jl
+++ b/src/DataWrangling/FLUXNET/FLUXNET_metadata.jl
@@ -1,0 +1,213 @@
+#####
+##### FLUXNETSite dataset type
+#####
+
+"""
+    FLUXNETSite(site; product = "FLUXNET2015",
+                      kind = "FULLSET",
+                      resolution = :halfhourly,
+                      longitude = 0.0,
+                      latitude = 0.0,
+                      dir = download_FLUXNET_cache)
+
+A handle to the flux-tower record for a single FLUXNET `site` (e.g. `"US-Var"`),
+used as the `dataset` of a [`Metadata`](@ref). The data live in one comma-separated
+file per site and time `resolution`, named
+`FLX_<site>_<product>_<kind>_<HH|HR|DD>_<years>_<version>.csv`, discovered in `dir`
+by globbing on everything but the (unpredictable) year/version suffix.
+
+FLUXNET data requires registration and acceptance of a data-use policy and so is
+**not** downloaded automatically: download a site archive from
+<https://fluxnet.org/data/download-data/> (or AmeriFlux / ICOS), unzip it, and place
+the CSV in `dir`. Site coordinates are not stored in the flux file; pass `longitude`
+and `latitude` if a downstream consumer needs them.
+
+Keyword Arguments
+=================
+- `product`: data product, e.g. `"FLUXNET2015"`.
+- `kind`: `"FULLSET"` or `"SUBSET"`.
+- `resolution`: `:halfhourly` (`HH`), `:hourly` (`HR`), or `:daily` (`DD`).
+- `longitude`, `latitude`: site coordinates in degrees.
+- `dir`: directory holding the site CSV.
+"""
+struct FLUXNETSite
+    site :: String
+    product :: String
+    kind :: String
+    resolution :: Symbol
+    longitude :: Float64
+    latitude :: Float64
+    dir :: String
+end
+
+function FLUXNETSite(site; product = "FLUXNET2015",
+                           kind = "FULLSET",
+                           resolution = :halfhourly,
+                           longitude = 0.0,
+                           latitude = 0.0,
+                           dir = download_FLUXNET_cache)
+
+    resolution_token(resolution) # validate early
+    return FLUXNETSite(String(site), String(product), String(kind), Symbol(resolution),
+                       Float64(longitude), Float64(latitude), String(dir))
+end
+
+const FLUXNETMetadata{D} = Metadata{<:FLUXNETSite, D}
+const FLUXNETMetadatum   = Metadatum{<:FLUXNETSite}
+
+#####
+##### Variable name mapping: NumericalEarth names → FLUXNET2015 column names
+#####
+
+const FLUXNET_variable_names = Dict{Symbol, String}(
+    # Meteorological forcing (gap-filled `_F`)
+    :air_temperature              => "TA_F",       # °C → K
+    :surface_pressure             => "PA_F",       # kPa → Pa
+    :wind_speed                   => "WS_F",       # m s⁻¹
+    :relative_humidity            => "RH",         # %
+    :vapor_pressure_deficit       => "VPD_F",      # hPa
+    :precipitation                => "P_F",        # mm per averaging interval
+    :incoming_shortwave_radiation => "SW_IN_F",    # W m⁻²
+    :incoming_longwave_radiation  => "LW_IN_F",    # W m⁻²
+    :carbon_dioxide_mole_fraction => "CO2_F_MDS",  # µmol mol⁻¹
+    # Turbulent-flux targets (gap-filled `_F_MDS`; `_CORR` are energy-balance-corrected)
+    :sensible_heat_flux           => "H_F_MDS",    # W m⁻²
+    :latent_heat_flux             => "LE_F_MDS",   # W m⁻²
+    :sensible_heat_flux_corrected => "H_CORR",     # W m⁻²
+    :latent_heat_flux_corrected   => "LE_CORR",    # W m⁻²
+    :friction_velocity            => "USTAR",      # m s⁻¹
+    :net_radiation                => "NETRAD",     # W m⁻²
+    :ground_heat_flux             => "G_F_MDS",    # W m⁻²
+    # Soil state (shallowest gap-filled level)
+    :soil_temperature             => "TS_F_MDS_1", # °C → K
+    :soil_water_content           => "SWC_F_MDS_1",# %
+)
+
+#####
+##### File discovery + cached access
+#####
+
+fluxnet_glob(ds::FLUXNETSite) =
+    string("FLX_", ds.site, "_", ds.product, "_", ds.kind, "_",
+           resolution_token(ds.resolution), "_*.csv")
+
+function fluxnet_path(ds::FLUXNETSite)
+    pattern = fluxnet_glob(ds)
+    matches = glob(pattern, ds.dir)
+
+    if isempty(matches)
+        error("""
+              No FLUXNET file matching "$pattern" found in "$(ds.dir)".
+              FLUXNET data requires registration and acceptance of a data-use policy and
+              cannot be downloaded automatically. Download the site archive from
+              https://fluxnet.org/data/download-data/ (or AmeriFlux / ICOS), unzip it, and
+              place the "$pattern" file in "$(ds.dir)".
+              """)
+    end
+
+    sorted = sort(matches)
+    length(sorted) > 1 &&
+        @warn "Multiple FLUXNET files match \"$pattern\" in \"$(ds.dir)\"; using $(basename(first(sorted)))"
+
+    return first(sorted)
+end
+
+fluxnet_filename(ds::FLUXNETSite) = basename(fluxnet_path(ds))
+
+function fluxnet_file(ds::FLUXNETSite)
+    path = fluxnet_path(ds)
+    return get!(() -> read_fluxnet_csv(path), FLUXNET_FILE_CACHE, path)
+end
+
+fluxnet_timestamps(ds::FLUXNETSite) = first(fluxnet_file(ds))
+fluxnet_columns(ds::FLUXNETSite)    = last(fluxnet_file(ds))
+
+function fluxnet_time_index(ds::FLUXNETSite, date)
+    path = fluxnet_path(ds)
+    index = get!(FLUXNET_TIME_INDEX_CACHE, path) do
+        Dict(t => i for (i, t) in enumerate(fluxnet_timestamps(ds)))
+    end
+    return get(index, DateTime(date), nothing)
+end
+
+#####
+##### Metadata interface
+#####
+
+DataWrangling.metaprefix(::FLUXNETMetadata) = "FLUXNETMetadata"
+DataWrangling.default_download_directory(ds::FLUXNETSite) = mkpath(ds.dir)
+DataWrangling.available_variables(::FLUXNETSite) = FLUXNET_variable_names
+DataWrangling.dataset_variable_name(md::FLUXNETMetadata) = FLUXNET_variable_names[md.name]
+
+Oceananigans.location(::FLUXNETMetadata) = (Center, Center, Center)
+DataWrangling.is_three_dimensional(::FLUXNETMetadata) = false
+DataWrangling.default_inpainting(::FLUXNETMetadata) = nothing
+
+Base.size(::FLUXNETSite, variable) = (1, 1, 1)
+
+DataWrangling.metadata_epoch(ds::FLUXNETSite) = first(fluxnet_timestamps(ds))
+DataWrangling.metadata_time_step(ds::FLUXNETSite) = resolution_seconds(ds.resolution)
+DataWrangling.all_dates(ds::FLUXNETSite, variable) = fluxnet_timestamps(ds)
+
+DataWrangling.longitude_interfaces(ds::FLUXNETSite) = (ds.longitude, ds.longitude)
+DataWrangling.latitude_interfaces(ds::FLUXNETSite)  = (ds.latitude, ds.latitude)
+
+# A tower is a single point: a `Flat, Flat, Flat` column carries the time series.
+DataWrangling.native_grid(::FLUXNETMetadata, arch=CPU(); halo=(3, 3, 3)) =
+    RectilinearGrid(arch; size=(), topology=(Flat, Flat, Flat))
+
+DataWrangling.metadata_filename(ds::FLUXNETSite, name, date, region) = fluxnet_filename(ds)
+DataWrangling.build_filename(ds::FLUXNETSite, name, dates::AbstractArray, region) = fluxnet_filename(ds)
+
+# FLUXNET is distributed as local files (no anonymous download); resolve the path,
+# erroring with download instructions if the site CSV is not present.
+Downloads.download(md::FLUXNETMetadata) = fluxnet_path(md.dataset)
+
+#####
+##### Unit conversions
+#####
+
+struct Kilopascal end # atmospheric pressure kPa → Pa
+DataWrangling.convert_units(P::FT, ::Kilopascal) where FT = P * convert(FT, 1000)
+
+function DataWrangling.conversion_units(md::FLUXNETMetadatum)
+    md.name in (:air_temperature, :soil_temperature) && return Celsius()
+    md.name == :surface_pressure && return Kilopascal()
+    return nothing
+end
+
+#####
+##### Data retrieval — read a single sample from the parsed CSV
+#####
+
+function DataWrangling.retrieve_data(metadata::FLUXNETMetadatum)
+    columns = fluxnet_columns(metadata.dataset)
+    name = DataWrangling.dataset_variable_name(metadata)
+    haskey(columns, name) ||
+        error("FLUXNET site $(metadata.dataset.site) has no column \"$name\" for variable $(metadata.name)")
+
+    index = fluxnet_time_index(metadata.dataset, metadata.dates)
+    isnothing(index) &&
+        error("Date $(metadata.dates) not found in FLUXNET site $(metadata.dataset.site)")
+
+    return reshape([columns[name][index]], 1, 1, 1)
+end
+
+# The generic `set!`/`Field` read coordinates from a NetCDF file; FLUXNET is a CSV,
+# so fill the single column directly, applying the unit conversion in the same step.
+function Oceananigans.Fields.set!(target::Field, metadata::FLUXNETMetadatum; kw...)
+    arch = child_architecture(target.grid)
+    FT = eltype(target)
+    raw = DataWrangling.retrieve_data(metadata)
+    value = DataWrangling.convert_units(convert(FT, raw[1, 1, 1]), DataWrangling.conversion_units(metadata))
+    interior(target) .= on_architecture(arch, reshape([value], 1, 1, 1))
+    return target
+end
+
+function Oceananigans.Fields.Field(metadata::FLUXNETMetadatum, arch=CPU(); kw...)
+    grid = DataWrangling.native_grid(metadata, arch)
+    LX, LY, LZ = Oceananigans.location(metadata)
+    field = Field{LX, LY, LZ}(grid)
+    Oceananigans.Fields.set!(field, metadata; kw...)
+    return field
+end

--- a/src/DataWrangling/FLUXNET/FLUXNET_metadata.jl
+++ b/src/DataWrangling/FLUXNET/FLUXNET_metadata.jl
@@ -3,52 +3,51 @@
 #####
 
 """
-    FLUXNETSite(site; product = "FLUXNET2015",
-                      kind = "FULLSET",
+    FLUXNETSite(site; grouping = "FULLSET",
                       resolution = :halfhourly,
                       longitude = 0.0,
                       latitude = 0.0,
                       dir = download_FLUXNET_cache)
 
-A handle to the flux-tower record for a single FLUXNET `site` (e.g. `"US-Var"`),
-used as the `dataset` of a [`Metadata`](@ref). The data live in one comma-separated
+A handle to the [FLUXNET Shuttle](https://data.fluxnet.org) data product for a
+single flux-tower `site` (e.g. `"US-Var"`), used as the `dataset` of a
+[`Metadata`](@ref). The Shuttle federates the ONEFlux-processed FLUXNET products
+of the regional networks (AmeriFlux, ICOS, TERN, …); each is one comma-separated
 file per site and time `resolution`, named
-`FLX_<site>_<product>_<kind>_<HH|HR|DD>_<years>_<version>.csv`, discovered in `dir`
-by globbing on everything but the (unpredictable) year/version suffix.
+`<PUBLISHER>_<site>_<PROCESSING-VERSION>_<grouping>_<HH|HR|DD>_<years>_<version>.csv`
+(e.g. `AMF_US-Var_FLUXNET_FULLSET_HH_…`). Files are discovered in `dir` by matching
+on the stable `grouping`/`resolution` tokens, so the publisher prefix and processing
+version — which differ across hubs — are irrelevant.
 
-FLUXNET data requires registration and acceptance of a data-use policy and so is
-**not** downloaded automatically: download a site archive from
-<https://fluxnet.org/data/download-data/> (or AmeriFlux / ICOS), unzip it, and place
-the CSV in `dir`. Site coordinates are not stored in the flux file; pass `longitude`
-and `latitude` if a downstream consumer needs them.
+If no matching file is present, it is downloaded from the Shuttle via the
+`fluxnet-shuttle` command-line tool (see [`download_from_shuttle`](@ref)). Site
+coordinates are not stored in the flux file; pass `longitude`/`latitude` if a
+downstream consumer needs them.
 
 Keyword Arguments
 =================
-- `product`: data product, e.g. `"FLUXNET2015"`.
-- `kind`: `"FULLSET"` or `"SUBSET"`.
+- `grouping`: `"FULLSET"` (all variables) or `"SUBSET"` (core variables).
 - `resolution`: `:halfhourly` (`HH`), `:hourly` (`HR`), or `:daily` (`DD`).
 - `longitude`, `latitude`: site coordinates in degrees.
-- `dir`: directory holding the site CSV.
+- `dir`: directory holding (or to download) the site CSV.
 """
 struct FLUXNETSite
     site :: String
-    product :: String
-    kind :: String
+    grouping :: String
     resolution :: Symbol
     longitude :: Float64
     latitude :: Float64
     dir :: String
 end
 
-function FLUXNETSite(site; product = "FLUXNET2015",
-                           kind = "FULLSET",
+function FLUXNETSite(site; grouping = "FULLSET",
                            resolution = :halfhourly,
                            longitude = 0.0,
                            latitude = 0.0,
                            dir = download_FLUXNET_cache)
 
     resolution_token(resolution) # validate early
-    return FLUXNETSite(String(site), String(product), String(kind), Symbol(resolution),
+    return FLUXNETSite(String(site), String(grouping), Symbol(resolution),
                        Float64(longitude), Float64(latitude), String(dir))
 end
 
@@ -56,7 +55,7 @@ const FLUXNETMetadata{D} = Metadata{<:FLUXNETSite, D}
 const FLUXNETMetadatum   = Metadatum{<:FLUXNETSite}
 
 #####
-##### Variable name mapping: NumericalEarth names → FLUXNET2015 column names
+##### Variable name mapping: NumericalEarth names → ONEFlux FLUXNET column names
 #####
 
 const FLUXNET_variable_names = Dict{Symbol, String}(
@@ -87,8 +86,11 @@ const FLUXNET_variable_names = Dict{Symbol, String}(
 ##### File discovery + cached access
 #####
 
+# Publisher- and processing-version-agnostic: match only the stable ONEFlux
+# `<grouping>_<resolution>` tokens, so `AMF_…_FLUXNET_…`, `FLX_…_FLUXNET2015_…`,
+# and other hubs' products are all found.
 fluxnet_glob(ds::FLUXNETSite) =
-    string("FLX_", ds.site, "_", ds.product, "_", ds.kind, "_",
+    string("*_", ds.site, "_*_", ds.grouping, "_",
            resolution_token(ds.resolution), "_*.csv")
 
 function fluxnet_path(ds::FLUXNETSite)
@@ -96,14 +98,12 @@ function fluxnet_path(ds::FLUXNETSite)
     matches = glob(pattern, ds.dir)
 
     if isempty(matches)
-        error("""
-              No FLUXNET file matching "$pattern" found in "$(ds.dir)".
-              FLUXNET data requires registration and acceptance of a data-use policy and
-              cannot be downloaded automatically. Download the site archive from
-              https://fluxnet.org/data/download-data/ (or AmeriFlux / ICOS), unzip it, and
-              place the "$pattern" file in "$(ds.dir)".
-              """)
+        download_from_shuttle(ds)            # fetch via the FLUXNET Shuttle
+        matches = glob(pattern, ds.dir)
     end
+
+    isempty(matches) &&
+        error("No FLUXNET file matching \"$pattern\" found in \"$(ds.dir)\" after download.")
 
     sorted = sort(matches)
     length(sorted) > 1 &&
@@ -159,8 +159,7 @@ DataWrangling.native_grid(::FLUXNETMetadata, arch=CPU(); halo=(3, 3, 3)) =
 DataWrangling.metadata_filename(ds::FLUXNETSite, name, date, region) = fluxnet_filename(ds)
 DataWrangling.build_filename(ds::FLUXNETSite, name, dates::AbstractArray, region) = fluxnet_filename(ds)
 
-# FLUXNET is distributed as local files (no anonymous download); resolve the path,
-# erroring with download instructions if the site CSV is not present.
+# Resolve the site file, downloading it from the FLUXNET Shuttle if not present.
 Downloads.download(md::FLUXNETMetadata) = fluxnet_path(md.dataset)
 
 #####

--- a/src/DataWrangling/FLUXNET/FLUXNET_prescribed_atmosphere.jl
+++ b/src/DataWrangling/FLUXNET/FLUXNET_prescribed_atmosphere.jl
@@ -1,0 +1,88 @@
+"""
+    fluxnet_specific_humidity_fts(site, Ta, pa, ℂ; start_date, end_date, max_gap)
+
+Build a `FieldTimeSeries` of specific humidity (kg kg⁻¹) for `site` from air
+temperature `Ta` (K) and pressure `pa` (Pa). Relative humidity is read directly
+(`RH`, %) when present; otherwise it is recovered from the vapor pressure deficit
+`VPD_F` (hPa) as `RH = 1 − VPD / qᵛ⁺(Ta)`. Specific humidity then follows from
+`Thermodynamics.q_vap_from_RH` with the `Liquid()` saturation curve.
+"""
+function fluxnet_specific_humidity_fts(site, Ta, pa, ℂ; start_date, end_date, max_gap)
+    grid = Ta.grid
+    columns = fluxnet_columns(site)
+    qa = FieldTimeSeries{Center, Center, Nothing}(grid, Ta.times)
+
+    has_relative_humidity = haskey(columns, "RH") && any(!isnan, columns["RH"])
+
+    if has_relative_humidity
+        RHa = fluxnet_field_time_series(site, :relative_humidity, grid; start_date, end_date, max_gap)
+        RH = parent(RHa) ./ 100
+    else
+        VPDa = fluxnet_field_time_series(site, :vapor_pressure_deficit, grid; start_date, end_date, max_gap)
+        esat = saturation_vapor_pressure.(Ref(ℂ), parent(Ta), Ref(Liquid()))
+        RH = clamp.(1 .- (parent(VPDa) .* 100) ./ esat, 0, 1) # VPD hPa → Pa
+    end
+
+    parent(qa) .= q_vap_from_RH.(Ref(ℂ), parent(pa), parent(Ta), RH, Ref(Liquid()))
+    max_gap > 0 && fill_gaps!(qa; max_gap)
+    return qa
+end
+
+"""
+    FLUXNETPrescribedAtmosphere(site::FLUXNETSite, architecture = CPU(), FT = Float64;
+                                start_date = first_date(site, :air_temperature),
+                                end_date = last_date(site, :air_temperature),
+                                surface_layer_height = 10,
+                                max_gap = 48,
+                                thermodynamics_parameters = nothing)
+
+Construct a [`PrescribedAtmosphere`](@ref) from a FLUXNET flux tower's
+meteorological record on a single-column `Flat, Flat, Flat` grid, suitable for
+forcing a single-column land model.
+
+Air temperature (`TA_F`), pressure (`PA_F`), and wind speed (`WS_F`) are loaded
+directly; specific humidity is derived from `RH`/`VPD_F` (see
+[`fluxnet_specific_humidity_fts`](@ref)); precipitation (`P_F`, mm per averaging
+interval) is converted to a mass flux (kg m⁻² s⁻¹). Because towers report a scalar
+wind *speed*, it is placed in the eastward component with `v = 0`.
+
+Keyword Arguments
+=================
+- `start_date`, `end_date`: time range to load.
+- `surface_layer_height`: tower measurement height in meters.
+- `max_gap`: maximum gap length (in time steps) to fill by linear interpolation.
+- `thermodynamics_parameters`: shared thermodynamics (defaults to
+  `AtmosphereThermodynamicsParameters` at float type `FT`).
+"""
+function FLUXNETPrescribedAtmosphere(site::FLUXNETSite, architecture = CPU(), FT = Float64;
+                                     start_date = first_date(site, :air_temperature),
+                                     end_date = last_date(site, :air_temperature),
+                                     surface_layer_height = 10,
+                                     max_gap = 48,
+                                     thermodynamics_parameters = nothing)
+
+    grid = RectilinearGrid(architecture, FT; size=(), topology=(Flat, Flat, Flat))
+    fts(name) = fluxnet_field_time_series(site, name, grid; start_date, end_date, max_gap)
+
+    Ta = fts(:air_temperature) # K
+    pa = fts(:surface_pressure) # Pa
+    ua = fts(:wind_speed)       # m s⁻¹, placed in the eastward component
+
+    va = FieldTimeSeries{Center, Center, Nothing}(grid, ua.times)
+    parent(va) .= 0
+
+    ℂ = isnothing(thermodynamics_parameters) ? AtmosphereThermodynamicsParameters(FT) :
+                                                thermodynamics_parameters
+    qa = fluxnet_specific_humidity_fts(site, Ta, pa, ℂ; start_date, end_date, max_gap)
+
+    rain = fts(:precipitation) # mm per averaging interval
+    parent(rain) ./= resolution_seconds(site.resolution) # mm/interval → kg m⁻² s⁻¹
+
+    return PrescribedAtmosphere(grid, ua.times;
+                                velocities = (u = ua, v = va),
+                                tracers = (T = Ta, q = qa),
+                                pressure = pa,
+                                freshwater_flux = PrescribedPrecipitationFlux(; rain),
+                                thermodynamics_parameters = ℂ,
+                                surface_layer_height = convert(FT, surface_layer_height))
+end

--- a/src/DataWrangling/FLUXNET/FLUXNET_prescribed_radiation.jl
+++ b/src/DataWrangling/FLUXNET/FLUXNET_prescribed_radiation.jl
@@ -1,0 +1,30 @@
+"""
+    FLUXNETPrescribedRadiation(site::FLUXNETSite, architecture = CPU(), FT = Float64;
+                               start_date = first_date(site, :incoming_shortwave_radiation),
+                               end_date = last_date(site, :incoming_shortwave_radiation),
+                               max_gap = 48,
+                               land_surface = SurfaceRadiationProperties(0.2, 0.97),
+                               stefan_boltzmann_constant = default_stefan_boltzmann_constant)
+
+Construct a [`PrescribedRadiation`](@ref) from a FLUXNET tower's downwelling
+shortwave (`SW_IN_F`) and longwave (`LW_IN_F`) radiation on a single-column grid.
+`land_surface` sets the surface albedo and emissivity; ocean and sea-ice surfaces
+are omitted.
+"""
+function FLUXNETPrescribedRadiation(site::FLUXNETSite, architecture = CPU(), FT = Float64;
+                                    start_date = first_date(site, :incoming_shortwave_radiation),
+                                    end_date = last_date(site, :incoming_shortwave_radiation),
+                                    max_gap = 48,
+                                    land_surface = SurfaceRadiationProperties(0.2, 0.97),
+                                    stefan_boltzmann_constant = default_stefan_boltzmann_constant)
+
+    grid = RectilinearGrid(architecture, FT; size=(), topology=(Flat, Flat, Flat))
+    sw = fluxnet_field_time_series(site, :incoming_shortwave_radiation, grid; start_date, end_date, max_gap)
+    lw = fluxnet_field_time_series(site, :incoming_longwave_radiation,  grid; start_date, end_date, max_gap)
+
+    return PrescribedRadiation(sw, lw;
+                               ocean_surface = nothing,
+                               sea_ice_surface = nothing,
+                               land_surface,
+                               stefan_boltzmann_constant)
+end

--- a/src/DataWrangling/FLUXNET/FLUXNET_shuttle.jl
+++ b/src/DataWrangling/FLUXNET/FLUXNET_shuttle.jl
@@ -1,0 +1,76 @@
+#####
+##### FLUXNET Shuttle download (https://data.fluxnet.org)
+#####
+##### Data is fetched through the official `fluxnet-shuttle` command-line tool, which
+##### federates the ONEFlux products of the regional networks (AmeriFlux, ICOS, TERN, …).
+##### Install it with:  pip install git+https://github.com/fluxnet/shuttle.git
+#####
+
+const FLUXNET_SHUTTLE_EXECUTABLE = "fluxnet-shuttle"
+const FLUXNET_SHUTTLE_INSTALL = "pip install git+https://github.com/fluxnet/shuttle.git"
+
+function fluxnet_shuttle_executable()
+    exe = Sys.which(FLUXNET_SHUTTLE_EXECUTABLE)
+    isnothing(exe) &&
+        error("""
+              The `$(FLUXNET_SHUTTLE_EXECUTABLE)` tool was not found on the PATH, so FLUXNET
+              data cannot be downloaded. Either install it with
+
+                  $(FLUXNET_SHUTTLE_INSTALL)
+
+              or download the site's FLUXNET data product from https://data.fluxnet.org and
+              place the unzipped CSV in the dataset's `dir`.
+              """)
+    return exe
+end
+
+# `listall` writes a timestamped catalog `fluxnet_shuttle_snapshot_<...>.csv`; reuse the
+# newest existing one (rebuilding it queries every hub) or create it in `dir`.
+function fluxnet_shuttle_snapshot(dir, exe)
+    existing = glob("fluxnet_shuttle_snapshot_*.csv", dir)
+    isempty(existing) || return first(sort(existing; rev=true))
+
+    @info "Building the FLUXNET Shuttle catalog (fluxnet-shuttle listall)..."
+    cd(dir) do
+        run(`$exe listall`)
+    end
+
+    snapshots = glob("fluxnet_shuttle_snapshot_*.csv", dir)
+    isempty(snapshots) &&
+        error("`$(FLUXNET_SHUTTLE_EXECUTABLE) listall` did not produce a snapshot in \"$dir\".")
+    return first(sort(snapshots; rev=true))
+end
+
+# The Shuttle delivers one archive zip per site; extract its CSVs alongside it.
+function extract_shuttle_archives(ds::FLUXNETSite)
+    for zip_path in glob(string("*_", ds.site, "_*.zip"), ds.dir)
+        reader = ZipFile.Reader(zip_path)
+        for file in reader.files
+            endswith(file.name, ".csv") || continue
+            out = joinpath(ds.dir, basename(file.name))
+            isfile(out) || open(io -> write(io, read(file)), out, "w")
+        end
+        close(reader)
+    end
+    return nothing
+end
+
+"""
+    download_from_shuttle(ds::FLUXNETSite)
+
+Download the FLUXNET data product for `ds.site` from the FLUXNET Shuttle into
+`ds.dir`, using the `fluxnet-shuttle` command-line tool, and unpack the resulting
+archive. Errors with installation instructions if the tool is not available.
+"""
+function download_from_shuttle(ds::FLUXNETSite)
+    exe = fluxnet_shuttle_executable()
+    mkpath(ds.dir)
+
+    snapshot = fluxnet_shuttle_snapshot(ds.dir, exe)
+
+    @info "Downloading FLUXNET site $(ds.site) from the FLUXNET Shuttle..."
+    @root run(`$exe download -f $snapshot -s $(ds.site) -o $(ds.dir) --quiet`)
+
+    extract_shuttle_archives(ds)
+    return nothing
+end

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -64,6 +64,10 @@ export
     OSPapaPrescribedAtmosphere,
     os_papa_prescribed_fluxes,
     os_papa_prescribed_flux_boundary_conditions,
+    FLUXNETSite,
+    FLUXNETPrescribedAtmosphere,
+    FLUXNETPrescribedRadiation,
+    fluxnet_flux_observations,
     FreezingLimitedOceanTemperature,
     SurfaceRadiationProperties,
     InterfaceRadiationFlux,
@@ -197,6 +201,7 @@ using .DataWrangling.WOA
 using .DataWrangling.JRA55
 using .DataWrangling.GloFAS
 using .DataWrangling.OSPapa
+using .DataWrangling.FLUXNET
 using .DataWrangling.ERA5
 using .DataWrangling.SoilGrids
 

--- a/test/test_fluxnet.jl
+++ b/test/test_fluxnet.jl
@@ -1,0 +1,170 @@
+include("runtests_setup.jl")
+
+using NumericalEarth.FLUXNET
+using NumericalEarth.Atmospheres: PrescribedAtmosphere, PrescribedPrecipitationFlux
+using NumericalEarth.Radiations: PrescribedRadiation
+using Dates: DateTime, Minute, format
+using Printf: @sprintf
+
+# Write a small synthetic FLUXNET2015 half-hourly CSV covering a few diurnal cycles.
+# `with_relative_humidity` toggles the FULLSET (`RH` present) vs SUBSET (`VPD_F` only)
+# humidity path. A handful of `-9999` and elevated QC flags exercise gap filling and
+# quality-control masking.
+function write_synthetic_fluxnet(dir; site="XX-Tst", kind="FULLSET",
+                                 start = DateTime(2020, 1, 1), ndays = 3,
+                                 with_relative_humidity = true)
+    Δ = Minute(30)
+    times = start : Δ : (start + Minute(30) * (48 * ndays - 1))
+
+    columns = ["TIMESTAMP_START", "TIMESTAMP_END",
+               "TA_F", "TA_F_QC", "PA_F", "WS_F",
+               "VPD_F", "P_F", "SW_IN_F", "LW_IN_F", "CO2_F_MDS",
+               "H_F_MDS", "H_F_MDS_QC", "LE_F_MDS", "LE_F_MDS_QC",
+               "USTAR", "NETRAD", "G_F_MDS", "TS_F_MDS_1", "SWC_F_MDS_1"]
+    with_relative_humidity && insert!(columns, findfirst(==("VPD_F"), columns), "RH")
+
+    rows = String[join(columns, ",")]
+    for (i, t) in enumerate(times)
+        hour = (i - 1) % 48 / 2                # local hour of day
+        daylight = max(0.0, sinpi((hour - 6) / 12))
+        Ta = 15 + 8 * sinpi((hour - 9) / 12)   # °C
+        VPD = 2 + 8 * daylight                 # hPa
+        RH = 90 - 40 * daylight                # %
+        SW = 800 * daylight                    # W/m²
+        H  = 220 * daylight                    # W/m²
+        LE = 160 * daylight                    # W/m²
+        rain = (i % 40 == 0) ? 0.6 : 0.0       # mm/30min, occasional
+        # Missing air-temperature sample (short gap) and a poor-quality H flag.
+        Ta_str = i == 5 ? "-9999" : @sprintf("%.3f", Ta)
+        H_qc   = i in (10, 11) ? 3 : 0
+
+        fields = [format(t, "yyyymmddHHMM"),
+                  format(t + Δ, "yyyymmddHHMM"),
+                  Ta_str, "0",
+                  @sprintf("%.3f", 101.3),     # PA_F  kPa
+                  @sprintf("%.3f", 2.5),       # WS_F  m/s
+                  ]
+        with_relative_humidity && push!(fields, @sprintf("%.3f", RH))
+        append!(fields, [@sprintf("%.3f", VPD),
+                         @sprintf("%.4f", rain),
+                         @sprintf("%.3f", SW),
+                         @sprintf("%.3f", 320.0),   # LW_IN_F
+                         @sprintf("%.3f", 400.0),   # CO2_F_MDS
+                         @sprintf("%.3f", H), string(H_qc),
+                         @sprintf("%.3f", LE), "0",
+                         @sprintf("%.4f", 0.35),    # USTAR
+                         @sprintf("%.3f", SW - 120),# NETRAD
+                         @sprintf("%.3f", 10.0),    # G_F_MDS
+                         @sprintf("%.3f", 12.0),    # TS_F_MDS_1  °C
+                         @sprintf("%.3f", 25.0)])   # SWC_F_MDS_1 %
+        push!(rows, join(fields, ","))
+    end
+
+    filename = "FLX_$(site)_FLUXNET2015_$(kind)_HH_2020-2020_1-1.csv"
+    path = joinpath(dir, filename)
+    open(io -> foreach(r -> println(io, r), rows), path, "w")
+    return path
+end
+
+@testset "FLUXNET metadata + FieldTimeSeries parsing" begin
+    for arch in test_architectures
+        dir = mktempdir()
+        write_synthetic_fluxnet(dir)
+        site = FLUXNETSite("XX-Tst"; dir, longitude = -120.95, latitude = 38.41)
+
+        @test all_dates(site, :air_temperature)[1] == DateTime(2020, 1, 1)
+        @test length(all_dates(site, :air_temperature)) == 48 * 3
+
+        grid = RectilinearGrid(arch; size=(), topology=(Flat, Flat, Flat))
+
+        # Air temperature: °C → K, with the injected -9999 filled by fill_gaps!.
+        md = Metadata(:air_temperature; dataset = site, dir)
+        Ta = FieldTimeSeries(md, grid; time_indices_in_memory = length(md))
+        NumericalEarth.DataWrangling.fill_gaps!(Ta; max_gap = 4)
+        Ta_data = Array(interior(Ta))
+        @test all(isfinite, Ta_data)
+        @test all(240 .< Ta_data .< 320)     # sane Kelvin range
+
+        # Pressure: kPa → Pa.
+        pmd = Metadata(:surface_pressure; dataset = site, dir)
+        pa = FieldTimeSeries(pmd, grid; time_indices_in_memory = length(pmd))
+        @test all(Array(interior(pa)) .≈ 101300)
+    end
+end
+
+@testset "FLUXNETPrescribedAtmosphere" begin
+    for arch in test_architectures
+        for with_rh in (true, false)
+            dir = mktempdir()
+            write_synthetic_fluxnet(dir; with_relative_humidity = with_rh)
+            site = FLUXNETSite("XX-Tst"; dir)
+
+            atmosphere = FLUXNETPrescribedAtmosphere(site, arch)
+
+            @test atmosphere isa PrescribedAtmosphere
+            @test haskey(atmosphere.velocities, :u)
+            @test haskey(atmosphere.velocities, :v)
+            @test atmosphere.tracers.T isa FieldTimeSeries
+            @test atmosphere.tracers.q isa FieldTimeSeries
+            @test atmosphere.freshwater_flux isa PrescribedPrecipitationFlux
+
+            T_data = Array(interior(atmosphere.tracers.T))
+            q_data = Array(interior(atmosphere.tracers.q))
+            u_data = Array(interior(atmosphere.velocities.u))
+            v_data = Array(interior(atmosphere.velocities.v))
+            rain_data = Array(interior(atmosphere.freshwater_flux.rain))
+
+            @test all(240 .< T_data .< 320)
+            @test all(0 .< q_data .< 0.05)       # physical specific humidity
+            @test all(isfinite, q_data)
+            @test all(u_data .≈ 2.5)             # scalar wind speed in the eastward slot
+            @test all(v_data .== 0)
+            @test all(rain_data .≥ 0)
+            @test maximum(rain_data) ≈ 0.6 / 1800  # mm/30min → kg/m²/s
+        end
+    end
+end
+
+@testset "FLUXNETPrescribedRadiation" begin
+    for arch in test_architectures
+        dir = mktempdir()
+        write_synthetic_fluxnet(dir)
+        site = FLUXNETSite("XX-Tst"; dir)
+
+        radiation = FLUXNETPrescribedRadiation(site, arch)
+        @test radiation isa PrescribedRadiation
+        @test haskey(radiation.surface_properties, :land)
+
+        sw = Array(interior(radiation.downwelling_shortwave))
+        lw = Array(interior(radiation.downwelling_longwave))
+        @test all(sw .≥ 0)
+        @test maximum(sw) < 1500
+        @test all(lw .> 0)
+    end
+end
+
+@testset "fluxnet_flux_observations + quality control" begin
+    for arch in test_architectures
+        dir = mktempdir()
+        write_synthetic_fluxnet(dir)
+        site = FLUXNETSite("XX-Tst"; dir)
+
+        observations = fluxnet_flux_observations(site, arch)
+        @test keys(observations) == (:H, :LE, :ustar, :Rn, :G)
+        for fts in observations
+            @test fts isa FieldTimeSeries
+        end
+
+        # Without masking, all values are present.
+        H_all = Array(interior(observations.H))
+        @test all(isfinite, H_all)
+
+        # With QC ≤ 1, the two H_F_MDS_QC = 3 samples (indices 10, 11) become NaN.
+        masked = fluxnet_flux_observations(site, arch; quality_control = 1)
+        H_masked = vec(Array(interior(masked.H)))
+        @test isnan(H_masked[10]) && isnan(H_masked[11])
+        @test count(isnan, H_masked) == 2
+        # USTAR has no QC column, so masking leaves it untouched.
+        @test all(isfinite, Array(interior(masked.ustar)))
+    end
+end

--- a/test/test_fluxnet.jl
+++ b/test/test_fluxnet.jl
@@ -6,11 +6,14 @@ using NumericalEarth.Radiations: PrescribedRadiation
 using Dates: DateTime, Minute, format
 using Printf: @sprintf
 
-# Write a small synthetic FLUXNET2015 half-hourly CSV covering a few diurnal cycles.
-# `with_relative_humidity` toggles the FULLSET (`RH` present) vs SUBSET (`VPD_F` only)
-# humidity path. A handful of `-9999` and elevated QC flags exercise gap filling and
-# quality-control masking.
-function write_synthetic_fluxnet(dir; site="XX-Tst", kind="FULLSET",
+# Write a small synthetic ONEFlux FLUXNET half-hourly CSV covering a few diurnal
+# cycles, using the FLUXNET Shuttle file naming
+# `<publisher>_<site>_<processing_version>_<grouping>_HH_<years>_<version>.csv`.
+# `with_relative_humidity` toggles the FULLSET (`RH` present) vs SUBSET (`VPD_F`
+# only) humidity path. A handful of `-9999` and elevated QC flags exercise gap
+# filling and quality-control masking.
+function write_synthetic_fluxnet(dir; site="XX-Tst", grouping="FULLSET",
+                                 publisher="AMF", processing_version="FLUXNET",
                                  start = DateTime(2020, 1, 1), ndays = 3,
                                  with_relative_humidity = true)
     Δ = Minute(30)
@@ -60,7 +63,7 @@ function write_synthetic_fluxnet(dir; site="XX-Tst", kind="FULLSET",
         push!(rows, join(fields, ","))
     end
 
-    filename = "FLX_$(site)_FLUXNET2015_$(kind)_HH_2020-2020_1-1.csv"
+    filename = "$(publisher)_$(site)_$(processing_version)_$(grouping)_HH_2020-2020_1-1.csv"
     path = joinpath(dir, filename)
     open(io -> foreach(r -> println(io, r), rows), path, "w")
     return path
@@ -89,6 +92,19 @@ end
         pmd = Metadata(:surface_pressure; dataset = site, dir)
         pa = FieldTimeSeries(pmd, grid; time_indices_in_memory = length(pmd))
         @test all(Array(interior(pa)) .≈ 101300)
+    end
+end
+
+@testset "Shuttle publisher/version-agnostic discovery" begin
+    # The same site is found regardless of the hub's publisher prefix and
+    # processing version — AmeriFlux (AMF_/FLUXNET) and legacy FLUXNET2015 (FLX_).
+    for (publisher, version) in (("AMF", "FLUXNET"), ("FLX", "FLUXNET2015"))
+        dir = mktempdir()
+        write_synthetic_fluxnet(dir; publisher, processing_version = version)
+        site = FLUXNETSite("XX-Tst"; dir)
+        @test length(all_dates(site, :air_temperature)) == 48 * 3
+        @test basename(NumericalEarth.FLUXNET.fluxnet_path(site)) ==
+              "$(publisher)_XX-Tst_$(version)_FULLSET_HH_2020-2020_1-1.csv"
     end
 end
 


### PR DESCRIPTION
Ingests flux-tower records from the [FLUXNET Shuttle](https://data.fluxnet.org) — the current system that supersedes FLUXNET2015 and federates the regional networks' ONEFlux products (AmeriFlux, ICOS, TERN, …) — for driving and calibrating a single-column land model. Follows the `OSPapa` point-observation pattern and reuses the `Metadata`/`FieldTimeSeries`/`PrescribedAtmosphere` machinery.

New `NumericalEarth.DataWrangling.FLUXNET` submodule:

- `FLUXNETSite(site; grouping, resolution, longitude, latitude, dir)` — a `Metadata` dataset for one site's Shuttle product. Discovery is publisher/processing-version-agnostic (globs the stable `<grouping>_<resolution>` tokens), so `AMF_…FLUXNET…`, `FLX_…FLUXNET2015…`, and other hubs' files all resolve. Missing files are downloaded lazily via the official `fluxnet-shuttle` CLI (no credentials; CC-BY), with a clear install error if it's absent.
- `FLUXNETPrescribedAtmosphere` — `TA_F`/`PA_F`/`WS_F`/`RH`|`VPD_F`/`P_F` as a single-column `PrescribedAtmosphere`; specific humidity derived via `Thermodynamics`.
- `FLUXNETPrescribedRadiation` — downwelling `SW_IN_F`/`LW_IN_F`.
- `fluxnet_flux_observations` — measured `H`, `LE`, `USTAR`, `NETRAD`, `G` as `FieldTimeSeries` targets, with optional quality-flag masking.

```julia
using NumericalEarth

site = FLUXNETSite("US-Var"; dir = "/path/to/fluxnet")   # downloads via fluxnet-shuttle if absent
atmosphere = FLUXNETPrescribedAtmosphere(site)
radiation  = FLUXNETPrescribedRadiation(site)
targets    = fluxnet_flux_observations(site; quality_control = 0)  # measured-only H, LE, ...
```

Self-contained test uses a synthetic ONEFlux CSV (no network, no CLI), and checks publisher/version-agnostic discovery. ExplicitImports clean. The live-download path (CLI + unzip) follows the codebase's shell-out/`ZipFile` patterns but is not exercised in CI.