### PR TITLE
Enshrine proven GPU-closure and cluster strategies in agent docs

### DIFF
--- a/.agents/cluster.md
+++ b/.agents/cluster.md
@@ -40,3 +40,21 @@ NFS home directories and NVIDIA GPUs. Every rule below was learned from a real f
   separate analysis script that a CPU job (or the login node) can run after the fact.
 - Log progress with wall-clock instrumentation (seconds per iteration, simulated days
   per day) so throughput regressions are visible from the log alone.
+
+## Multi-GPU without CUDA-aware MPI
+
+- **Check GPU topology before touching MPI** (`nvidia-smi topo -m`). If the GPUs share a
+  node, NCCL over NVLink is the natural device-buffer transport and MPI only needs to
+  launch ranks and carry host-side control traffic — a cluster with no CUDA-aware MPI
+  (no UCX, device-pointer `MPI.Isend` segfaults) is NOT a blocker for single-node
+  multi-GPU.
+- Bootstrap NCCL from host MPI: rank 0 creates the NCCL unique ID and broadcasts it;
+  each rank binds its CUDA device, then builds the NCCL communicator.
+- NCCL has no message tags: point-to-point ops match by issue order per peer, so the
+  send/recv issue order must be identical on both ranks.
+- **Always wrap a halo exchange's sends and receives in `ncclGroupStart`/`ncclGroupEnd`**:
+  ungrouped send/recv on a single stream deadlocks (the recv kernel blocks the stream
+  head in front of the matching send).
+- Enqueue NCCL ops on the same CUDA stream as compute so downstream copy-back kernels
+  order after the communication with no host synchronization.
+- Only reach for CUDA-aware MPI (UCX-OpenMPI/HPC-X) when the job spans nodes.

--- a/.agents/cluster.md
+++ b/.agents/cluster.md
@@ -43,18 +43,15 @@ NFS home directories and NVIDIA GPUs. Every rule below was learned from a real f
 
 ## Multi-GPU without CUDA-aware MPI
 
-- **Check GPU topology before touching MPI** (`nvidia-smi topo -m`). If the GPUs share a
-  node, NCCL over NVLink is the natural device-buffer transport and MPI only needs to
-  launch ranks and carry host-side control traffic — a cluster with no CUDA-aware MPI
-  (no UCX, device-pointer `MPI.Isend` segfaults) is NOT a blocker for single-node
-  multi-GPU.
-- Bootstrap NCCL from host MPI: rank 0 creates the NCCL unique ID and broadcasts it;
-  each rank binds its CUDA device, then builds the NCCL communicator.
-- NCCL has no message tags: point-to-point ops match by issue order per peer, so the
-  send/recv issue order must be identical on both ranks.
-- **Always wrap a halo exchange's sends and receives in `ncclGroupStart`/`ncclGroupEnd`**:
-  ungrouped send/recv on a single stream deadlocks (the recv kernel blocks the stream
-  head in front of the matching send).
-- Enqueue NCCL ops on the same CUDA stream as compute so downstream copy-back kernels
-  order after the communication with no host synchronization.
+- **Grep for the technology by name before declaring it unsupported** — search the whole
+  installed package including `ext/`, and check Project.toml `[weakdeps]`/`[extensions]`.
+  Oceananigans ships NCCL support as the `OceananigansNCCLExt` extension; it is invisible
+  to a grep that only covers `src/`.
+- On a single node with NVLink, `NCCLDistributed(GPU(); partition = Partition(N))`
+  (drop-in for `Distributed`, activated by `using NCCL, CUDA`) moves device halo buffers
+  over NCCL while host MPI handles launch, bootstrap, and scalar reductions — a cluster
+  with no CUDA-aware MPI is NOT a blocker for single-node multi-GPU.
+- Validate transports with `fill_halo_regions!` on a distributed `Field` (rank-constant
+  interior, assert halos equal the neighbor's constant) — a meaningful end-to-end test,
+  unlike raw send/recv smoke tests.
 - Only reach for CUDA-aware MPI (UCX-OpenMPI/HPC-X) when the job spans nodes.

--- a/.agents/cluster.md
+++ b/.agents/cluster.md
@@ -1,0 +1,42 @@
+# Running on Slurm/GPU Clusters
+
+Hard-won operational rules for running NumericalEarth simulations on Slurm clusters with
+NFS home directories and NVIDIA GPUs. Every rule below was learned from a real failure.
+
+## Precompilation
+
+- **Precompile serially BEFORE `mpiexec`, never inside it.** Ranks precompiling
+  concurrently race the shared depot's pidfiles: duplicated work, long silent stalls.
+  Batch scripts run `julia --project -e 'using Pkg; Pkg.precompile()'` as a first job
+  step, then launch ranks.
+- **Precompile on the partition you will run on.** Julia's cache is per CPU
+  microarchitecture; a login node with a different CPU family than the compute nodes
+  produces caches the job cannot reuse, and the job silently recompiles everything.
+  Verify precompilation with `srun` on a compute node, not on the login node.
+- **Size Julia to the allocation, not the node.** Export
+  `JULIA_NUM_PRECOMPILE_TASKS=$SLURM_CPUS_PER_TASK` and
+  `OPENBLAS_NUM_THREADS=$SLURM_CPUS_PER_TASK`; the defaults assume the whole node and
+  thrash the cgroup.
+- **Prefer `GPUCompiler` disk caching over sysimages during development.** Set
+  `disk_cache = "true"` for GPUCompiler in `LocalPreferences.toml` — it survives code
+  edits. A sysimage silently pins stale package versions; if you build one, guard its
+  use with a hash of `Manifest.toml` + `LocalPreferences.toml`, and expect break-even
+  only after ~6 job launches per stack change.
+
+## Judging whether a job is alive
+
+- **Never kill a job because its log went quiet.** Slurm block-buffers stdout in ~32 KB
+  chunks and NFS serves stale file attributes; a healthy job can look frozen for tens of
+  minutes. Check GPU utilization (`srun --overlap --jobid=<id> nvidia-smi`), process RSS,
+  and output-file mtimes before concluding anything.
+- A run that dies instantly with no log output often means the script path is not
+  visible from compute nodes (e.g. node-local `/tmp`) — keep scripts and outputs on the
+  shared filesystem.
+
+## Simulation scripts
+
+- **Keep plotting packages out of simulation scripts.** Loading Makie costs minutes per
+  job and buys nothing on a headless compute node; write slices to JLD2 and render in a
+  separate analysis script that a CPU job (or the login node) can run after the fact.
+- Log progress with wall-clock instrumentation (seconds per iteration, simulated days
+  per day) so throughput regressions are visible from the log alone.

--- a/.claude/rules/kernel-rules.md
+++ b/.claude/rules/kernel-rules.md
@@ -42,3 +42,20 @@ GPU-compatible kernel functions are critical for NumericalEarth performance.
 - Take care of staggered grid location when writing operators or designing diagnostics
 - **Always use 3D indexing** for fields (`field[i, j, k]`); 2D indexing works by coincidence
   but is unsupported and may break
+
+## Closure Captures
+
+- **Never reassign a variable captured by a closure that reaches a GPU kernel** (masks,
+  forcings, boundary conditions). Reassignment turns the capture into a `Core.Box`, the
+  closure stops being `isbits`, and the kernel launch fails — often only at run time on GPU.
+- Compute with single-assignment names instead: `λ₁ˡ, λ₂ˡ = x_domain(grid)` then
+  `λ₁ = all_reduce(min, λ₁ˡ, arch)` — never `λ₁ = ...` followed by `λ₁ = f(λ₁)`.
+- When in doubt, check `isbits(closure)` before launching.
+
+## Dispatch Over Branching
+
+- No value-level guards (`haskey`, `isnothing` chains) inside small GPU helper functions;
+  make the decision once outside the kernel — fetch with `get(container, key, nothing)` —
+  and provide a `::Nothing` method for the missing case.
+- A `MethodError` on an unhandled combination is the intended "not implemented" signal;
+  don't paper over it with runtime branches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,7 @@ Detailed reference docs are in `.agents/` — read on demand:
 | `.agents/documentation.md` | Building docs, fast builds, Literate.jl examples, doctest details |
 | `.agents/validation.md` | Reproducing paper results, common issues, TC genesis |
 | `.agents/physics-debugging.md` | Thermodynamic variables, diagnose-before-fix, model architecture |
+| `.agents/cluster.md` | Slurm/GPU clusters: precompilation, MPI launches, job health, sysimages |
 
 ### Auto-loading Rules
 


### PR DESCRIPTION
Codifies lessons proven during the AtmosphericRivers downscaling campaign so agents (and humans) don't relearn them:

**`.claude/rules/kernel-rules.md`** (auto-loads for `src/**`)
- Closure-capture boxing: reassigning a captured variable makes the closure non-`isbits` and kills GPU kernel launches — use single-assignment names. (Bit us in `davies_relaxation_mask`.)
- Dispatch over branching in small GPU helpers: `get(..., nothing)` outside the kernel + a `::Nothing` method, not `haskey` guards inside.

**`.agents/cluster.md`** (new; row added to the AGENTS.md Further Reading table)
- Precompile serially *before* `mpiexec` — concurrent rank precompilation races the depot pidfiles.
- Precompile on the run partition (per-microarchitecture caches).
- `JULIA_NUM_PRECOMPILE_TASKS`/`OPENBLAS_NUM_THREADS` sized to `SLURM_CPUS_PER_TASK`.
- Judge job health by GPU utilization and output mtimes, never by a quiet (block-buffered, NFS-stale) log.
- Keep Makie out of simulation scripts; GPUCompiler `disk_cache` over sysimages during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)