### PR TITLE
Qualify CopernicusLandAlbedo decode/dekad helpers with dataset prefix

### DIFF
--- a/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
+++ b/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
@@ -34,8 +34,8 @@ diffuse fraction of the downwelling shortwave radiation:
 @inline bluesky_blend(α_bs, α_ws, f) = (1 - f) * α_bs + f * α_ws
 
 # Missing (the decoded fill value) and out-of-range values map to NaN; albedo ∈ [0, 1].
-@inline decode_albedo(α::Number) = ifelse((α < 0) | (α > 1), NaN32, Float32(α))
-@inline decode_albedo(::Missing) = NaN32
+@inline copernicus_albedo_decode(α::Number) = ifelse((α < 0) | (α > 1), NaN32, Float32(α))
+@inline copernicus_albedo_decode(::Missing) = NaN32
 
 #####
 ##### Dataset types
@@ -153,7 +153,7 @@ DataWrangling.latitude_interfaces(metadata::CopernicusAlbedoMetadata) =
 #####
 
 # CGLS dekads are stamped on day 10, day 20, and the last day of each month.
-function dekadal_dates(start_date, end_date)
+function copernicus_albedo_dekadal_dates(start_date, end_date)
     dates = DateTime[]
     d = DateTime(year(start_date), month(start_date), 1)
     while d ≤ end_date
@@ -174,7 +174,7 @@ const last_albedo_date  = DateTime(2020, 6, 30)
 # SPOT ends May 2014; PROBA-V takes over from June 2014.
 albedo_satellite(date) = date < DateTime(2014, 6, 1) ? "spot" : "proba"
 
-DataWrangling.all_dates(::CopernicusAlbedo, variable) = dekadal_dates(first_albedo_date, last_albedo_date)
+DataWrangling.all_dates(::CopernicusAlbedo, variable) = copernicus_albedo_dekadal_dates(first_albedo_date, last_albedo_date)
 
 # 12 climatological months; the year is arbitrary, only the month matters.
 DataWrangling.all_dates(::CopernicusAlbedoClimatology, variable) = [DateTime(2018, m, 1) for m in 1:12]
@@ -305,8 +305,8 @@ function DataWrangling.retrieve_data(metadatum::CopernicusAlbedoMetadatum)
         chunk = 1120
         for j in 1:chunk:Ny
             rows = j:min(j + chunk - 1, Ny)
-            α_bs = decode_albedo.(ds[blacksky_name][:, rows])
-            α_ws = decode_albedo.(ds[whitesky_name][:, rows])
+            α_bs = copernicus_albedo_decode.(ds[blacksky_name][:, rows])
+            α_ws = copernicus_albedo_decode.(ds[whitesky_name][:, rows])
             @. blended[:, rows] = bluesky_blend(α_bs, α_ws, f)
         end
         blended
@@ -387,7 +387,7 @@ function write_monthly_mean(filepath, source_paths, variable_names, latitude_chu
 
                 for path in source_paths
                     NCDataset(path) do ds
-                        α = decode_albedo.(ds[name][:, rows])
+                        α = copernicus_albedo_decode.(ds[name][:, rows])
                         @. Σα += ifelse(isnan(α), 0f0, α)
                         @. n += !isnan(α)
                     end

--- a/test/test_copernicus_albedo.jl
+++ b/test/test_copernicus_albedo.jl
@@ -1,12 +1,12 @@
 include("runtests_setup.jl")
 
 using NumericalEarth.DataWrangling: BoundingBox, Metadatum,
-                                    is_three_dimensional, default_inpainting,
-                                    dataset_variable_name, metadata_filename,
-                                    longitude_name, latitude_name, all_dates
+    is_three_dimensional, default_inpainting,
+    dataset_variable_name, metadata_filename,
+    longitude_name, latitude_name, all_dates
 using NumericalEarth.DataWrangling.CopernicusLandAlbedo: bluesky_blend, copernicus_albedo_decode,
-                                                         copernicus_albedo_dekadal_dates, albedo_satellite,
-                                                         albedo_cds_request_variables
+    copernicus_albedo_dekadal_dates, albedo_satellite,
+    albedo_cds_request_variables
 using Dates: DateTime, Day, day, month, daysinmonth
 
 @testset "Copernicus land albedo helpers" begin

--- a/test/test_copernicus_albedo.jl
+++ b/test/test_copernicus_albedo.jl
@@ -4,8 +4,8 @@ using NumericalEarth.DataWrangling: BoundingBox, Metadatum,
                                     is_three_dimensional, default_inpainting,
                                     dataset_variable_name, metadata_filename,
                                     longitude_name, latitude_name, all_dates
-using NumericalEarth.DataWrangling.CopernicusLandAlbedo: bluesky_blend, decode_albedo,
-                                                         dekadal_dates, albedo_satellite,
+using NumericalEarth.DataWrangling.CopernicusLandAlbedo: bluesky_blend, copernicus_albedo_decode,
+                                                         copernicus_albedo_dekadal_dates, albedo_satellite,
                                                          albedo_cds_request_variables
 using Dates: DateTime, Day, day, month, daysinmonth
 
@@ -14,18 +14,18 @@ using Dates: DateTime, Day, day, month, daysinmonth
     @test bluesky_blend(0.3, 0.5, 1.0) == 0.5
     @test bluesky_blend(0.3, 0.5, 0.2) ≈ 0.34
 
-    @test decode_albedo(0.37) === 0.37f0
-    @test decode_albedo(0) === 0.0f0
-    @test decode_albedo(1) === 1.0f0
-    @test isnan(decode_albedo(-0.01))
-    @test isnan(decode_albedo(1.2))
-    @test isnan(decode_albedo(missing))
-    @test isnan(decode_albedo(NaN32))
-    @test isnan(bluesky_blend(decode_albedo(missing), 0.5f0, 0.2f0))
+    @test copernicus_albedo_decode(0.37) === 0.37f0
+    @test copernicus_albedo_decode(0) === 0.0f0
+    @test copernicus_albedo_decode(1) === 1.0f0
+    @test isnan(copernicus_albedo_decode(-0.01))
+    @test isnan(copernicus_albedo_decode(1.2))
+    @test isnan(copernicus_albedo_decode(missing))
+    @test isnan(copernicus_albedo_decode(NaN32))
+    @test isnan(bluesky_blend(copernicus_albedo_decode(missing), 0.5f0, 0.2f0))
 end
 
 @testset "Copernicus land albedo dekadal dates" begin
-    dates = dekadal_dates(DateTime(2019, 1, 10), DateTime(2019, 12, 31))
+    dates = copernicus_albedo_dekadal_dates(DateTime(2019, 1, 10), DateTime(2019, 12, 31))
     @test length(dates) == 36
     @test issorted(dates)
     @test all(d -> day(d) in (10, 20, daysinmonth(d)), dates)


### PR DESCRIPTION
Give two internal `CopernicusLandAlbedo` helpers the `copernicus_albedo_` prefix already used by the module's consts, matching the `asterged_*` convention in the sibling ASTERGED module. Both bake in dataset-specific conventions, so they carry the dataset name.

- `decode_albedo` -> `copernicus_albedo_decode`
- `dekadal_dates` -> `copernicus_albedo_dekadal_dates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)