### PR TITLE
Fix land mask in examples for Oceananigans 0.110.6+ OffsetArray bottom_height

### DIFF
--- a/examples/near_global_ocean_simulation.jl
+++ b/examples/near_global_ocean_simulation.jl
@@ -171,7 +171,7 @@ Nt = length(times)
 
 n = Observable(Nt)
 
-land = interior(T.grid.immersed_boundary.bottom_height) .≥ 0
+land = T.grid.immersed_boundary.bottom_height[1:Nx, 1:Ny, 1:1] .≥ 0
 
 Tn = @lift begin
     Tn = interior(T[$n])

--- a/examples/near_global_ocean_simulation.jl
+++ b/examples/near_global_ocean_simulation.jl
@@ -171,7 +171,7 @@ Nt = length(times)
 
 n = Observable(Nt)
 
-land = T.grid.immersed_boundary.bottom_height[1:Nx, 1:Ny, 1:1] .≥ 0
+land = view(T.grid.immersed_boundary.bottom_height, 1:Nx, 1:Ny, 1:1) .≥ 0
 
 Tn = @lift begin
     Tn = interior(T[$n])

--- a/examples/one_degree_simulation.jl
+++ b/examples/one_degree_simulation.jl
@@ -208,7 +208,9 @@ Nt = length(times)
 n = Observable(Nt)
 
 # We create a land mask and use it to fill land points with `NaN`s.
-land = interior(To.grid.immersed_boundary.bottom_height) .≥ 0
+# The grid's `bottom_height` is stored as a halo-padded `OffsetArray`,
+# so we index its interior to obtain a plain `Array`.
+land = To.grid.immersed_boundary.bottom_height[1:Nx, 1:Ny, 1:1] .≥ 0
 
 Toₙ = @lift begin
     Tₙ = interior(To[$n])

--- a/examples/one_degree_simulation.jl
+++ b/examples/one_degree_simulation.jl
@@ -209,8 +209,8 @@ n = Observable(Nt)
 
 # We create a land mask and use it to fill land points with `NaN`s.
 # The grid's `bottom_height` is stored as a halo-padded `OffsetArray`,
-# so we index its interior to obtain a plain `Array`.
-land = To.grid.immersed_boundary.bottom_height[1:Nx, 1:Ny, 1:1] .≥ 0
+# so we take a view of its interior to build the mask.
+land = view(To.grid.immersed_boundary.bottom_height, 1:Nx, 1:Ny, 1:1) .≥ 0
 
 Toₙ = @lift begin
     Tₙ = interior(To[$n])


### PR DESCRIPTION
The docs build on main fails while executing `one_degree_simulation.jl` ([failing run](https://github.com/NumericalEarth/NumericalEarth.jl/actions/runs/29315845726/job/87029574511)):

```
MethodError: no method matching interior(::OffsetArrays.OffsetArray{Float64, 3, Array{Float64, 3}})
```

Oceananigans v0.110.6 (CliMA/Oceananigans.jl#5737) changed `GridFittedBottom.bottom_height` from a `Field` to a plain halo-padded `OffsetArray`, so the one-argument `interior(bottom_height)` call used to build the land mask in the movie sections no longer has a matching method.

This PR builds the mask from a view of the interior of the `OffsetArray` instead:

```julia
land = view(To.grid.immersed_boundary.bottom_height, 1:Nx, 1:Ny, 1:1) .≥ 0
```

The resulting `(Nx, Ny, 1)` boolean mask applies to `interior(To[$n])` exactly as before, without copying the bottom height. Fixes both affected examples: `one_degree_simulation.jl` and `near_global_ocean_simulation.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)