### PR TITLE
Nested model: sample a terrain-following parent at its reference node

### DIFF
--- a/ext/NumericalEarthBreezeExt/breeze_nested_atmosphere.jl
+++ b/ext/NumericalEarthBreezeExt/breeze_nested_atmosphere.jl
@@ -15,7 +15,7 @@ using NumericalEarth.Atmospheres: PrescribedAtmosphere
 using NumericalEarth.DataWrangling: default_download_directory, default_horizontal_padding,
                                     matching_single_level_dataset
 using NumericalEarth.NestedModels: NestedModel, parent_boundary_conditions, parent_forcings,
-                                   blend_parent_terrain!
+                                   blend_parent_terrain!, interpolate_from_parent!
 using Oceananigans: Oceananigans, WENO
 using Oceananigans.Architectures: architecture
 using Oceananigans.BoundaryConditions: ValueBoundaryCondition, NormalFlowBoundaryCondition
@@ -23,13 +23,20 @@ using Oceananigans.Coriolis: SphericalCoriolis
 using Oceananigans.Fields: AbstractField, CenterField, Field, XFaceField, YFaceField,
                            compute!, interior, interpolate!, set!
 using Oceananigans.Forcings: Relaxation
-using Oceananigans.Grids: znode, λnodes, φnodes, minimum_xspacing, Center, Face
+using Oceananigans.Grids: znode, ξnode, ηnode, rnode, λnodes, φnodes, minimum_xspacing, Center, Face
 using Oceananigans.TimeSteppers: update_state!
 using Oceananigans.Units: Time
 using GPUArraysCore: @allowscalar
 using Breeze: CompressibleDynamics, SplitExplicitTimeDiscretization, UpperSponge, NoDivergenceDamping,
-              MixedPhaseEquilibrium, materialize_terrain!, moisture_prognostic_name
+              MixedPhaseEquilibrium, TerrainFollowingGrid, materialize_terrain!, moisture_prognostic_name
 using Breeze.AtmosphereModels: prognostic_field_names
+
+# `interpolate` locates the vertical in `znodes`, which here are the REFERENCE levels, while `node`
+# returns the terrain-deformed height. Querying the physical node would displace every sample by h·b(r).
+@inline NumericalEarth.NestedModels.query_node(::TerrainFollowingGrid, i, j, k, grid, ℓx, ℓy, ℓz) =
+    (ξnode(i, j, k, grid, ℓx, ℓy, ℓz),
+     ηnode(i, j, k, grid, ℓx, ℓy, ℓz),
+     rnode(i, j, k, grid, ℓx, ℓy, ℓz))
 
 # Default child microphysics: 1-moment bulk mixed-phase (rain + snow) precipitation with
 # saturation-adjustment cloud formation when Breeze's `CloudMicrophysics` extension is loaded,
@@ -329,11 +336,11 @@ function initialize_nested_child!(nested_model, dataset, date, dir; balancer = t
     t₀ = first(prognostic.ρᵈ.times)
 
     # Interpolate each exchanger prognostic (parent grid, initial time) to the child interior. Using the
-    # SAME parent-derived prognostics that drive the lateral boundaries — via the same `interpolate!` —
-    # makes the interior IC and the prescribed boundary agree at the walls, so there is no standing
-    # density/pressure jump to force spurious vertical velocity. The adiabatic balancer below then spins
-    # up ρw from this consistent state.
-    to_child(fts) = (field = CenterField(child_grid); interpolate!(field, fts[Time(t₀)]); field)
+    # SAME parent-derived prognostics that drive the lateral boundaries makes the interior IC and the
+    # prescribed boundary agree at the walls, so there is no standing density/pressure jump to force
+    # spurious vertical velocity. The adiabatic balancer below then spins up ρw from this consistent
+    # state.
+    to_child(fts) = interpolate_from_parent!(CenterField(child_grid), fts[Time(t₀)])
     ρᵈ  = to_child(prognostic.ρᵈ)
     ρθ  = to_child(prognostic.ρθ)
     ρqᵛ = to_child(prognostic.ρqᵛ)
@@ -345,8 +352,8 @@ function initialize_nested_child!(nested_model, dataset, date, dir; balancer = t
     ρ   = compute!(Field(ρᵈ + ρqᵛ))
     qᵗ  = compute!(Field(ρqᵛ / ρ))
     θˡⁱ = compute!(Field(ρθ / ρᵈ))
-    u   = XFaceField(child_grid); interpolate!(u, compute!(Field(ρu / ρᵈ)))
-    v   = YFaceField(child_grid); interpolate!(v, compute!(Field(ρv / ρᵈ)))
+    u   = interpolate_from_parent!(XFaceField(child_grid), compute!(Field(ρu / ρᵈ)))
+    v   = interpolate_from_parent!(YFaceField(child_grid), compute!(Field(ρv / ρᵈ)))
 
     set!(nested_model; ρ, u, v, qᵗ, θˡⁱ, compute_reference_state = true)
 

--- a/src/NestedModels/NestedModels.jl
+++ b/src/NestedModels/NestedModels.jl
@@ -2,7 +2,8 @@ module NestedModels
 
 export NestedModel, NestedSimulation, nested_atmosphere_model,
        parent_boundary_conditions, parent_forcings, blend_parent_terrain!,
-       exchange_state!, total_density, reconstruct_parent_state
+       exchange_state!, total_density, reconstruct_parent_state,
+       interpolate_from_parent!
 
 # Model-specific extension point (methods defined in the Breeze extension):
 #   `nested_atmosphere_model(parent, child_grid; …)` builds a child atmosphere over `child_grid` driven
@@ -24,14 +25,20 @@ function total_density end
 function reconstruct_parent_state end
 
 using Oceananigans
+using Oceananigans.Architectures: architecture
+using Oceananigans.BoundaryConditions: NormalFlowBoundaryCondition, FieldBoundaryConditions, fill_halo_regions!
+using Oceananigans.Fields: instantiated_location, interpolate
 using Oceananigans.Forcings: Relaxation
-using Oceananigans.Grids: AbstractGrid
-using Oceananigans.BoundaryConditions: NormalFlowBoundaryCondition, FieldBoundaryConditions
+using Oceananigans.Grids: AbstractGrid, interior_indices, node
 using Oceananigans.Simulations: Simulation
 using Oceananigans.Units: Time
+using Oceananigans.Utils: launch!, KernelParameters
+using DocStringExtensions: TYPEDSIGNATURES
+using KernelAbstractions: @kernel, @index
 
 include("nested_model.jl")
 include("nested_simulation.jl")
+include("parent_sampling.jl")
 include("interpolated_fts_boundary.jl")
 include("parent_boundary_conditions.jl")
 include("parent_forcings.jl")

--- a/src/NestedModels/interpolated_fts_boundary.jl
+++ b/src/NestedModels/interpolated_fts_boundary.jl
@@ -22,7 +22,7 @@
 import Oceananigans.BoundaryConditions: regularize_boundary_condition, getbc,
                                         LeftBoundary, RightBoundary
 import Oceananigans.OutputReaders: FlavorOfFTS
-using Oceananigans.Grids: node, Face
+using Oceananigans.Grids: Face
 using Adapt: Adapt, adapt
 
 const InterpolatedSource = Union{FlavorOfFTS, Oceananigans.Fields.AbstractField}
@@ -143,20 +143,20 @@ end
     # center node). A Value BC's value is the value AT the boundary, so for a Center
     # field this must be the face, not the half-cell-inside center; for a Face-normal
     # field (the normal velocity) this is unchanged (its location is already Face).
-    X = node(i, j, k, grid, Face(), LY(), LZ())
+    X = query_node(bc.source_grid, i, j, k, grid, Face(), LY(), LZ())
     return _query_source(bc.source, bc.source_grid, X, (LX(), LY(), LZ()), clock_time(clock, grid))
 end
 
 @inline function getbc(bc::Interpolated{2, S, LX, LY, LZ},
                        i::Integer, k::Integer, grid::AbstractGrid, clock=nothing, args...) where {S, LX, LY, LZ}
     j = _boundary_index(S, grid.Ny)
-    X = node(i, j, k, grid, LX(), Face(), LZ())   # boundary face in the y-normal direction
+    X = query_node(bc.source_grid, i, j, k, grid, LX(), Face(), LZ())   # boundary face in the y-normal direction
     return _query_source(bc.source, bc.source_grid, X, (LX(), LY(), LZ()), clock_time(clock, grid))
 end
 
 @inline function getbc(bc::Interpolated{3, S, LX, LY, LZ},
                        i::Integer, j::Integer, grid::AbstractGrid, clock=nothing, args...) where {S, LX, LY, LZ}
     k = _boundary_index(S, grid.Nz)
-    X = node(i, j, k, grid, LX(), LY(), Face())   # boundary face in the z-normal direction
+    X = query_node(bc.source_grid, i, j, k, grid, LX(), LY(), Face())   # boundary face in the z-normal direction
     return _query_source(bc.source, bc.source_grid, X, (LX(), LY(), LZ()), clock_time(clock, grid))
 end

--- a/src/NestedModels/parent_sampling.jl
+++ b/src/NestedModels/parent_sampling.jl
@@ -1,0 +1,49 @@
+#####
+##### query_node: the coordinate at which a child samples its parent
+#####
+#
+# `interpolate` locates the vertical through the SOURCE grid's 1-D `znodes`, so the query must be
+# expressed in the coordinate those nodes span: physical height for a geopotential parent (what `node`
+# returns, the default below), but the reference levels for a terrain-following one, whose
+# `znodes(grid, ℓz) = rnodes(grid, ℓz)` while `node` returns the terrain-deformed height. Dispatching
+# on the source grid keeps both in the same coordinate; the terrain-following method lives in the
+# Breeze extension. Sampling in the terrain-following coordinate is also what nesting wants — no child
+# node maps below the parent's ground.
+
+"""
+    query_node(source_grid, i, j, k, grid, ℓx, ℓy, ℓz)
+
+Coordinate at which a child on `grid` samples a parent living on `source_grid`, for the child node
+`(i, j, k)` at location `(ℓx, ℓy, ℓz)`. Defaults to the child's physical `node`; a source grid whose
+`znodes` are not physical heights (e.g. a terrain-following grid) overrides this to return the
+matching coordinate.
+
+An override reads that coordinate off `grid`, so it assumes the child shares the parent's kind of
+vertical coordinate — the case for nested grids. A child without one (a flat-bottom, fixed-height LES
+under a terrain-following parent) has none to offer; that case needs the parent's column mapping
+inverted, not a different query.
+"""
+@inline query_node(source_grid, i, j, k, grid, ℓx, ℓy, ℓz) = node(i, j, k, grid, ℓx, ℓy, ℓz)
+
+@kernel function _interpolate_from_parent!(child_field, grid, loc, source, source_grid)
+    i, j, k = @index(Global, NTuple)
+    X = query_node(source_grid, i, j, k, grid, loc...)
+    @inbounds child_field[i, j, k] = interpolate(X, source, loc, source_grid)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Fill `child_field` by interpolating the parent field `source` at each child node, sampling in the
+parent's own vertical coordinate ([`query_node`](@ref)). `Oceananigans.interpolate!` with that
+convention: identical for a parent whose vertical is physical height, terrain-offset-free for a
+terrain-following one.
+"""
+function interpolate_from_parent!(child_field, source)
+    grid = child_field.grid
+    loc = instantiated_location(child_field)
+    launch!(architecture(child_field), grid, KernelParameters(interior_indices(child_field)),
+            _interpolate_from_parent!, child_field, grid, loc, source, source.grid)
+    fill_halo_regions!(child_field)
+    return child_field
+end

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -46,6 +46,7 @@ export
     nested_atmosphere_model,
     parent_boundary_conditions,
     parent_forcings,
+    interpolate_from_parent!,
     # Atmosphere-land interface closures
     BulkHumidity,
     SkinHumidity,
@@ -273,7 +274,8 @@ using .SeaIces
 using .Diagnostics
 using .EarthSystemModels: ComponentInterfaces, MomentumRoughnessLength, ScalarRoughnessLength, default_sea_ice
 using .NestedModels
-using .NestedModels: NestedModel, NestedSimulation, nested_atmosphere_model, parent_boundary_conditions, parent_forcings
+using .NestedModels: NestedModel, NestedSimulation, nested_atmosphere_model, parent_boundary_conditions,
+                     parent_forcings, interpolate_from_parent!
 using .DataWrangling.ETOPO
 using .DataWrangling.ECCO
 using .DataWrangling.GLORYS

--- a/test/test_nested_simulation.jl
+++ b/test/test_nested_simulation.jl
@@ -1,12 +1,14 @@
 include("runtests_setup.jl")
 
 using NumericalEarth
-using NumericalEarth.NestedModels: parent_boundary_conditions, nested_atmosphere_model
+using NumericalEarth.NestedModels: parent_boundary_conditions, nested_atmosphere_model,
+                                   interpolate_from_parent!, query_node
 using Oceananigans
 using Oceananigans: prognostic_fields
 using Oceananigans.OutputReaders: interpolating_time_indices, memory_index
 using Oceananigans.Units: Time
 using Oceananigans.Fields: location
+using Oceananigans.Grids: rnode, znode
 using Oceananigans.BoundaryConditions: ValueBoundaryCondition, FieldBoundaryConditions, fill_halo_regions!
 using Breeze
 using Breeze: ThermodynamicConstants, dry_air_gas_constant, vapor_gas_constant, CompressibleDynamics
@@ -696,4 +698,37 @@ end
     Δxf = minimum_xspacing(fine,   Center(), Center(), Center())
     @test isapprox(wc * Δxc, 60_000; rtol = 0.2)
     @test isapprox(wf * Δxf, 60_000; rtol = 0.2)
+end
+
+# A child samples its parent wherever `interpolate` locates the vertical: through the source grid's 1-D
+# `znodes`. On a terrain-following grid those are the REFERENCE levels while `node` returns the
+# terrain-deformed height, so a physical-node query into a terrain-following parent is displaced by the
+# terrain elevation. `query_node` dispatches the query coordinate on the source grid to keep the two in
+# the same vertical coordinate.
+@testset "query_node samples a terrain-following source in its own vertical coordinate" begin
+    z = ReferenceToStretchedDiscretization(extent = 12000.0, bias = :left, bias_edge = 0.0,
+                                           constant_spacing = 100.0, constant_spacing_extent = 100.0,
+                                           maximum_spacing = 800.0, stretching = LinearStretching(0.2))
+    plateau = 400.0
+    grid = LatitudeLongitudeGrid(size = (6, 6, length(z)), longitude = (-100, -96), latitude = (34, 38),
+                                 z = TerrainFollowingVerticalDiscretization(z), halo = (5, 5, 5),
+                                 topology = (Bounded, Bounded, Bounded))
+    Breeze.materialize_terrain!(grid, (λ, φ) -> plateau)
+
+    flat_grid = LatitudeLongitudeGrid(size = (6, 6, length(z)), longitude = (-100, -96), latitude = (34, 38),
+                                      z = z, halo = (5, 5, 5), topology = (Bounded, Bounded, Bounded))
+
+    # A terrain-following source is queried at the reference node, a flat one at the physical node.
+    reference = query_node(grid, 3, 3, 1, grid, Center(), Center(), Center())
+    physical  = query_node(flat_grid, 3, 3, 1, grid, Center(), Center(), Center())
+    @test reference[3] ≈ rnode(3, 3, 1, grid, Center(), Center(), Center())
+    @test physical[3]  ≈ znode(3, 3, 1, grid, Center(), Center(), Center())
+    # the displacement the dispatch removes: h·b(r) at the first cell, just under the full height
+    @test physical[3] - reference[3] ≈ plateau rtol = 0.01
+
+    # Regridding a terrain-following source therefore reproduces it exactly on a coincident grid.
+    source = CenterField(grid)
+    set!(source, (λ, φ, z) -> z)             # `set!` evaluates at the physical node
+    target = interpolate_from_parent!(CenterField(grid), source)
+    @test interior(target) ≈ interior(source)
 end


### PR DESCRIPTION
## The bug

`interpolate` locates the vertical of a query through the source grid's 1-D `znodes`, and
`znodes(grid, ℓz) = rnodes(grid, ℓz)` for every grid — so on a terrain-following grid the lookup table
is the **reference** column `r`. But `node`/`_node` on such a grid returns the terrain-deformed
**physical** height — for the Gal-Chen & Somerville (1975) coordinate Breeze uses,
`z = r + h(x, y)·b(r)`, with `b(r) = 1 − r/z_top` under the default `LinearDecay` — and that is what
the query side passes in: `getbc` for an `Interpolated` boundary condition, and `interpolate!`'s kernel.

Asking for a value at physical height and finding it in a table of reference heights is neither
convention: every sample is displaced by `h·b(r)` — the full terrain height at the ground, decaying to
zero at the lid. Identical parent and child terrain does not cancel it, because the mismatch is between
the query convention and the lookup table, not between the grids.

This is invisible in the ERA5 → LAM path, because a `PressureLevelGrid`'s `znodes` *are* physical
(geopotential) heights. It bites wherever the source grid is terrain-following.

## Where it shows up today

`initialize_nested_child!` shifts the interpolated momentum onto the child's own staggered locations
with `interpolate!(u::XFaceField, Field(ρu / ρᵈ))`. Source and target are both the child's
terrain-following grid, so the intended Center → Face horizontal shift also picks up the vertical
displacement — an error in the initial `u`, `v` near the ground, where the shear is strongest.

## The fix

`query_node(source_grid, i, j, k, grid, ℓx, ℓy, ℓz)` is the coordinate at which a child samples a
parent. It defaults to the child's physical `node`; the Breeze extension defines the
`TerrainFollowingGrid` method returning `(ξnode, ηnode, rnode)`, so both sides are read in the same
vertical coordinate. `getbc` and the new `interpolate_from_parent!` go through it, and the two velocity
regrids in `initialize_nested_child!` switch to the latter. The 2-D elevation regrid keeps
`interpolate!` — a `(Center, Center, Nothing)` field has no vertical lookup.

## Why terrain-following (σ-to-σ) sampling

σ is the generic name for a terrain-following vertical coordinate — classically the pressure-based
σ = p/pₛ, WRF's mass-based η, or the height-based `r` here — so "σ-to-σ" means sampling the parent at
the same value of that coordinate. Near the ground that is height above ground; aloft, where `b(r) → 0`,
the levels flatten and it becomes physical height.

Sampling this way is also the convention nesting wants, for three reasons beyond internal consistency.

**It cannot sample below the parent's ground.** Where a coarse parent smooths a ridge into a ramp and
the child resolves the peaks and valleys under it, a child valley floor sits *underground* in the
parent. Querying it at its own physical height finds no valid data: the query clamps to the parent's
lowest level, or reads whatever is stored below the surface. Child peaks are fine — they are above the
parent's ground — so the failure is asymmetric, and valleys are the common case in a refined nest.
Sampling at constant `r` maps every child level to a valid parent level by construction. This repo
already carries the evidence that sampling a terrain-bearing source by physical height is fragile:
`clip_subsurface!` and `column_fractional_z_index` exist to keep ERA5's non-physical sub-surface levels
out of exactly this kind of query.

**It follows the coordinate the physics does.** Constant `r` is height above ground up to a column
compression, `AGL = r·(1 − h/z_top)` — 2 % over 400 m of terrain with a 19.5 km lid — so it is
terrain-following exactly where height above ground governs the flow (surface layer, boundary layer,
flow over terrain). Aloft, where height above sea level governs it (free troposphere, the jet,
isentropic structure), `b(r) → 0` and the levels are already flat.

**It is exact when the levels are shared.** Nests that share a reference discretization — the normal
case for a telescope — map level `k` to level `k`, so only the horizontal is interpolated and there is
no vertical interpolation error anywhere, including in the boundary zone.

## Test

A new testset asserts the round trip on a 400 m plateau: the reference-node query reproduces the source
exactly, the physical-node query is displaced by ≈ h, and `interpolate_from_parent!` reproduces a
terrain-following field exactly on a coincident grid. The existing nested-simulation integration tests
cover the changed initialization call sites.

## Complementary Breeze fix

The general fix belongs in Breeze: a `_fractional_indices(::NTuple{3}, ::TerrainFollowingGrid, …)` that
inverts the column mapping, mirroring what this package already does for `PressureLevelGrid` via
`column_fractional_z_index` (#241). The mapping is column-dependent, so it cannot be expressed in the
1-D `znodes` table `interpolate` consults, and cannot be fixed on the lookup side from here. I found no
Breeze issue or PR covering it, and no such method anywhere in Breeze's history.

It would serve the case this PR does not: a terrain-following parent read by a child that has no
terrain-following coordinate of its own. Nesting down to a flat-bottom, uniform-grid LES is the
concrete example. Its levels are fixed heights, not σ levels, so there is no value of `r` on the child
side to match and "sample at the same level" has no referent; the well-posed question there is the
parent's value at a physical height, which needs the parent's column mapping inverted. The displacement
scales with the parent's terrain height under the nest, so this is harmless over lowland and wrong over
an elevated plateau — and it is quiet either way, because `query_node` dispatches on the source grid, so
such a child falls back to its own physical node and keeps the mismatch. The `query_node` docstring
records the assumption. Nests that share the parent's terrain-following coordinate — the telescoping
case — are covered here.

For reference, the inversion is closed form under the default `LinearDecay`,
`r = (z − h)/(1 − h/z_top)`; `TwoLevelDecay` (SLEVE) would need iteration.
