### PR TITLE
Reject regional reads whose file does not cover the native grid

### DIFF
--- a/src/DataWrangling/set_region_data.jl
+++ b/src/DataWrangling/set_region_data.jl
@@ -17,13 +17,16 @@ end
 # promoted to Float64; `tolerance` absorbs the promotion drift, capped at a quarter cell because
 # `eps(Float32) * |h|` alone exceeds half a cell on arc-second axes near 180°. On an axis whose
 # labels sit half a cell from the grid's nodes (regional ERA5 latitude), the tie resolves to the
-# label north/east of the node.
+# label north/east of the node. A node more than half a cell before the first label extrapolates to
+# an index below 1, marking a file that begins east/north of where the read starts.
 function file_cell_index(h, hc)
     Nh = length(hc)
     Nh > 1 || return 1
     j = clamp(searchsortedlast(hc, h), 1, Nh - 1)
-    tolerance = min(8 * eps(Float32) * max(1, abs(h)), abs(hc[j+1] - hc[j]) / 4)
-    return clamp(searchsortedfirst(hc, h - tolerance), 1, Nh)
+    Δ = hc[j+1] - hc[j]
+    tolerance = min(8 * eps(Float32) * max(1, abs(h)), abs(Δ) / 4)
+    h ≥ hc[1] && return clamp(searchsortedfirst(hc, h - tolerance), 1, Nh)
+    return 1 + ceil(Int, (h - tolerance - hc[1]) / Δ)
 end
 
 # Periodic only when the restricted span equals the full native span.
@@ -101,20 +104,19 @@ function region_info(::BoundingBox, target, λc, φc)
     # Shift the target's longitude into the file's `[λc[1], λc[1]+360)`, allowing half a cell of
     # slack at the west edge: a Float32 grid node can land a few ulps below `λc[1]`, and wrapping
     # such a node by +360° would place the window at the far end of the file.
-    if length(λc) > 1
-        λmin = convert_to_λ₀_λ₀_plus360(λmin, λc[1] - abs(λc[2] - λc[1]) / 2)
-    end
+    λfile = length(λc) > 1 ? convert_to_λ₀_λ₀_plus360(λmin, λc[1] - abs(λc[2] - λc[1]) / 2) : λmin
 
-    i₁ = file_cell_index(λmin, λc)
-    j₁ = file_cell_index(φmin, φc)
+    di = file_cell_index(λfile, λc) - 1
+    dj = file_cell_index(φmin, φc) - 1
 
     Nx, Ny, _ = size(target)
 
     # A window overhanging the file's east edge continues across the seam when the file spans the
-    # globe; a regional file has no data beyond its edge, so there the window is clamped inside.
+    # globe; a regional file has no data beyond its edge, so its window has to stay inside.
     Nλ = isnothing(infer_longitudinal_period(λc)) ? 0 : length(λc)
-    di = Nλ > 0 ? i₁ - 1 : clamp(i₁ - 1, 0, max(length(λc) - Nx, 0))
-    dj = clamp(j₁ - 1, 0, max(length(φc) - Ny, 0))
+    Nλ > 0 || validate_file_covers_grid(di, Nx, λmin, λc, "longitude")
+    validate_file_covers_grid(dj, Ny, φmin, φc, "latitude")
+
     return BoundingBoxOffset(di, dj, Nλ)
 end
 
@@ -123,6 +125,21 @@ function region_info(col::Column, target, λc, φc)
     j⁻, j⁺, wy = bracket_with_weight(φc, col.latitude)  # latitude is never cyclic
     FT = eltype(target)
     return ColumnInfo(i⁻, i⁺, j⁻, j⁺, FT(wx), FT(wy), col.interpolation)
+end
+
+# Data lands at one fixed offset into the file, so the file has to label every cell it fills.
+# `restrict` builds the native grid by bracketing the region with native cell centers, which
+# reaches one cell past an edge that falls on a cell face — a file materialized on the requested
+# region alone then comes up short, and its values would land on the wrong cells.
+function validate_file_covers_grid(offset, N, hmin, hc, axis)
+    0 ≤ offset && offset + N ≤ length(hc) && return nothing
+
+    Δ = length(hc) > 1 ? hc[2] - hc[1] : zero(eltype(hc))
+    throw(ArgumentError("the file does not cover the native grid in $axis: the read needs $N cells " *
+                        "from $hmin to $(hmin + (N - 1) * Δ), but the file labels $(length(hc)) cells " *
+                        "from $(first(hc)) to $(last(hc)). Materialize the file on " *
+                        "`native_grid(metadatum)`, or fetch a margin of native cells around the " *
+                        "region the way `era5_request_area` does."))
 end
 
 # 360 if `λc` spans the full globe (cyclic), else `nothing`.

--- a/test/test_bare_earth_terrain.jl
+++ b/test/test_bare_earth_terrain.jl
@@ -3,7 +3,8 @@ include("runtests_setup.jl")
 using NumericalEarth.Bathymetry: bare_earth_elevation, BathymetryRegridding
 using NumericalEarth.DataWrangling: validate_dataset_coverage, validate_region_covers_grid,
                                     default_region, dataset_bounding_box, native_grid,
-                                    file_cell_index, region_info, file_window, wrapped_i
+                                    file_cell_index, region_info, file_window, wrapped_i,
+                                    set_region_data!
 using NumericalEarth.DataWrangling.CopernicusDEM: GLO30
 using NumericalEarth.ETOPO
 using Oceananigans.Grids: λnodes
@@ -158,6 +159,42 @@ end
     # nothing to offset.
     @test first(longitude_range) == offset.di + 1
     @test region_info(region, field, longitudes[longitude_range], latitudes[latitude_range]).di == 0
+end
+
+@testset "windowed reads — data lands on the coordinates that carry it" begin
+    # Cell centers -0.5 … 4.5: the native grid of a (0, 4) box on a 1° lattice, one cell wider
+    # than the box on each side because `restrict` brackets it with cell centers.
+    grid   = LatitudeLongitudeGrid(CPU(); size = (6, 6), longitude = (-1, 5), latitude = (-1, 5),
+                                   topology = (Bounded, Bounded, Flat))
+    field  = Field{Center, Center, Nothing}(grid)
+    region = BoundingBox(longitude = (0, 4), latitude = (0, 4))
+    metadatum = Metadatum(:bottom_height; dataset = ETOPO2022(), region)
+
+    # A file that is exactly the grid's window: no offset, values stay put.
+    exact = collect(-0.5:1.0:4.5)
+    data  = reshape(Float64[10i + j for i in 1:6, j in 1:6], 6, 6, 1)
+    offset = region_info(region, field, exact, exact)
+    @test (offset.di, offset.dj) == (0, 0)
+    set_region_data!(field, data, exact, exact, metadatum)
+    @test interior(field, :, :, 1) == data[:, :, 1]
+
+    # A file over-fetched by two cells per side: the same values, located by coordinate.
+    padded      = collect(-2.5:1.0:6.5)
+    padded_data = reshape(Float64[10i + j for i in 1:10, j in 1:10], 10, 10, 1)
+    offset = region_info(region, field, padded, padded)
+    @test (offset.di, offset.dj) == (2, 2)
+    set_region_data!(field, padded_data, padded, padded, metadatum)
+    @test interior(field, :, :, 1) == padded_data[3:8, 3:8, 1]
+
+    # A file spanning the region rather than the grid reaches neither edge, and is rejected
+    # instead of writing its values one cell off.
+    short = collect(0.5:1.0:3.5)
+    short_data = reshape(Float64[10i + j for i in 1:4, j in 1:4], 4, 4, 1)
+    @test_throws ArgumentError region_info(region, field, short, short)
+    @test_throws ArgumentError set_region_data!(field, short_data, short, short, metadatum)
+
+    # A file starting north of the grid's first row is rejected as well.
+    @test_throws ArgumentError region_info(region, field, exact, collect(0.5:1.0:7.5))
 end
 
 @testset "windowed reads — guards on region and padding" begin


### PR DESCRIPTION
A regional read placed the file's data at an offset clamped to `≥ 0` with an upper bound that
collapsed when the file was smaller than the grid, so a file spanning only the requested box —
rather than the native grid, which `restrict` widens by up to one native cell per side — had every
value written one cell off, with the trailing cells duplicating the file's edge. Fixes #498.

- `region_info` now resolves the offset from the file's coordinate labels and rejects a window that
  falls outside the file, naming both spans.
- Files that do cover the grid are unaffected: an exact window still gives offset `0`, an
  over-fetched file a positive offset, and the global-file seam continuation is unchanged.
- `GHSL`'s writer warps to the requested box, so its reads now raise until it materializes the file
  on `native_grid(metadatum)`.

```julia
λc = φc = collect(0.5:1.0:3.5)                                     # file: 1° cells over (0, 4)
grid = LatitudeLongitudeGrid(CPU(); size = (6, 6), longitude = (-1, 5), latitude = (-1, 5),
                             topology = (Bounded, Bounded, Flat))  # centers -0.5 … 4.5
metadatum = Metadatum(:bottom_height; dataset = ETOPO2022(),
                      region = BoundingBox(longitude = (0, 4), latitude = (0, 4)))
set_region_data!(Field{Center, Center, Nothing}(grid), zeros(4, 4, 1), λc, φc, metadatum)
# ERROR: ArgumentError: the file does not cover the native grid in longitude: the read needs
# 6 cells from -0.5 to 4.5, but the file labels 4 cells from 0.5 to 3.5. …
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
