### PR TITLE
Use `ifelse` instead of ternary operator for Reactant compatibility

### DIFF
--- a/src/SeaIces/freezing_limited_ocean_temperature.jl
+++ b/src/SeaIces/freezing_limited_ocean_temperature.jl
@@ -85,7 +85,7 @@ function InterfaceComputations.compute_sea_ice_ocean_fluxes!(cm::FreezingLimited
     cᵒᶜ = ocean_properties.heat_capacity
 
     # Guard for ocean.model.clock.iteration == 0
-    Δt_frazil = ocean.model.clock.iteration == 0 ? convert(typeof(Δt), Inf) : Δt
+    Δt_frazil = ifelse(ocean.model.clock.iteration == 0, convert(typeof(Δt), Inf), Δt)
 
     launch!(arch, grid, :xy, _freeze_ocean_temperature!, 𝒬ᶠʳᶻ, Tᵒᶜ, Sᵒᶜ, liquidus, grid, ρᵒᶜ, cᵒᶜ, Δt_frazil)
 


### PR DESCRIPTION
Hopefully fixes https://github.com/NumericalEarth/NumericalEarth.jl/pull/411#issuecomment-5049005729