### PR TITLE
Fix docs CI: Literate parse error + broken DOI

### DIFF
--- a/examples/coupled_conservation.jl
+++ b/examples/coupled_conservation.jl
@@ -451,7 +451,7 @@ function budget_column!(fig, col, name, unit, stores, Δ, ∫F;
     end
     axislegend(axs, position = :lt, framevisible = false)
 
-    # The two curves sit on top of each other, so the flux gets sparse markers to stay visible under the line.
+    ## The two curves sit on top of each other, so the flux gets sparse markers to stay visible under the line.
     axc = Axis(fig[2, col], ylabel = "Cumulative ($unit)")
     marked = 1:(length(τ) ÷ 25):length(τ)
     lines!(axc, τ, Δ, label = "Δ total", color = :black)

--- a/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
@@ -98,7 +98,7 @@ end
     mahrt_sun_subgrid_velocity(Δx; threshold = 5e3)
 
 Return the mesoscale subgrid velocity [m/s] for grid spacing `Δx` [m] following
-[Mahrt and Sun (1995)](https://doi.org/10.1175/1520-0493(1995)123<3032:TSVOMF>2.0.CO;2),
+[Mahrt and Sun (1995)](https://doi.org/10.1175/1520-0493(1995)123<3032:TSVSIT>2.0.CO;2),
 as implemented in the revised MM5 surface layer scheme of [Jiménez et al. (2012)](https://doi.org/10.1175/MWR-D-11-00056.1):
 
 ```math


### PR DESCRIPTION
Two fixes that unblock the documentation build (both were failing it in sequence):

1. **`coupled_conservation.jl`** — a full-line `# ` comment inside `budget_column!` was read by Literate as prose, splitting the function across code chunks (`ParseError: Expected end`). Changed to `##` so it stays a code comment.

2. **`similarity_theory_turbulent_fluxes.jl`** — the Mahrt & Sun (1995) DOI had the wrong AMS acronym (`TSVOMF`), which 404s and failed Documenter's linkcheck. Corrected to `TSVSIT`; the DOI now resolves.

Verified fix 1 with Literate's parser (`budget_column!` now lands in one complete chunk) and fix 2 against the DOI resolver (301 → non-fatal per Documenter's linkcheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)