### PR TITLE
Add freshwater flux containers to the Veros net_fluxes

### DIFF
--- a/ext/NumericalEarthVerosExt/veros_state_exchanger.jl
+++ b/ext/NumericalEarthVerosExt/veros_state_exchanger.jl
@@ -18,7 +18,12 @@ NumericalEarth.EarthSystemModels.exchange_grid(atmosphere, ocean::VerosOceanSimu
     T = Field{Center, Center, Nothing}(grid)
     S = Field{Center, Center, Nothing}(grid)
 
-    return (; u, v, T, S)
+    # The flux assembly kernel also fills a freshwater volume flux and its heat
+    # content; Veros does not consume them, but the containers must exist.
+    η = Field{Center, Center, Nothing}(grid)
+    freshwater_heat_content = Field{Center, Center, Nothing}(grid)
+
+    return (; u, v, T, S, η, freshwater_heat_content)
 end
 
 function NumericalEarth.EarthSystemModels.interpolate_state!(exchanger, exchange_grid, ocean::VerosOceanSimulation, coupled_model)

--- a/ext/NumericalEarthVerosExt/veros_state_exchanger.jl
+++ b/ext/NumericalEarthVerosExt/veros_state_exchanger.jl
@@ -20,10 +20,10 @@ NumericalEarth.EarthSystemModels.exchange_grid(atmosphere, ocean::VerosOceanSimu
 
     # The flux assembly kernel also fills a freshwater volume flux and its heat
     # content; Veros does not consume them, but the containers must exist.
-    η = Field{Center, Center, Nothing}(grid)
-    freshwater_heat_content = Field{Center, Center, Nothing}(grid)
+    η  = Field{Center, Center, Nothing}(grid)
+    Jᴴ = Field{Center, Center, Nothing}(grid)
 
-    return (; u, v, T, S, η, freshwater_heat_content)
+    return (; u, v, T, S, η, freshwater_heat_content = Jᴴ)
 end
 
 function NumericalEarth.EarthSystemModels.interpolate_state!(exchanger, exchange_grid, ocean::VerosOceanSimulation, coupled_model)


### PR DESCRIPTION
## Why

#244 extended `_assemble_net_ocean_fluxes!` to fill a freshwater volume flux (`η`) and its heat content (`freshwater_heat_content`), updating the Oceananigans-ocean and `SlabOcean` `net_fluxes` accordingly — but the Veros extension's `net_fluxes` still returns only `(; u, v, T, S)`. Assembling fluxes for a Veros-coupled model therefore throws

```
FieldError: type NamedTuple has no field `η`, available fields: `u`, `v`, `T`, `S`
```

at `src/Oceans/assemble_net_ocean_fluxes.jl:123`. This went unnoticed since July because the Veros example is the only exercise of this path, and no full-examples docs build has completed since #244 merged (see #503). Caught by the docs build on #503's L4 runner: [failed run](https://github.com/NumericalEarth/NumericalEarth.jl/actions/runs/31589724985).

## What

Add the two surface-field containers to the Veros `net_fluxes`, matching the slab-ocean pattern. The kernel fills them; Veros does not consume them (its `update_net_fluxes!` reads only `u`, `v`, `T`, `S`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)