### PR TITLE
Allow Field-valued `dry_heat_capacity` in `WaterCoupledEnergy`

### DIFF
--- a/docs/src/appendix/notation.md
+++ b/docs/src/appendix/notation.md
@@ -134,6 +134,9 @@ component-superscript rule above.
 | ``𝒮ᶜ`` | `dry_layer_onset_saturation` | dry-layer onset saturation | Saturation below which a dry surface layer forms, for `StorageBasedDryLayerDepth`; shares the symbol ``𝒮ᶜ`` with `critical_saturation` above (–) |
 | ``T^{\mathrm{deep}}`` | `deep_temperature` | deep climatological temperature | Prescribed deep/climatological target temperature for force-restore (K) |
 | ``τ^{\mathrm{deep}}`` | `deep_time_scale` | deep-restore time scale | Time scale of surface relaxation toward ``T^{\mathrm{deep}}`` (s) |
+| ``c^{\mathrm{dry}}`` | `dry_heat_capacity` | dry areal heat capacity | Areal heat capacity of the water-free slab; a `Number` or an `AbstractField` (J m⁻² K⁻¹) |
+| ``c^l`` | `liquid_heat_capacity` | liquid heat capacity | Specific heat capacity of slab liquid water (J kg⁻¹ K⁻¹) |
+| ``c^{\mathrm{la}}`` | – | land areal heat capacity | Water-dependent areal heat capacity ``c^{\mathrm{la}} = c^{\mathrm{dry}} + c^l M`` (J m⁻² K⁻¹) |
 | ``d`` | `surface_thickness` | surface thickness | Thickness of the dry surface layer through which soil vapor diffuses, for `SkinHumidity` (m) |
 | ``κ^q`` | `vapor_diffusivity` | soil vapor diffusivity | Vapor mass diffusivity in the surface soil layer, for `SkinHumidity` (kg m⁻¹ s⁻¹) |
 | ``\chi^{\mathrm{sand}}`` | `sand` | soil sand fraction | Mass fraction of sand grains in the mineral (non-organic) solid matrix (kg kg⁻¹)

--- a/examples/breeze_over_slab_land.jl
+++ b/examples/breeze_over_slab_land.jl
@@ -96,7 +96,7 @@ hydrology = VariablySaturatedHydrology(eltype(land_grid);
     runoff = InfiltrationCapacityRunoff(infiltration_capacity = 1e-3))
 
 # Water-mass-coupled energy with a water-mass-dependent areal heat capacity
-# `C(Mˡᵃ) = C_dry + cˡ Mˡᵃ` and conservative `Tˡᵃ` update — adding or removing
+# `cˡᵃ(Mˡᵃ) = cᵈʳʸ + cˡ Mˡᵃ` and conservative `Tˡᵃ` update — adding or removing
 # water at the slab temperature leaves `Tˡᵃ` unchanged.
 #
 # `deep_temperature` should sit near the surface's radiative–convective

--- a/examples/era5_forced_slab_land.jl
+++ b/examples/era5_forced_slab_land.jl
@@ -4,7 +4,7 @@
 # example, then demonstrating a more realistic case with ERA5 forcing on realistic topography.
 # We use a `SlabLand` composed of
 #
-#     energy    = WaterCoupledEnergy(...)          # C(Mˡᵃ) = C_dry + cˡ Mˡᵃ, conservative dTˡᵃ/dt
+#     energy    = WaterCoupledEnergy(...)          # cˡᵃ(Mˡᵃ) = cᵈʳʸ + cˡ Mˡᵃ, conservative dTˡᵃ/dt
 #     hydrology = VariablySaturatedHydrology(...)  # augmented-storage ϑˡ budget
 #     humidity  = DryLayerHumidity(...)            # qⁱⁿ from a dry-layer vapor-flux balance
 #
@@ -136,8 +136,8 @@ initial_water_storage =
 # `WaterCoupledEnergy` is the slab's energy budget which steps the skin temperature `Tˡᵃ`
 #  with a force-restore balance toward a deep reservoir at `deep_temperature` on the
 # `deep_time_scale`, and folds the water storage into the areal heat capacity
-# `C(Mˡᵃ) = C_dry + cˡ Mˡᵃ`, recomputed each step so that a wetter slab carries more
-# thermal inertia. `dry_heat_capacity` is `C_dry` (depth × density × specific heat of
+# `cˡᵃ(Mˡᵃ) = cᵈʳʸ + cˡ Mˡᵃ`, recomputed each step so that a wetter slab carries more
+# thermal inertia. `dry_heat_capacity` is `cᵈʳʸ` (depth × density × specific heat of
 # the dry soil), `liquid_heat_capacity` is `cˡ`.
 soil_energy(FT; deep_time_scale) = WaterCoupledEnergy(FT;
     dry_heat_capacity     = 0.1 * 1500 * 1480,

--- a/src/Lands/energy_balance/force_restore_energy.jl
+++ b/src/Lands/energy_balance/force_restore_energy.jl
@@ -6,10 +6,10 @@
 ##### under the surface energy flux (positive upward, hence the minus sign)
 ##### plus a restoring term toward a prescribed deep temperature `Tᵈᵉᵉᵖ`:
 #####
-#####     ∂T/∂t = −Jᴱs / C + (Tᵈᵉᵉᵖ − T) / τ
+#####     ∂T/∂t = −Jᴱs / cˡᵃ + (Tᵈᵉᵉᵖ − T) / τ
 #####
-##### where `C = Cdry + Cl · Mˡᵃ` is the effective areal heat capacity
-##### (the liquid-water term `Cl · Mˡᵃ` is included when bucket hydrology is
+##### where `cˡᵃ = cᵈʳʸ + cˡ · Mˡᵃ` is the effective areal heat capacity
+##### (the liquid-water term `cˡ · Mˡᵃ` is included when bucket hydrology is
 ##### present), and `τ` is the deep-restore time scale.
 #####
 ##### `Tᵈᵉᵉᵖ` is prescribed, not prognostic: a `Number`, per-cell
@@ -66,7 +66,7 @@ Adapt.adapt_structure(to, energy::ForceRestoreEnergy) =
 # kinematic momentum flux `τ`. `Tᵈ` is the deep-target temperature.
 # `Jᴱs` is the surface energy flux, positive *upward* (out of the slab), so it
 # enters the budget with a minus sign:
-# ∂T/∂t = −Jᴱs/C + (Tᵈ − T)/τᵈ, with C = Cdry + Cl·max(Mˡᵃ, 0).
+# ∂T/∂t = −Jᴱs/cˡᵃ + (Tᵈ − T)/τᵈ, with cˡᵃ = cᵈʳʸ + cˡ·max(Mˡᵃ, 0).
 @inline function temperature_tendency(i, j, grid, energy::ForceRestoreEnergy,
                                       prognostic, fluxes, diagnostics, time)
     @inbounds begin
@@ -74,11 +74,11 @@ Adapt.adapt_structure(to, energy::ForceRestoreEnergy) =
         Mᵢⱼ = prognostic.M[i, j, 1]
         Jᴱs = fluxes.surface_energy_flux[i, j, 1]
     end
-    Cdry = property_value(energy.dry_heat_capacity, i, j, 1)
-    Cl   = property_value(energy.liquid_heat_capacity, i, j, 1)
-    C    = Cdry + Cl * max(Mᵢⱼ, 0)
+    cᵈʳʸ = property_value(energy.dry_heat_capacity, i, j, 1)
+    cˡ   = property_value(energy.liquid_heat_capacity, i, j, 1)
+    cˡᵃ  = cᵈʳʸ + cˡ * max(Mᵢⱼ, 0)
     Tᵈ   = stateindex(energy.deep_temperature, i, j, 1, grid, time, (Center, Center, Center))
-    return -Jᴱs / C + (Tᵈ - Tᵢⱼ) / energy.deep_time_scale
+    return -Jᴱs / cˡᵃ + (Tᵈ - Tᵢⱼ) / energy.deep_time_scale
 end
 
 time_step!(energy::ForceRestoreEnergy, land, Δt, time) = step_land_temperature!(energy, land, Δt, time)

--- a/src/Lands/energy_balance/water_coupled_energy.jl
+++ b/src/Lands/energy_balance/water_coupled_energy.jl
@@ -6,7 +6,7 @@
 ##### Like `ForceRestoreEnergy`, this closure restores the bulk land temperature
 ##### toward a prescribed deep climatology, but with two refinements:
 #####
-##### 1. The areal heat capacity `C(Mˡᵃ) = C_dry + cˡ Mˡᵃ` is recomputed every
+##### 1. The areal heat capacity `cˡᵃ(Mˡᵃ) = cᵈʳʸ + cˡ Mˡᵃ` is recomputed every
 #####    step, so a wetting/drying slab has the correct thermal inertia.
 ##### 2. The energy budget is written conservatively as
 #####
@@ -15,7 +15,7 @@
 #####    with `eˡ = cˡ(Tˡᵃ − Tᵣ)` the internal energy of slab liquid, and `Tˡᵃ`
 #####    is updated via
 #####
-#####        dTˡᵃ/dt = [dEˡᵃ/dt − eˡ dMˡᵃ/dt] / C(Mˡᵃ),
+#####        dTˡᵃ/dt = [dEˡᵃ/dt − eˡ dMˡᵃ/dt] / cˡᵃ(Mˡᵃ),
 #####
 #####    so adding/removing water *at the slab temperature* leaves `Tˡᵃ`
 #####    unchanged. `dMˡᵃ/dt` is consumed from `land.diagnostics.water_storage_tendency`
@@ -34,7 +34,7 @@
 ##### `surface_energy_flux` via the interface balance.
 #####
 ##### `Tᵈᵉᵉᵖ` may be a `Number`, `AbstractField`, or any state-indexable
-##### property (e.g. a `FieldTimeSeries`); `Cᵈʳʸ` and `Λᵈᵉᵉᵖ` may be
+##### property (e.g. a `FieldTimeSeries`); `cᵈʳʸ` and `Λᵈᵉᵉᵖ` may be
 ##### `Number`s or `AbstractField`s.
 #####
 
@@ -54,7 +54,7 @@ treatment of water-energy advection across the slab boundaries.
 
 Use either `deep_conductance` (`Λᵈᵉᵉᵖ`, W m⁻² K⁻¹) or `deep_time_scale` (`τᵈᵉᵉᵖ`,
 s) to set the deep restoring strength; exactly one must be supplied. With
-`deep_time_scale`, the effective conductance is `C(Mˡᵃ)/τᵈᵉᵉᵖ` (matches
+`deep_time_scale`, the effective conductance is `cˡᵃ(Mˡᵃ)/τᵈᵉᵉᵖ` (matches
 [`ForceRestoreEnergy`](@ref)).
 
 `dry_heat_capacity` accepts a `Number` (uniform) or a per-cell `AbstractField` —
@@ -131,12 +131,12 @@ Adapt.adapt_structure(to, energy::WaterCoupledEnergy) =
 ##### Helpers
 #####
 
-@inline function deep_conductance_value(energy::WaterCoupledEnergy, C, i, j, grid, time)
+@inline function deep_conductance_value(energy::WaterCoupledEnergy, cˡᵃ, i, j, grid, time)
     FT = eltype(grid)
     Λ  = energy.deep_conductance
     τ  = energy.deep_time_scale
     if Λ === nothing
-        return C / convert(FT, τ)
+        return cˡᵃ / convert(FT, τ)
     else
         return property_value(Λ, i, j, 1)
     end
@@ -168,11 +168,11 @@ end
 
     cˡ   = energy.liquid_heat_capacity
     Tᵣ   = energy.reference_temperature
-    Cdry = property_value(energy.dry_heat_capacity, i, j, 1)
-    C    = Cdry + cˡ * max(Mᵢⱼ, 0)
+    cᵈʳʸ = property_value(energy.dry_heat_capacity, i, j, 1)
+    cˡᵃ  = cᵈʳʸ + cˡ * max(Mᵢⱼ, 0)
 
     Tᵈ = stateindex(energy.deep_temperature, i, j, 1, grid, time, (Center, Center, Center))
-    Λᵈ = deep_conductance_value(energy, C, i, j, grid, time)
+    Λᵈ = deep_conductance_value(energy, cˡᵃ, i, j, grid, time)
 
     # Internal energy of slab liquid; the boundary fluxes upwind to it. A flux
     # whose advective switch is off carries eˡ — it exchanges mass but no heat —
@@ -187,7 +187,7 @@ end
     # temperature; the latent heat of evaporation is already inside Jᴱs.
     dEdt = Λᵈ * (Tᵈ - Tᵢⱼ) + eᵇ * Jˡᵇ - eˢ * Jˡˢ - Jᴱs - eˡ * Jᵛ - eˡ * Rˡᵃᵗ
 
-    return (dEdt - eˡ * dMdt) / C
+    return (dEdt - eˡ * dMdt) / cˡᵃ
 end
 
 time_step!(energy::WaterCoupledEnergy, land, Δt, time) = step_land_temperature!(energy, land, Δt, time)

--- a/src/Lands/energy_balance/water_coupled_energy.jl
+++ b/src/Lands/energy_balance/water_coupled_energy.jl
@@ -34,8 +34,8 @@
 ##### `surface_energy_flux` via the interface balance.
 #####
 ##### `Tᵈᵉᵉᵖ` may be a `Number`, `AbstractField`, or any state-indexable
-##### property (e.g. a `FieldTimeSeries`); `Λᵈᵉᵉᵖ` may be a `Number` or
-##### `AbstractField`.
+##### property (e.g. a `FieldTimeSeries`); `Cᵈʳʸ` and `Λᵈᵉᵉᵖ` may be
+##### `Number`s or `AbstractField`s.
 #####
 
 """
@@ -57,13 +57,16 @@ s) to set the deep restoring strength; exactly one must be supplied. With
 `deep_time_scale`, the effective conductance is `C(Mˡᵃ)/τᵈᵉᵉᵖ` (matches
 [`ForceRestoreEnergy`](@ref)).
 
+`dry_heat_capacity` accepts a `Number` (uniform) or a per-cell `AbstractField` —
+for example pavement carrying building thermal mass next to soil that does not.
+
 `reference_temperature` is the reference for internal energy `eˡ(T) = cˡ(T − Tᵣ)`.
 The temperature update is invariant to `Tᵣ`: fluxes whose advective switch is
 disabled enter and leave at the slab temperature, so `Tᵣ` cancels exactly (up
 to the positivity floor on `Mˡᵃ`). A standard choice is the triple point 273.15 K.
 """
-struct WaterCoupledEnergy{FT, TD, ΛD, Tau} <: AbstractEnergyBalance
-    dry_heat_capacity            :: FT
+struct WaterCoupledEnergy{CD, FT, TD, ΛD, Tau} <: AbstractEnergyBalance
+    dry_heat_capacity            :: CD
     liquid_heat_capacity         :: FT
     reference_temperature        :: FT
     deep_temperature             :: TD
@@ -98,7 +101,7 @@ function WaterCoupledEnergy(FT::Type = Oceananigans.defaults.FloatType;
     Λ = isnothing(deep_conductance) ? nothing : normalize_property(FT, deep_conductance)
     τ = isnothing(deep_time_scale)  ? nothing : convert(FT, deep_time_scale)
     Td = deep_temperature isa Number ? convert(FT, deep_temperature) : deep_temperature
-    return WaterCoupledEnergy(convert(FT, dry_heat_capacity),
+    return WaterCoupledEnergy(normalize_property(FT, dry_heat_capacity),
                               convert(FT, liquid_heat_capacity),
                               convert(FT, reference_temperature),
                               Td, Λ, τ,

--- a/test/test_slab_land.jl
+++ b/test/test_slab_land.jl
@@ -99,17 +99,17 @@ end
                                z = (-1, 0),
                                topology = (Flat, Flat, Bounded))
 
-        Cdry = CenterField(grid)
-        Cl   = CenterField(grid)
+        cᵈʳʸ = CenterField(grid)
+        cˡ   = CenterField(grid)
         Wmax = CenterField(grid)
 
-        fill!(Cdry, 8)
-        fill!(Cl, 2)
+        fill!(cᵈʳʸ, 8)
+        fill!(cˡ, 2)
         fill!(Wmax, 12)
 
         energy = SlabEnergy(eltype(grid);
-                            dry_heat_capacity = Cdry,
-                            liquid_heat_capacity = Cl)
+                            dry_heat_capacity = cᵈʳʸ,
+                            liquid_heat_capacity = cˡ)
         hydrology = BucketHydrology(eltype(grid); maximum_water_storage = Wmax)
 
         land = SlabLand(grid; energy, hydrology)

--- a/test/test_water_coupled_energy.jl
+++ b/test/test_water_coupled_energy.jl
@@ -178,3 +178,56 @@ end
         @test isapprox(M₁, 100.0 + 1e-4 * 100 * 100.0; rtol = 1e-12)
     end
 end
+
+@testset "WaterCoupledEnergy per-cell dry heat capacity" begin
+    for arch in test_architectures
+        grid = RectilinearGrid(arch;
+                               size = (2, 1),
+                               x = (0, 2),
+                               z = (-1, 0),
+                               topology = (Periodic, Flat, Bounded))
+
+        # Two dry columns restoring toward Tᵈ, each at its own rate Λ/Cᵢ.
+        Cdry = Field{Center, Center, Nothing}(grid)
+        set!(Cdry, reshape([1.0e6, 2.0e6], 2, 1, 1))
+
+        Λ     = 5.0
+        Tᵈ    = 280.0
+        T₀    = 290.0
+        Δt    = 100.0
+        steps = 100
+
+        hydrology = VariablySaturatedHydrology(eltype(grid);
+            slab_depth = 1.0, porosity = 0.4, storage_height = 1000,
+            retention_curve = VanGenuchtenRetention(α = 1.0, n = 2.0),
+            hydraulic_conductivity = VanGenuchtenConductivity(K_saturated = 1e-6, n = 2.0),
+            deep_liquid_flux = NoDeepLiquidFlux(), runoff = NoRunoff())
+        energy = WaterCoupledEnergy(eltype(grid);
+            dry_heat_capacity = Cdry,
+            liquid_heat_capacity = 4186,
+            reference_temperature = 273.15,
+            deep_temperature = Tᵈ,
+            deep_conductance = Λ,
+            advect_deep_liquid_energy = false,
+            advect_surface_liquid_energy = false)
+
+        land = SlabLand(grid; hydrology, energy)
+        set!(land; T = T₀, M = 0.0)
+        fill!(land.fluxes.surface_energy_flux, 0)
+        fill!(land.fluxes.vapor_flux, 0)
+        fill!(land.fluxes.liquid_precipitation_flux, 0)
+        fill!(land.fluxes.liquid_precipitation_temperature, T₀)
+
+        t = 0.0
+        for _ in 1:steps
+            time_step!(land, Δt)
+            t += Δt
+        end
+
+        actual_temperatures = vec(Array(interior(land.temperature)))
+        for (n, Cᵢ) in enumerate((1.0e6, 2.0e6))
+            expected_temperature = Tᵈ + (T₀ - Tᵈ) * exp(-Λ / Cᵢ * t)
+            @test isapprox(actual_temperatures[n], expected_temperature; atol = 1e-3)
+        end
+    end
+end

--- a/test/test_water_coupled_energy.jl
+++ b/test/test_water_coupled_energy.jl
@@ -12,9 +12,9 @@ using Oceananigans.TimeSteppers: time_step!
                                z = (-1, 0),
                                topology = (Flat, Flat, Bounded))
 
-        # Dry slab (M = 0) so C reduces to C_dry. Pure restoration:
-        #     T(t) − Tᵈ = (T₀ − Tᵈ) exp(−(Λ/C) t).
-        Cdry  = 1.0e6
+        # Dry slab (M = 0) so cˡᵃ reduces to cᵈʳʸ. Pure restoration:
+        #     T(t) − Tᵈ = (T₀ − Tᵈ) exp(−(Λ/cˡᵃ) t).
+        cᵈʳʸ  = 1e6
         Λ     = 5.0          # W m⁻² K⁻¹
         Tᵈ    = 280.0
         T₀    = 290.0
@@ -27,7 +27,7 @@ using Oceananigans.TimeSteppers: time_step!
             hydraulic_conductivity = VanGenuchtenConductivity(K_saturated = 1e-6, n = 2.0),
             deep_liquid_flux = NoDeepLiquidFlux(), runoff = NoRunoff())
         energy = WaterCoupledEnergy(eltype(grid);
-            dry_heat_capacity = Cdry,
+            dry_heat_capacity = cᵈʳʸ,
             liquid_heat_capacity = 4186,
             reference_temperature = 273.15,
             deep_temperature = Tᵈ,
@@ -48,10 +48,10 @@ using Oceananigans.TimeSteppers: time_step!
             t += Δt
         end
 
-        expected_temperature = Tᵈ + (T₀ - Tᵈ) * exp(-Λ / Cdry * t)
+        expected_temperature = Tᵈ + (T₀ - Tᵈ) * exp(-Λ / cᵈʳʸ * t)
         actual_temperature = only(Array(interior(land.temperature)))
         # Forward Euler converges to the analytic solution as Δt → 0; with
-        # ΛΔt/C = 5e-4 the truncation error per step is O(Δt²) ⇒ test tolerance 1e-3 K.
+        # ΛΔt/cˡᵃ = 5e-4 the truncation error per step is O(Δt²) ⇒ test tolerance 1e-3 K.
         @test isapprox(actual_temperature, expected_temperature; atol = 1e-3)
     end
 end
@@ -187,9 +187,10 @@ end
                                z = (-1, 0),
                                topology = (Periodic, Flat, Bounded))
 
-        # Two dry columns restoring toward Tᵈ, each at its own rate Λ/Cᵢ.
-        Cdry = Field{Center, Center, Nothing}(grid)
-        set!(Cdry, reshape([1.0e6, 2.0e6], 2, 1, 1))
+        # Two dry columns (M = 0, so cˡᵃ = cᵈʳʸ) restoring toward Tᵈ, each at
+        # its own rate Λ/cˡᵃ.
+        cᵈʳʸ = Field{Center, Center, Nothing}(grid)
+        set!(cᵈʳʸ, reshape([1e6, 2e6], 2, 1, 1))
 
         Λ     = 5.0
         Tᵈ    = 280.0
@@ -198,12 +199,12 @@ end
         steps = 100
 
         hydrology = VariablySaturatedHydrology(eltype(grid);
-            slab_depth = 1.0, porosity = 0.4, storage_height = 1000,
-            retention_curve = VanGenuchtenRetention(α = 1.0, n = 2.0),
-            hydraulic_conductivity = VanGenuchtenConductivity(K_saturated = 1e-6, n = 2.0),
+            slab_depth = 1, porosity = 0.4, storage_height = 1000,
+            retention_curve = VanGenuchtenRetention(α = 1, n = 2),
+            hydraulic_conductivity = VanGenuchtenConductivity(K_saturated = 1e-6, n = 2),
             deep_liquid_flux = NoDeepLiquidFlux(), runoff = NoRunoff())
         energy = WaterCoupledEnergy(eltype(grid);
-            dry_heat_capacity = Cdry,
+            dry_heat_capacity = cᵈʳʸ,
             liquid_heat_capacity = 4186,
             reference_temperature = 273.15,
             deep_temperature = Tᵈ,
@@ -212,7 +213,7 @@ end
             advect_surface_liquid_energy = false)
 
         land = SlabLand(grid; hydrology, energy)
-        set!(land; T = T₀, M = 0.0)
+        set!(land; T = T₀, M = 0)
         fill!(land.fluxes.surface_energy_flux, 0)
         fill!(land.fluxes.vapor_flux, 0)
         fill!(land.fluxes.liquid_precipitation_flux, 0)
@@ -225,8 +226,8 @@ end
         end
 
         actual_temperatures = vec(Array(interior(land.temperature)))
-        for (n, Cᵢ) in enumerate((1.0e6, 2.0e6))
-            expected_temperature = Tᵈ + (T₀ - Tᵈ) * exp(-Λ / Cᵢ * t)
+        for (n, cˡᵃ) in enumerate((1e6, 2e6))
+            expected_temperature = Tᵈ + (T₀ - Tᵈ) * exp(-Λ / cˡᵃ * t)
             @test isapprox(actual_temperatures[n], expected_temperature; atol = 1e-3)
         end
     end


### PR DESCRIPTION
`WaterCoupledEnergy`'s `dry_heat_capacity` now accepts a per-cell `AbstractField` in addition to a uniform `Number`, like `deep_conductance` already does — e.g. sealed urban fabric carrying building thermal mass next to bare soil that doesn't. The time-step kernel already read it through `property_value` and `Adapt` already adapted it; this stops the constructor from forcing a scalar and adds a two-column restoration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)