### PR TITLE
Fix model access in the four-oceans example

### DIFF
--- a/examples/breeze_over_four_oceans.jl
+++ b/examples/breeze_over_four_oceans.jl
@@ -64,7 +64,7 @@ nh_ocean_atmos         = atmosphere_simulation(grid; potential_temperature=θᵃ
 # A background zonal wind `U₀` provides a nonzero wind speed for the
 # similarity theory flux computation.
 
-reference_state = slab_ocean_atmos.dynamics.reference_state
+reference_state = slab_ocean_atmos.model.dynamics.reference_state
 
 θᵢ(x, z) = reference_state.surface_potential_temperature + 0.1 * randn() * (z < 500)
 set!(prescribed_ocean_atmos, θ=θᵢ, u=U₀)
@@ -236,16 +236,16 @@ add_callback!(nh_sim,         nh_progress,         IterationInterval(400))
 # * Full simulation: atmospheric θ, u, cloud water, and w, plus full-depth ocean temperature T.
 # * Nonhydrostatic simulation: atmospheric θ, u, cloud water, and w, plus full-depth ocean temperature T.
 
-u_p, v_p, w_p = prescribed_ocean_atmos.velocities
-θ_p = liquid_ice_potential_temperature(prescribed_ocean_atmos)
+u_p, v_p, w_p = prescribed_ocean_atmos.model.velocities
+θ_p = liquid_ice_potential_temperature(prescribed_ocean_atmos.model)
 
 prescribed_sim.output_writers[:atmos] = JLD2Writer(prescribed_model, (; θ=θ_p, u=u_p),
                                                    filename = "prescribed_ocean_atmos",
                                                    schedule = TimeInterval(1minute),
                                                    overwrite_existing = true)
 
-u_s, v_s, w_s = slab_ocean_atmos.velocities
-θ_s = liquid_ice_potential_temperature(slab_ocean_atmos)
+u_s, v_s, w_s = slab_ocean_atmos.model.velocities
+θ_s = liquid_ice_potential_temperature(slab_ocean_atmos.model)
 
 slab_sim.output_writers[:atmos] = JLD2Writer(slab_model, (; θ=θ_s, u=u_s),
                                              filename = "slab_ocean_atmos",
@@ -257,9 +257,9 @@ slab_sim.output_writers[:sst] = JLD2Writer(slab_model, (; SST=slab_ocean.tempera
                                            schedule = TimeInterval(1minute),
                                            overwrite_existing = true)
 
-u_f, v_f, w_f = full_ocean_atmos.velocities
-θ_f = liquid_ice_potential_temperature(full_ocean_atmos)
-qˡ_f = full_ocean_atmos.microphysical_fields.qˡ
+u_f, v_f, w_f = full_ocean_atmos.model.velocities
+θ_f = liquid_ice_potential_temperature(full_ocean_atmos.model)
+qˡ_f = full_ocean_atmos.model.microphysical_fields.qˡ
 
 full_sim.output_writers[:atmos] = JLD2Writer(full_model, (; θ=θ_f, u=u_f, qˡ=qˡ_f, w=w_f),
                                              filename = "full_ocean_atmos",
@@ -271,9 +271,9 @@ full_sim.output_writers[:ocean] = JLD2Writer(full_model, (; T=ocean.model.tracer
                                              schedule = TimeInterval(1minute),
                                              overwrite_existing = true)
 
-u_nh, v_nh, w_nh = nh_ocean_atmos.velocities
-θ_nh = liquid_ice_potential_temperature(nh_ocean_atmos)
-qˡ_nh = nh_ocean_atmos.microphysical_fields.qˡ
+u_nh, v_nh, w_nh = nh_ocean_atmos.model.velocities
+θ_nh = liquid_ice_potential_temperature(nh_ocean_atmos.model)
+qˡ_nh = nh_ocean_atmos.model.microphysical_fields.qˡ
 
 nh_sim.output_writers[:atmos] = JLD2Writer(nh_model, (; θ=θ_nh, u=u_nh, qˡ=qˡ_nh, w=w_nh),
                                            filename = "nh_ocean_atmos",


### PR DESCRIPTION
## Why

`atmosphere_simulation` returns a `Simulation` (since #433), but `breeze_over_four_oceans.jl` still reads model-level state directly off the return value: `.dynamics.reference_state`, `.velocities`, `.microphysical_fields.qˡ`, and `liquid_ice_potential_temperature(...)` (whose Breeze methods accept only `AtmosphereModel`). The example dies at the first of these:

```
FieldError: type Oceananigans.Simulations.Simulation has no field `dynamics`
```

aborting the docs build. Caught by the docs build on #503's L4 runner ([failed run](https://github.com/NumericalEarth/NumericalEarth.jl/actions/runs/31597314603)); like the Veros bug (#506), it went unnoticed because no full-examples docs build has completed since July.

## What

Access the model through the simulation (`sim.model.…`) at each site, matching the `breeze_over_slab_land` pattern. `set!(sim, …)` and the `ComponentInterfaces`/`AtmosphereOceanModel` calls already accept the `Simulation` and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)