### PR TITLE
Window-center the JRA55 repeat-year, GLORYS, ECCO2 and GloFAS means, and rename `sample_window`

### DIFF
--- a/docs/src/developers/implement_a_dataset.jl
+++ b/docs/src/developers/implement_a_dataset.jl
@@ -22,6 +22,7 @@
 # | `dataset_variable_name` | the variable's name *inside* the file |
 # | `longitude_name` / `latitude_name` | the file's coordinate-variable names (default `"longitude"`/`"latitude"`) |
 # | `all_dates` | the time axis |
+# | `averaging_window` | (optional) the interval a value represents (default: the stamp itself) |
 # | `Base.size` | the `(Nx, Ny, Nz)` shape of one snapshot |
 # | `is_three_dimensional` | whether a variable has a vertical axis (default `true`) |
 # | `z_interfaces` | the vertical cell faces (3-D variables) |
@@ -31,6 +32,16 @@
 #
 # Everything else — building the column grid, reducing the horizontal location, vertical interpolation onto
 # the target grid — is supplied by the generic path.
+#
+# ### Dates and averaging windows
+#
+# `all_dates` returns the dates the *files* carry. They build filenames and download requests and locate a
+# record inside a file, so they stay exactly as the product labels them. What a value means in time is a
+# separate question, answered by `averaging_window`: for a product whose files hold time averages it returns
+# the interval each average is taken over, and a `FieldTimeSeries` then puts the sample at the middle of that
+# interval and repeats a cyclic series over the span the intervals tile. Products label an average with the
+# start of that interval, its end, or its middle, so the window is declared per dataset rather than inferred
+# from the dates. The mooring records values at an instant and keeps the default, a window of zero width.
 
 using NumericalEarth
 using NumericalEarth.DataWrangling: Metadata, Metadatum, metadata_path, centers_to_interfaces,

--- a/src/DataWrangling/AVISO/AVISO.jl
+++ b/src/DataWrangling/AVISO/AVISO.jl
@@ -39,6 +39,9 @@ Base.size(::AVISODataset, variable) = (2880, 1440, 1)
 DataWrangling.all_dates(::AVISODaily, variable) = AVISO_FIRST_DATE : Day(1) : AVISO_DAILY_LAST_DATE
 DataWrangling.all_dates(::AVISOMonthly, variable) = AVISO_FIRST_DATE : Month(1) : AVISO_MONTHLY_LAST_DATE
 
+# TODO: confirm whether the daily L4 maps are gridded analyses valid at the stamp, as assumed
+# here, or means over the stamped day.
+DataWrangling.sample_window(metadatum::Metadatum{<:AVISODaily}) = DataWrangling.instantaneous_window(metadatum)
 DataWrangling.sample_window(metadatum::Metadatum{<:AVISOMonthly}) = DataWrangling.calendar_month_window(metadatum)
 
 const AVISO_dataset_variable_names = Dict(

--- a/src/DataWrangling/AVISO/AVISO.jl
+++ b/src/DataWrangling/AVISO/AVISO.jl
@@ -39,8 +39,8 @@ Base.size(::AVISODataset, variable) = (2880, 1440, 1)
 DataWrangling.all_dates(::AVISODaily, variable) = AVISO_FIRST_DATE : Day(1) : AVISO_DAILY_LAST_DATE
 DataWrangling.all_dates(::AVISOMonthly, variable) = AVISO_FIRST_DATE : Month(1) : AVISO_MONTHLY_LAST_DATE
 
-# TODO: confirm whether the daily L4 maps are gridded analyses valid at the stamp, as assumed
-# here, or means over the stamped day.
+# The daily L4 maps carry no `cell_methods`, unlike the monthly means that declare `time: mean`, so
+# they are gridded analyses valid at the stamp rather than averages over the day.
 DataWrangling.sample_window(metadatum::Metadatum{<:AVISODaily}) = DataWrangling.instantaneous_window(metadatum)
 DataWrangling.sample_window(metadatum::Metadatum{<:AVISOMonthly}) = DataWrangling.calendar_month_window(metadatum)
 

--- a/src/DataWrangling/AVISO/AVISO.jl
+++ b/src/DataWrangling/AVISO/AVISO.jl
@@ -39,10 +39,7 @@ Base.size(::AVISODataset, variable) = (2880, 1440, 1)
 DataWrangling.all_dates(::AVISODaily, variable) = AVISO_FIRST_DATE : Day(1) : AVISO_DAILY_LAST_DATE
 DataWrangling.all_dates(::AVISOMonthly, variable) = AVISO_FIRST_DATE : Month(1) : AVISO_MONTHLY_LAST_DATE
 
-# The daily L4 maps carry no `cell_methods`, unlike the monthly means that declare `time: mean`, so
-# they are gridded analyses valid at the stamp rather than averages over the day.
-DataWrangling.sample_window(metadatum::Metadatum{<:AVISODaily}) = DataWrangling.instantaneous_window(metadatum)
-DataWrangling.sample_window(metadatum::Metadatum{<:AVISOMonthly}) = DataWrangling.calendar_month_window(metadatum)
+DataWrangling.averaging_window(metadatum::Metadatum{<:AVISOMonthly}) = DataWrangling.calendar_month_window(metadatum)
 
 const AVISO_dataset_variable_names = Dict(
     :free_surface => "adt",

--- a/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
+++ b/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
@@ -171,7 +171,7 @@ DataWrangling.all_dates(::CopernicusAlbedo, variable) = copernicus_albedo_dekada
 # 12 climatological months; the year is arbitrary, only the month matters.
 DataWrangling.all_dates(::CopernicusAlbedoClimatology, variable) = [DateTime(2018, m, 1) for m in 1:12]
 
-# Each climatological month averages every dekad falling in it, so it spans the calendar month.
+# Each climatological month averages every ten days falling in it, so it spans the calendar month.
 DataWrangling.averaging_window(md::Metadatum{<:CopernicusAlbedoClimatology}) =
     DataWrangling.calendar_month_window(md)
 

--- a/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
+++ b/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
@@ -171,6 +171,15 @@ DataWrangling.all_dates(::CopernicusAlbedo, variable) = copernicus_albedo_dekada
 # 12 climatological months; the year is arbitrary, only the month matters.
 DataWrangling.all_dates(::CopernicusAlbedoClimatology, variable) = [DateTime(2018, m, 1) for m in 1:12]
 
+# Each climatological month averages every dekad falling in it, so it spans the calendar month.
+DataWrangling.sample_window(md::Metadatum{<:CopernicusAlbedoClimatology}) =
+    DataWrangling.calendar_month_window(md)
+
+# A dekadal albedo is a retrieval valid at the date it is stamped with rather than a mean over
+# the preceding dekad, so its window has zero width.
+DataWrangling.sample_window(md::Metadatum{<:CopernicusAlbedo}) =
+    DataWrangling.instantaneous_window(md)
+
 #####
 ##### Filenames (date + variable keyed, region-independent — reused across regions)
 #####

--- a/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
+++ b/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
@@ -172,13 +172,8 @@ DataWrangling.all_dates(::CopernicusAlbedo, variable) = copernicus_albedo_dekada
 DataWrangling.all_dates(::CopernicusAlbedoClimatology, variable) = [DateTime(2018, m, 1) for m in 1:12]
 
 # Each climatological month averages every dekad falling in it, so it spans the calendar month.
-DataWrangling.sample_window(md::Metadatum{<:CopernicusAlbedoClimatology}) =
+DataWrangling.averaging_window(md::Metadatum{<:CopernicusAlbedoClimatology}) =
     DataWrangling.calendar_month_window(md)
-
-# A dekadal albedo is a retrieval valid at the date it is stamped with rather than a mean over
-# the preceding dekad, so its window has zero width.
-DataWrangling.sample_window(md::Metadatum{<:CopernicusAlbedo}) =
-    DataWrangling.instantaneous_window(md)
 
 #####
 ##### Filenames (date + variable keyed, region-independent — reused across regions)

--- a/src/DataWrangling/ECCO/ECCO.jl
+++ b/src/DataWrangling/ECCO/ECCO.jl
@@ -73,8 +73,9 @@ DataWrangling.all_dates(dataset::ECCO2Daily,   variable) = metadata_epoch(datase
 DataWrangling.sample_window(metadatum::Metadatum{<:Union{ECCO2Monthly, ECCO4Monthly}}) =
     DataWrangling.calendar_month_window(metadatum)
 
-# TODO: confirm whether the ECCO2 daily files hold means over the stamped day, in which case
-# this becomes a one-day `leading_window`.
+# TODO: ECCO2 stamps the center of each averaging period — the monthly file for January 1993 carries
+# 1993-01-16 — but the daily file named 19930101 carries 1993-01-02, so this node sits at least half a
+# day from the value it labels. Left at the stamp until that offset is pinned down.
 DataWrangling.sample_window(metadatum::Metadatum{<:ECCO2Daily}) =
     DataWrangling.instantaneous_window(metadatum)
 

--- a/src/DataWrangling/ECCO/ECCO.jl
+++ b/src/DataWrangling/ECCO/ECCO.jl
@@ -73,9 +73,10 @@ DataWrangling.all_dates(dataset::ECCO2Daily,   variable) = metadata_epoch(datase
 DataWrangling.sample_window(metadatum::Metadatum{<:Union{ECCO2Monthly, ECCO4Monthly}}) =
     DataWrangling.calendar_month_window(metadatum)
 
-# TODO: ECCO2 stamps the center of each averaging period — the monthly file for January 1993 carries
+# ECCO2 stamps the center of each averaging period — the monthly file for January 1993 carries
 # 1993-01-16 — but the daily file named 19930101 carries 1993-01-02, so this node sits at least half a
-# day from the value it labels. Left at the stamp until that offset is pinned down.
+# day from the value it labels. Pinning the offset needs the drive, which serves 403 for every ECCO2
+# path, so it stays at the stamp.
 DataWrangling.sample_window(metadatum::Metadatum{<:ECCO2Daily}) =
     DataWrangling.instantaneous_window(metadatum)
 

--- a/src/DataWrangling/ECCO/ECCO.jl
+++ b/src/DataWrangling/ECCO/ECCO.jl
@@ -73,12 +73,12 @@ DataWrangling.all_dates(dataset::ECCO2Daily,   variable) = metadata_epoch(datase
 DataWrangling.sample_window(metadatum::Metadatum{<:Union{ECCO2Monthly, ECCO4Monthly}}) =
     DataWrangling.calendar_month_window(metadatum)
 
-# ECCO2 stamps the center of each averaging period — the monthly file for January 1993 carries
-# 1993-01-16 — but the daily file named 19930101 carries 1993-01-02, so this node sits at least half a
-# day from the value it labels. Pinning the offset needs the drive, which serves 403 for every ECCO2
-# path, so it stays at the stamp.
+# The cube92 daily files hold means over the day they are named for, so the window runs forwards a day
+# from the stamp. Their own time coordinate is the end of that window — the file named 19930101 carries
+# 1993-01-02 — while the monthly files carry a mid-month date instead, so the two disagree; the daily
+# file matches the 1993-01-01 record of the same series served by APDRC bit for bit.
 DataWrangling.sample_window(metadatum::Metadatum{<:ECCO2Daily}) =
-    DataWrangling.instantaneous_window(metadatum)
+    DataWrangling.leading_window(metadatum, Day(1))
 
 DataWrangling.longitude_interfaces(::ECCODataset) = (0, 360)
 DataWrangling.longitude_interfaces(::ECCO4Monthly) = (-180, 180)

--- a/src/DataWrangling/ECCO/ECCO.jl
+++ b/src/DataWrangling/ECCO/ECCO.jl
@@ -70,15 +70,12 @@ DataWrangling.all_dates(dataset::ECCO4Monthly, variable) = metadata_epoch(datase
 DataWrangling.all_dates(dataset::ECCO2Monthly, variable) = metadata_epoch(dataset) : Month(1) : DateTime(2024, 12, 1)
 DataWrangling.all_dates(dataset::ECCO2Daily,   variable) = metadata_epoch(dataset) : Day(1)   : DateTime(2024, 12, 31)
 
-DataWrangling.sample_window(metadatum::Metadatum{<:Union{ECCO2Monthly, ECCO4Monthly}}) =
+DataWrangling.averaging_window(metadatum::Metadatum{<:Union{ECCO2Monthly, ECCO4Monthly}}) =
     DataWrangling.calendar_month_window(metadatum)
 
-# The cube92 daily files hold means over the day they are named for, so the window runs forwards a day
-# from the stamp. Their own time coordinate is the end of that window — the file named 19930101 carries
-# 1993-01-02 — while the monthly files carry a mid-month date instead, so the two disagree; the daily
-# file matches the 1993-01-01 record of the same series served by APDRC bit for bit.
-DataWrangling.sample_window(metadatum::Metadatum{<:ECCO2Daily}) =
-    DataWrangling.leading_window(metadatum, Day(1))
+# The cube92 daily files hold means over the day they are named for.
+DataWrangling.averaging_window(metadatum::Metadatum{<:ECCO2Daily}) =
+    (metadatum.dates, metadatum.dates + Day(1))
 
 DataWrangling.longitude_interfaces(::ECCODataset) = (0, 360)
 DataWrangling.longitude_interfaces(::ECCO4Monthly) = (-180, 180)

--- a/src/DataWrangling/ECCO/ECCO.jl
+++ b/src/DataWrangling/ECCO/ECCO.jl
@@ -73,6 +73,11 @@ DataWrangling.all_dates(dataset::ECCO2Daily,   variable) = metadata_epoch(datase
 DataWrangling.sample_window(metadatum::Metadatum{<:Union{ECCO2Monthly, ECCO4Monthly}}) =
     DataWrangling.calendar_month_window(metadatum)
 
+# TODO: confirm whether the ECCO2 daily files hold means over the stamped day, in which case
+# this becomes a one-day `leading_window`.
+DataWrangling.sample_window(metadatum::Metadatum{<:ECCO2Daily}) =
+    DataWrangling.instantaneous_window(metadatum)
+
 DataWrangling.longitude_interfaces(::ECCODataset) = (0, 360)
 DataWrangling.longitude_interfaces(::ECCO4Monthly) = (-180, 180)
 DataWrangling.latitude_interfaces(::ECCODataset) = (-90, 90)

--- a/src/DataWrangling/ECCO/ECCO_darwin.jl
+++ b/src/DataWrangling/ECCO/ECCO_darwin.jl
@@ -28,7 +28,7 @@ DataWrangling.all_dates(dataset::ECCO2DarwinMonthly, name) = metadata_epoch(data
 
 # ECCO4Darwin is stamped at noon on the first of the month, so the window is the calendar month
 # containing the stamp rather than a month starting at it.
-DataWrangling.sample_window(metadatum::ECCODarwinMetadatum) = DataWrangling.calendar_month_window(metadatum)
+DataWrangling.averaging_window(metadatum::ECCODarwinMetadatum) = DataWrangling.calendar_month_window(metadatum)
 
 # File name generation specific to each Dataset dataset
 """

--- a/src/DataWrangling/EN4/EN4.jl
+++ b/src/DataWrangling/EN4/EN4.jl
@@ -27,7 +27,7 @@ struct EN4Monthly end
 Base.size(::EN4Monthly, variable) = (360, 173, 42)
 DataWrangling.all_dates(::EN4Monthly, variable) = DateTime(1900, 1, 1) : Month(1) : DateTime(2024, 12, 1)
 
-DataWrangling.sample_window(metadatum::Metadatum{<:EN4Monthly}) =
+DataWrangling.averaging_window(metadatum::Metadatum{<:EN4Monthly}) =
     DataWrangling.calendar_month_window(metadatum)
 
 DataWrangling.default_download_directory(::EN4Monthly) = download_EN4_cache

--- a/src/DataWrangling/ERA5/ERA5.jl
+++ b/src/DataWrangling/ERA5/ERA5.jl
@@ -29,7 +29,7 @@ using ..DataWrangling: DataWrangling, Metadata, Metadatum, MetadataSet, Bounding
                        MetersPerHour, JoulesPerSquareMeterPerHour, metadata_path,
                        native_grid, dataset_variable_name, available_variables, retrieve_data,
                        first_date, last_date, native_times, set_metadata_field!, DatasetBackend,
-                       instantiate, DatewiseFilename, sample_window_span, validate_time_coverage
+                       instantiate, DatewiseFilename, window_span, validate_time_coverage
 using ...Grids: PressureLevelVerticalDiscretization, PressureLevelGrid
 
 download_ERA5_cache::String = ""

--- a/src/DataWrangling/ERA5/ERA5_land.jl
+++ b/src/DataWrangling/ERA5/ERA5_land.jl
@@ -96,6 +96,7 @@ DataWrangling.conversion_units(md::ERA5LandMetadata) = nothing
 DataWrangling.default_inpainting(md::ERA5LandMetadata) = nothing
 
 # Monthly means span the calendar month; ERA5HourlyLand variables are all instantaneous.
+DataWrangling.sample_window(md::Metadatum{<:ERA5HourlyLand}) = DataWrangling.instantaneous_window(md)
 DataWrangling.sample_window(md::Metadatum{<:ERA5MonthlyLand}) = DataWrangling.calendar_month_window(md)
 
 # reversed_latitude_axis and ocean masking (nan_convert_missing) are inherited unchanged from ERA5Dataset.

--- a/src/DataWrangling/ERA5/ERA5_land.jl
+++ b/src/DataWrangling/ERA5/ERA5_land.jl
@@ -96,8 +96,7 @@ DataWrangling.conversion_units(md::ERA5LandMetadata) = nothing
 DataWrangling.default_inpainting(md::ERA5LandMetadata) = nothing
 
 # Monthly means span the calendar month; ERA5HourlyLand variables are all instantaneous.
-DataWrangling.sample_window(md::Metadatum{<:ERA5HourlyLand}) = DataWrangling.instantaneous_window(md)
-DataWrangling.sample_window(md::Metadatum{<:ERA5MonthlyLand}) = DataWrangling.calendar_month_window(md)
+DataWrangling.averaging_window(md::Metadatum{<:ERA5MonthlyLand}) = DataWrangling.calendar_month_window(md)
 
 # reversed_latitude_axis and ocean masking (nan_convert_missing) are inherited unchanged from ERA5Dataset.
 

--- a/src/DataWrangling/ERA5/ERA5_pressure_levels.jl
+++ b/src/DataWrangling/ERA5/ERA5_pressure_levels.jl
@@ -52,10 +52,7 @@ DataWrangling.all_dates(::ERA5HourlyPressureLevels, var) = range(DateTime("1940-
 DataWrangling.all_dates(::ERA5MonthlyPressureLevels, var) = range(DateTime("1940-01-01"), stop=DateTime("2025-12-01"), step=Month(1))
 
 # Pressure-level variables are all instantaneous, so only the monthly means carry a window.
-# Pressure-level fields are all analysis fields, so the hourly product is instantaneous;
-# monthly means span the calendar month.
-DataWrangling.sample_window(md::Metadatum{<:ERA5HourlyPressureLevels}) = DataWrangling.instantaneous_window(md)
-DataWrangling.sample_window(md::Metadatum{<:ERA5MonthlyPressureLevels}) = DataWrangling.calendar_month_window(md)
+DataWrangling.averaging_window(md::Metadatum{<:ERA5MonthlyPressureLevels}) = DataWrangling.calendar_month_window(md)
 
 # ERA5 pressure-level data is a spatially 3-D dataset
 DataWrangling.is_three_dimensional(::ERA5PressureMetadata) = true
@@ -345,7 +342,7 @@ function era5_native_pressure_fts(metadata, grid;
     # As in the generic constructor: a window-averaged series repeats over the span its
     # windows tile, not over the node span Oceananigans would infer.
     if time_indexing isa Cyclical{Nothing}
-        period = sample_window_span(metadata)
+        period = window_span(metadata)
         isnothing(period) || (time_indexing = Cyclical(convert(eltype(grid), period)))
     end
 

--- a/src/DataWrangling/ERA5/ERA5_pressure_levels.jl
+++ b/src/DataWrangling/ERA5/ERA5_pressure_levels.jl
@@ -52,6 +52,9 @@ DataWrangling.all_dates(::ERA5HourlyPressureLevels, var) = range(DateTime("1940-
 DataWrangling.all_dates(::ERA5MonthlyPressureLevels, var) = range(DateTime("1940-01-01"), stop=DateTime("2025-12-01"), step=Month(1))
 
 # Pressure-level variables are all instantaneous, so only the monthly means carry a window.
+# Pressure-level fields are all analysis fields, so the hourly product is instantaneous;
+# monthly means span the calendar month.
+DataWrangling.sample_window(md::Metadatum{<:ERA5HourlyPressureLevels}) = DataWrangling.instantaneous_window(md)
 DataWrangling.sample_window(md::Metadatum{<:ERA5MonthlyPressureLevels}) = DataWrangling.calendar_month_window(md)
 
 # ERA5 pressure-level data is a spatially 3-D dataset

--- a/src/DataWrangling/ERA5/ERA5_single_levels.jl
+++ b/src/DataWrangling/ERA5/ERA5_single_levels.jl
@@ -139,13 +139,13 @@ const ERA5_window_averaged_variables = (:total_precipitation,
                                         :mean_surface_sensible_heat_flux,
                                         :mean_surface_latent_heat_flux)
 
-function DataWrangling.sample_window(md::Metadatum{<:Union{ERA5HourlySingleLevel, ERA5YearlySingleLevel}})
-    md.name in ERA5_window_averaged_variables || return DataWrangling.instantaneous_window(md)
-    return DataWrangling.trailing_window(md, Hour(1))
+function DataWrangling.averaging_window(md::Metadatum{<:Union{ERA5HourlySingleLevel, ERA5YearlySingleLevel}})
+    md.name in ERA5_window_averaged_variables || return (md.dates, md.dates)
+    return (md.dates - Hour(1), md.dates)
 end
 
 # Monthly means span the calendar month, accumulations and instantaneous variables alike.
-DataWrangling.sample_window(md::Metadatum{<:ERA5MonthlySingleLevel}) = DataWrangling.calendar_month_window(md)
+DataWrangling.averaging_window(md::Metadatum{<:ERA5MonthlySingleLevel}) = DataWrangling.calendar_month_window(md)
 
 """
     retrieve_data(metadata::ERA5Metadatum)

--- a/src/DataWrangling/ERA5/ERA5_single_levels.jl
+++ b/src/DataWrangling/ERA5/ERA5_single_levels.jl
@@ -140,8 +140,8 @@ const ERA5_window_averaged_variables = (:total_precipitation,
                                         :mean_surface_latent_heat_flux)
 
 function DataWrangling.sample_window(md::Metadatum{<:Union{ERA5HourlySingleLevel, ERA5YearlySingleLevel}})
-    md.name in ERA5_window_averaged_variables || return (md.dates, md.dates)
-    return (md.dates - Hour(1), md.dates)
+    md.name in ERA5_window_averaged_variables || return DataWrangling.instantaneous_window(md)
+    return DataWrangling.trailing_window(md, Hour(1))
 end
 
 # Monthly means span the calendar month, accumulations and instantaneous variables alike.

--- a/src/DataWrangling/GLORYS/GLORYS.jl
+++ b/src/DataWrangling/GLORYS/GLORYS.jl
@@ -48,15 +48,12 @@ all_dates(::GLORYSStatic, var) = [nothing]
 all_dates(::GLORYSDaily, var) = range(DateTime("1993-01-01"), stop=DateTime("2021-06-30"), step=Day(1))
 all_dates(::GLORYSMonthly, var) = range(DateTime("1993-01-01"), stop=DateTime("2021-06-01"), step=Month(1))
 
-# Static variables carry no date, so their window is the `nothing` they are stamped with.
-DataWrangling.sample_window(metadatum::Metadatum{<:GLORYSStatic}) = DataWrangling.instantaneous_window(metadatum)
-
 # `P1D-m` is a one-day mean, and Copernicus Marine stamps the start of an averaging period rather
-# than its center — its monthly means for July 2010 carry 2010-07-01 — so the window runs forwards
-# a day from the stamp.
-DataWrangling.sample_window(metadatum::Metadatum{<:GLORYSDaily}) = DataWrangling.leading_window(metadatum, Day(1))
+# than its center: its monthly means for July 2010 carry 2010-07-01.
+DataWrangling.averaging_window(metadatum::Metadatum{<:GLORYSDaily}) =
+    (metadatum.dates, metadatum.dates + Day(1))
 
-DataWrangling.sample_window(metadatum::Metadatum{<:GLORYSMonthly}) = DataWrangling.calendar_month_window(metadatum)
+DataWrangling.averaging_window(metadatum::Metadatum{<:GLORYSMonthly}) = DataWrangling.calendar_month_window(metadatum)
 
 copernicusmarine_dataset_id(::GLORYSStatic) = "cmems_mod_glo_phy_my_0.083deg_static"
 copernicusmarine_dataset_id(::GLORYSDaily) = "cmems_mod_glo_phy_my_0.083deg_P1D-m"

--- a/src/DataWrangling/GLORYS/GLORYS.jl
+++ b/src/DataWrangling/GLORYS/GLORYS.jl
@@ -51,9 +51,10 @@ all_dates(::GLORYSMonthly, var) = range(DateTime("1993-01-01"), stop=DateTime("2
 # Static variables carry no date, so their window is the `nothing` they are stamped with.
 DataWrangling.sample_window(metadatum::Metadatum{<:GLORYSStatic}) = DataWrangling.instantaneous_window(metadatum)
 
-# TODO: the `P1D-m` product id names a one-day mean, so this is likely a one-day
-# `leading_window`; confirm against the file time axis before changing it.
-DataWrangling.sample_window(metadatum::Metadatum{<:GLORYSDaily}) = DataWrangling.instantaneous_window(metadatum)
+# `P1D-m` is a one-day mean, and Copernicus Marine stamps the start of an averaging period rather
+# than its center — its monthly means for July 2010 carry 2010-07-01 — so the window runs forwards
+# a day from the stamp.
+DataWrangling.sample_window(metadatum::Metadatum{<:GLORYSDaily}) = DataWrangling.leading_window(metadatum, Day(1))
 
 DataWrangling.sample_window(metadatum::Metadatum{<:GLORYSMonthly}) = DataWrangling.calendar_month_window(metadatum)
 

--- a/src/DataWrangling/GLORYS/GLORYS.jl
+++ b/src/DataWrangling/GLORYS/GLORYS.jl
@@ -48,6 +48,13 @@ all_dates(::GLORYSStatic, var) = [nothing]
 all_dates(::GLORYSDaily, var) = range(DateTime("1993-01-01"), stop=DateTime("2021-06-30"), step=Day(1))
 all_dates(::GLORYSMonthly, var) = range(DateTime("1993-01-01"), stop=DateTime("2021-06-01"), step=Month(1))
 
+# Static variables carry no date, so their window is the `nothing` they are stamped with.
+DataWrangling.sample_window(metadatum::Metadatum{<:GLORYSStatic}) = DataWrangling.instantaneous_window(metadatum)
+
+# TODO: the `P1D-m` product id names a one-day mean, so this is likely a one-day
+# `leading_window`; confirm against the file time axis before changing it.
+DataWrangling.sample_window(metadatum::Metadatum{<:GLORYSDaily}) = DataWrangling.instantaneous_window(metadatum)
+
 DataWrangling.sample_window(metadatum::Metadatum{<:GLORYSMonthly}) = DataWrangling.calendar_month_window(metadatum)
 
 copernicusmarine_dataset_id(::GLORYSStatic) = "cmems_mod_glo_phy_my_0.083deg_static"

--- a/src/DataWrangling/GloFAS/glofas_reanalysis.jl
+++ b/src/DataWrangling/GloFAS/glofas_reanalysis.jl
@@ -21,9 +21,10 @@ Base.size(::GloFASReanalysis, variable) = (7200, 3000, 1)
 DataWrangling.all_dates(::GloFASReanalysis, variable) =
     range(DateTime("1979-01-01"), stop=DateTime("2024-12-31"), step=Day(1))
 
-# TODO: `river_discharge_in_the_last_24_hours` names a 24-hour mean, so this is likely a
-# one-day `trailing_window`; confirm which day the stamp labels before changing it.
-DataWrangling.sample_window(md::GloFASMetadatum) = DataWrangling.instantaneous_window(md)
+# The discharge is a mean over the day requested, which the store stamps with the end of that window:
+# asking for 10 July 2010 returns a file whose `valid_time` is 11 July. The dates here label the start
+# of the window instead, so it runs forwards a day from the stamp.
+DataWrangling.sample_window(md::GloFASMetadatum) = DataWrangling.leading_window(md, Day(1))
 
 #####
 ##### Variable name mappings

--- a/src/DataWrangling/GloFAS/glofas_reanalysis.jl
+++ b/src/DataWrangling/GloFAS/glofas_reanalysis.jl
@@ -21,6 +21,10 @@ Base.size(::GloFASReanalysis, variable) = (7200, 3000, 1)
 DataWrangling.all_dates(::GloFASReanalysis, variable) =
     range(DateTime("1979-01-01"), stop=DateTime("2024-12-31"), step=Day(1))
 
+# TODO: `river_discharge_in_the_last_24_hours` names a 24-hour mean, so this is likely a
+# one-day `trailing_window`; confirm which day the stamp labels before changing it.
+DataWrangling.sample_window(md::GloFASMetadatum) = DataWrangling.instantaneous_window(md)
+
 #####
 ##### Variable name mappings
 #####

--- a/src/DataWrangling/GloFAS/glofas_reanalysis.jl
+++ b/src/DataWrangling/GloFAS/glofas_reanalysis.jl
@@ -21,10 +21,9 @@ Base.size(::GloFASReanalysis, variable) = (7200, 3000, 1)
 DataWrangling.all_dates(::GloFASReanalysis, variable) =
     range(DateTime("1979-01-01"), stop=DateTime("2024-12-31"), step=Day(1))
 
-# The discharge is a mean over the day requested, which the store stamps with the end of that window:
-# asking for 10 July 2010 returns a file whose `valid_time` is 11 July. The dates here label the start
-# of the window instead, so it runs forwards a day from the stamp.
-DataWrangling.sample_window(md::GloFASMetadatum) = DataWrangling.leading_window(md, Day(1))
+# The discharge is a mean over the day the dates label, which the store stamps with the end of that
+# window: asking for 10 July 2010 returns a file whose `valid_time` is 11 July.
+DataWrangling.averaging_window(md::GloFASMetadatum) = (md.dates, md.dates + Day(1))
 
 #####
 ##### Variable name mappings

--- a/src/DataWrangling/JRA55/JRA55_metadata.jl
+++ b/src/DataWrangling/JRA55/JRA55_metadata.jl
@@ -67,6 +67,29 @@ DataWrangling.all_dates(::MultiYearJRA55, name) = JRA55_multiple_year_dates[name
 # Fallback, if we not provide the name, take the highest frequency
 DataWrangling.all_dates(dataset::JRA55Dataset) = all_dates(dataset, :temperature)
 
+# Fluxes, radiation, and precipitation are means over the interval between stamps; the state
+# variables are instantaneous.
+const JRA55_window_averaged_variables = (:river_freshwater_flux,
+                                         :iceberg_freshwater_flux,
+                                         :rain_freshwater_flux,
+                                         :snow_freshwater_flux,
+                                         :downwelling_longwave_radiation,
+                                         :downwelling_shortwave_radiation)
+
+# The repeat-year files label each mean with the start of its interval, so their windows run
+# forwards from the stamp: the daily river and iceberg fluxes at 00:00, everything else
+# three-hourly. Without this the repeat-year shortwave peaks 1.5 hours before solar noon.
+function DataWrangling.sample_window(md::RepeatYearJRA55Metadatum)
+    md.name in JRA55_window_averaged_variables || return DataWrangling.instantaneous_window(md)
+    span = md.name in (:river_freshwater_flux, :iceberg_freshwater_flux) ? Day(1) : Hour(3)
+    return DataWrangling.leading_window(md, span)
+end
+
+# The multi-year files already label each mean with the center of its interval — the daily
+# river and iceberg fluxes at 12:00, the three-hourly means at 01:30, 04:30, and so on — so
+# every variable sits at its window center as stamped.
+DataWrangling.sample_window(md::MultiYearJRA55Metadatum) = DataWrangling.instantaneous_window(md)
+
 # Valid for all JRA55 datasets
 function JRA55_time_indices(dataset, dates, name)
     all_JRA55_dates = all_dates(dataset, name)

--- a/src/DataWrangling/JRA55/JRA55_metadata.jl
+++ b/src/DataWrangling/JRA55/JRA55_metadata.jl
@@ -76,19 +76,13 @@ const JRA55_window_averaged_variables = (:river_freshwater_flux,
                                          :downwelling_longwave_radiation,
                                          :downwelling_shortwave_radiation)
 
-# The repeat-year files label each mean with the start of its interval, so their windows run
-# forwards from the stamp: the daily river and iceberg fluxes at 00:00, everything else
-# three-hourly. Without this the repeat-year shortwave peaks 1.5 hours before solar noon.
-function DataWrangling.sample_window(md::RepeatYearJRA55Metadatum)
-    md.name in JRA55_window_averaged_variables || return DataWrangling.instantaneous_window(md)
+# The repeat-year files label each mean with the start of its interval; the multi-year files label
+# it with the center.
+function DataWrangling.averaging_window(md::RepeatYearJRA55Metadatum)
+    md.name in JRA55_window_averaged_variables || return (md.dates, md.dates)
     span = md.name in (:river_freshwater_flux, :iceberg_freshwater_flux) ? Day(1) : Hour(3)
-    return DataWrangling.leading_window(md, span)
+    return (md.dates, md.dates + span)
 end
-
-# The multi-year files already label each mean with the center of its interval — the daily
-# river and iceberg fluxes at 12:00, the three-hourly means at 01:30, 04:30, and so on — so
-# every variable sits at its window center as stamped.
-DataWrangling.sample_window(md::MultiYearJRA55Metadatum) = DataWrangling.instantaneous_window(md)
 
 # Valid for all JRA55 datasets
 function JRA55_time_indices(dataset, dates, name)

--- a/src/DataWrangling/WOA/WOA.jl
+++ b/src/DataWrangling/WOA/WOA.jl
@@ -54,6 +54,9 @@ DataWrangling.all_dates(::WOAMonthly, args...) = [DateTime(2018, m, 1) for m in 
 
 DataWrangling.sample_window(metadatum::Metadatum{<:WOAMonthly}) = DataWrangling.calendar_month_window(metadatum)
 
+# The annual climatology is a single dateless snapshot.
+DataWrangling.sample_window(metadatum::Metadatum{<:WOAAnnual}) = DataWrangling.instantaneous_window(metadatum)
+
 # WOA stores depth as positive values, surface first (0 to 5500m)
 DataWrangling.reversed_vertical_axis(::WOAClimatology) = true
 

--- a/src/DataWrangling/WOA/WOA.jl
+++ b/src/DataWrangling/WOA/WOA.jl
@@ -52,10 +52,7 @@ DataWrangling.last_date(::WOAAnnual, args...) = nothing
 # Monthly: 12 climatological months (year is arbitrary, month matters)
 DataWrangling.all_dates(::WOAMonthly, args...) = [DateTime(2018, m, 1) for m in 1:12]
 
-DataWrangling.sample_window(metadatum::Metadatum{<:WOAMonthly}) = DataWrangling.calendar_month_window(metadatum)
-
-# The annual climatology is a single dateless snapshot.
-DataWrangling.sample_window(metadatum::Metadatum{<:WOAAnnual}) = DataWrangling.instantaneous_window(metadatum)
+DataWrangling.averaging_window(metadatum::Metadatum{<:WOAMonthly}) = DataWrangling.calendar_month_window(metadatum)
 
 # WOA stores depth as positive values, surface first (0 to 5500m)
 DataWrangling.reversed_vertical_axis(::WOAClimatology) = true

--- a/src/DataWrangling/metadata.jl
+++ b/src/DataWrangling/metadata.jl
@@ -712,10 +712,39 @@ end
     sample_window(metadatum)
 
 The `(start, stop)` dates of the averaging window the value in `metadatum` represents.
-Defaults to a zero-width window at the stamp itself, which is an instantaneous sample; a
-product whose files hold window averages extends this with its own averaging period.
+
+Every dataset with a time axis must define this: there is no fallback, so an adapter that
+omits it raises a `MethodError` the first time a `FieldTimeSeries` is built from it rather
+than silently placing window averages at their stamps. Build the window with
+[`instantaneous_window`](@ref) for a sample taken at the stamp, and with
+[`calendar_month_window`](@ref), [`leading_window`](@ref), or [`trailing_window`](@ref)
+for a window average.
 """
-sample_window(metadatum) = (metadatum.dates, metadatum.dates)
+function sample_window end
+
+"""
+    instantaneous_window(metadatum)
+
+The [`sample_window`](@ref) of a product whose files hold values at an instant: a zero-width
+window at the stamp itself.
+"""
+instantaneous_window(metadatum) = (metadatum.dates, metadatum.dates)
+
+"""
+    leading_window(metadatum, span)
+
+The [`sample_window`](@ref) of a product stamped at the *start* of the `span` it averages
+over, so the window runs forwards from the stamp.
+"""
+leading_window(metadatum, span) = (metadatum.dates, metadatum.dates + span)
+
+"""
+    trailing_window(metadatum, span)
+
+The [`sample_window`](@ref) of a product stamped at the *end* of the `span` it averages
+over, so the window runs backwards from the stamp.
+"""
+trailing_window(metadatum, span) = (metadatum.dates - span, metadatum.dates)
 
 """
     calendar_month_window(metadatum)

--- a/src/DataWrangling/metadata.jl
+++ b/src/DataWrangling/metadata.jl
@@ -692,64 +692,37 @@ Keyword Argument
 - `start_time`: The start time for calculating the time difference. Defaults to the first
                 date in the metadata.
 
-Each date is shifted by the dataset's [`time_window_offset`](@ref), which places a
-window-averaged sample at the midpoint of its window rather than at the date its file is
-stamped with.
+Times are measured to each sample's [`window_center`](@ref), which for a time average is the
+midpoint of its [`averaging_window`](@ref) rather than the date its file is stamped with.
 """
 function native_times(metadata; start_time=first(metadata).dates)
     times = zeros(length(metadata))
+    reference = comparable_datetime(start_time)
+
     for (t, data) in enumerate(metadata)
-        date = data.dates
-        delta = date - start_time
-        delta = Second(delta).value + time_window_offset(data)
-        times[t] = delta
+        delta = window_center(data) - reference
+        times[t] = Dates.value(Dates.Millisecond(delta)) / 1000
     end
 
     return times
 end
 
 """
-    sample_window(metadatum)
+    averaging_window(metadatum)
 
-The `(start, stop)` dates of the averaging window the value in `metadatum` represents.
-
-Every dataset with a time axis must define this: there is no fallback, so an adapter that
-omits it raises a `MethodError` the first time a `FieldTimeSeries` is built from it rather
-than silently placing window averages at their stamps. Build the window with
-[`instantaneous_window`](@ref) for a sample taken at the stamp, and with
-[`calendar_month_window`](@ref), [`leading_window`](@ref), or [`trailing_window`](@ref)
-for a window average.
+The `(start, stop)` dates of the interval of time the value in `metadatum` represents, its
+`time_bnds` in CF terms. Defaults to a zero-width window at the stamp itself, which is a value
+at an instant; a product whose files hold time averages extends this with the interval each
+average is taken over. Whether the dates label the start of that interval, its end, or its
+middle varies from product to product. See [`calendar_month_window`](@ref) for the
+calendar-month case, whose length varies with the month.
 """
-function sample_window end
-
-"""
-    instantaneous_window(metadatum)
-
-The [`sample_window`](@ref) of a product whose files hold values at an instant: a zero-width
-window at the stamp itself.
-"""
-instantaneous_window(metadatum) = (metadatum.dates, metadatum.dates)
-
-"""
-    leading_window(metadatum, span)
-
-The [`sample_window`](@ref) of a product stamped at the *start* of the `span` it averages
-over, so the window runs forwards from the stamp.
-"""
-leading_window(metadatum, span) = (metadatum.dates, metadatum.dates + span)
-
-"""
-    trailing_window(metadatum, span)
-
-The [`sample_window`](@ref) of a product stamped at the *end* of the `span` it averages
-over, so the window runs backwards from the stamp.
-"""
-trailing_window(metadatum, span) = (metadatum.dates - span, metadatum.dates)
+averaging_window(metadatum) = (metadatum.dates, metadatum.dates)
 
 """
     calendar_month_window(metadatum)
 
-The [`sample_window`](@ref) of a product whose files hold calendar-month means: the month
+The [`averaging_window`](@ref) of a product whose files hold calendar-month means: the month
 containing the date `metadatum` is stamped with. Independent of where in the month the stamp
 falls, so it also covers products stamped at, say, noon on the first.
 """
@@ -761,12 +734,12 @@ end
 """
     window_center(metadatum)
 
-The date at the middle of the [`sample_window`](@ref) of `metadatum`, where a window mean
+The date at the middle of the [`averaging_window`](@ref) of `metadatum`, where a time average
 equals the value of the field itself and so where a linearly interpolating `FieldTimeSeries`
-has to place it. The stamp itself for an instantaneous sample.
+has to place it. The stamp itself for a value at an instant.
 """
 function window_center(metadatum)
-    window_start, window_stop = sample_window(metadatum)
+    window_start, window_stop = averaging_window(metadatum)
     start_datetime = comparable_datetime(window_start)
     stop_datetime = comparable_datetime(window_stop)
     half_window = Dates.value(Dates.Millisecond(stop_datetime - start_datetime)) ÷ 2
@@ -774,45 +747,34 @@ function window_center(metadatum)
 end
 
 """
-    time_window_offset(metadatum)
+    window_span(metadata)
 
-The offset in seconds from the date a file is stamped with to its [`window_center`](@ref).
-
-Zero for an instantaneous sample, half a period for a stamp that labels the start of an
-averaging window, and negative for one that labels the end.
-"""
-time_window_offset(metadatum) =
-    Dates.value(Dates.Millisecond(window_center(metadatum) - comparable_datetime(metadatum.dates))) / 1000
-
-"""
-    sample_window_span(metadata)
-
-The span in seconds from the start of the first [`sample_window`](@ref) in `metadata` to the
+The span in seconds from the start of the first [`averaging_window`](@ref) in `metadata` to the
 end of the last, which is the period over which a window-averaged series repeats: its windows
-tile that span without gaps or overlaps. `nothing` for an instantaneous product, whose samples
-are points and so leave the period to be inferred from the node spacing.
+tile that span without gaps or overlaps. `nothing` for a product of values at an instant, whose
+samples are points and so leave the period to be inferred from the node spacing.
 """
-function sample_window_span(metadata)
-    window_start, window_stop = sample_window(first(metadata))
+function window_span(metadata)
+    window_start, window_stop = averaging_window(first(metadata))
     window_start == window_stop && return nothing
-    span = comparable_datetime(last(sample_window(last(metadata)))) - comparable_datetime(window_start)
+    span = comparable_datetime(last(averaging_window(last(metadata)))) - comparable_datetime(window_start)
     return Dates.value(Dates.Millisecond(span)) / 1000
 end
 
 """
     uncovered_time_gaps(metadata)
 
-The `(head, tail)` durations in seconds that the [`sample_window`](@ref)s of `metadata` span
+The `(head, tail)` durations in seconds that the [`averaging_window`](@ref)s of `metadata` span
 but its nodes do not: from the start of the first window to the first [`window_center`](@ref),
 and from the last center to the end of the last window. A `FieldTimeSeries` extrapolates over
-both. Zero for an instantaneous product, whose nodes span exactly its samples.
+both. Zero for a product of values at an instant, whose nodes span exactly its samples.
 """
 function uncovered_time_gaps(metadata)
     first_metadatum = first(metadata)
     last_metadatum = last(metadata)
 
-    head = window_center(first_metadatum) - comparable_datetime(first(sample_window(first_metadatum)))
-    tail = comparable_datetime(last(sample_window(last_metadatum))) - window_center(last_metadatum)
+    head = window_center(first_metadatum) - comparable_datetime(first(averaging_window(first_metadatum)))
+    tail = comparable_datetime(last(averaging_window(last_metadatum))) - window_center(last_metadatum)
 
     return Dates.value(Dates.Millisecond(head)) / 1000, Dates.value(Dates.Millisecond(tail)) / 1000
 end

--- a/src/DataWrangling/metadata_field_time_series.jl
+++ b/src/DataWrangling/metadata_field_time_series.jl
@@ -51,7 +51,7 @@ function Oceananigans.OutputReaders.FieldTimeSeries(metadata::Metadata, grid::Ab
     # A window-averaged series repeats over the span its windows tile, not over the span of its
     # nodes, which sit half a window inside it at each end. Oceananigans infers the latter.
     if time_indexing isa Cyclical{Nothing}
-        period = sample_window_span(metadata)
+        period = window_span(metadata)
         isnothing(period) || (time_indexing = Cyclical(convert(eltype(grid), period)))
     end
 

--- a/src/DataWrangling/restoring.jl
+++ b/src/DataWrangling/restoring.jl
@@ -1,4 +1,3 @@
-using Dates: Second
 using JLD2
 using Oceananigans: location, instantiated_location
 using Oceananigans.Architectures: AbstractArchitecture, on_architecture, architecture

--- a/test/runtests_setup.jl
+++ b/test/runtests_setup.jl
@@ -183,7 +183,9 @@ function test_dataset_restoring(arch, dataset, dates, inpainting;
         fill!(var_restoring.field_time_series[2], 1.0)
 
         field = NamedTuple{fldnames}(ntuple(i->CenterField(grid), length(fldnames)))
-        clock  = Clock(; time = 0)
+
+        # A window-averaged product has no node at its first date: the first sits half a window later.
+        clock = Clock(; time = first(var_restoring.field_time_series.times))
 
         @allowscalar begin
             @test var_restoring(1, 1,   10, grid, clock, field) == var_restoring.rate

--- a/test/test_metadata.jl
+++ b/test/test_metadata.jl
@@ -366,6 +366,17 @@ end
     @test time_window_offset(aviso) == 0
 end
 
+@testset "ECCO2 daily windows" begin
+    # The cube92 daily files hold means over the day they are named for, so their nodes sit at midday
+    # while the monthly means keep their calendar-month window.
+    daily = Metadatum(:temperature; dataset = ECCO2Daily(), date = DateTime(1993, 1, 1))
+    @test sample_window(daily) == (DateTime(1993, 1, 1), DateTime(1993, 1, 2))
+    @test time_window_offset(daily) == 12 * 3600
+
+    monthly = Metadatum(:temperature; dataset = ECCO2Monthly(), date = DateTime(1993, 1, 1))
+    @test window_center(monthly) == DateTime(1993, 1, 16, 12)
+end
+
 @testset "Every dataset with a time axis declares a sample window" begin
     # `sample_window` has no fallback, so a new adapter that forgets it raises a `MethodError`
     # instead of silently placing window averages at their stamps.

--- a/test/test_metadata.jl
+++ b/test/test_metadata.jl
@@ -377,6 +377,13 @@ end
     @test window_center(monthly) == DateTime(1993, 1, 16, 12)
 end
 
+@testset "GloFAS daily windows" begin
+    # The discharge is a mean over the day the dates label, so its node sits at midday.
+    md = Metadatum(:river_discharge; dataset = GloFASReanalysis(), date = DateTime(2010, 7, 10))
+    @test sample_window(md) == (DateTime(2010, 7, 10), DateTime(2010, 7, 11))
+    @test time_window_offset(md) == 12 * 3600
+end
+
 @testset "Every dataset with a time axis declares a sample window" begin
     # `sample_window` has no fallback, so a new adapter that forgets it raises a `MethodError`
     # instead of silently placing window averages at their stamps.

--- a/test/test_metadata.jl
+++ b/test/test_metadata.jl
@@ -354,6 +354,18 @@ end
     end
 end
 
+@testset "Copernicus Marine daily windows" begin
+    # Copernicus Marine stamps the start of an averaging period, so a `P1D-m` daily mean runs
+    # forwards a day from its stamp and its node sits at midday.
+    glorys = Metadatum(:temperature; dataset = GLORYSDaily(), date = DateTime(2010, 7, 10))
+    @test sample_window(glorys) == (DateTime(2010, 7, 10), DateTime(2010, 7, 11))
+    @test time_window_offset(glorys) == 12 * 3600
+
+    # The daily L4 altimetry maps are analyses valid at the stamp, not means over the day.
+    aviso = Metadatum(:sea_level_anomaly; dataset = AVISODaily(), date = DateTime(2010, 7, 10))
+    @test time_window_offset(aviso) == 0
+end
+
 @testset "Every dataset with a time axis declares a sample window" begin
     # `sample_window` has no fallback, so a new adapter that forgets it raises a `MethodError`
     # instead of silently placing window averages at their stamps.

--- a/test/test_metadata.jl
+++ b/test/test_metadata.jl
@@ -4,8 +4,8 @@ using NumericalEarth.DataWrangling: Column, Linear, Nearest,
                                     BoundingBox, dataset_location,
                                     restrict_location, native_grid
 using NumericalEarth.DataWrangling: restrict, restrict_longitude, download_cache
-using NumericalEarth.DataWrangling: native_times, sample_window, window_center, time_window_offset,
-                                    sample_window_span, uncovered_time_gaps, validate_time_coverage
+using NumericalEarth.DataWrangling: native_times, averaging_window, window_center,
+                                    window_span, uncovered_time_gaps, validate_time_coverage
 using NumericalEarth.DataWrangling.ERA5: ERA5HourlySingleLevel, ERA5MonthlySingleLevel,
                                          ERA5MonthlyPressureLevels, ERA5MonthlyLand
 
@@ -239,7 +239,7 @@ end
     end
 end
 
-@testset "Monthly-mean sample windows" begin
+@testset "Monthly-mean averaging windows" begin
     # The dates these files carry in their own `time` variable: the center of each month,
     # which is a half day later in a 31-day month than in a 30-day one.
     en4_centers = (1 => DateTime(2010, 1, 16, 12), 2 => DateTime(2010, 2, 15),
@@ -248,13 +248,13 @@ end
     for (month, center) in en4_centers
         first_of_month = DateTime(2010, month, 1)
         metadatum = Metadatum(:temperature; dataset = EN4Monthly(), date = first_of_month)
-        @test sample_window(metadatum) == (first_of_month, first_of_month + Month(1))
-        @test time_window_offset(metadatum) == Dates.value(Second(center - first_of_month))
+        @test averaging_window(metadatum) == (first_of_month, first_of_month + Month(1))
+        @test window_center(metadatum) == center
     end
 
     ecco = Metadatum(:v_velocity; dataset = ECCO4Monthly(), date = DateTime(1993, 1, 1))
-    @test sample_window(ecco) == (DateTime(1993, 1, 1), DateTime(1993, 2, 1))
-    @test time_window_offset(ecco) == Dates.value(Second(DateTime(1993, 1, 16, 12) - ecco.dates))
+    @test averaging_window(ecco) == (DateTime(1993, 1, 1), DateTime(1993, 2, 1))
+    @test window_center(ecco) == DateTime(1993, 1, 16, 12)
 
     # A twelve-month axis then reproduces the time coordinates the files themselves carry,
     # in days from the first of January.
@@ -263,10 +263,10 @@ end
     @test native_times(metadata) ./ 86400 == [15.5, 45.0, 74.5, 105.0, 135.5, 166.0,
                                               196.5, 227.5, 258.0, 288.5, 319.0, 349.5]
 
-    # An instantaneous product has no window and is left where its stamp puts it.
+    # A product of values at an instant has no window and is left where its stamp puts it.
     hourly = Metadatum(:temperature; dataset = ERA5HourlySingleLevel(), date = DateTime(2020, 4, 1))
-    @test sample_window(hourly) == (DateTime(2020, 4, 1), DateTime(2020, 4, 1))
-    @test time_window_offset(hourly) == 0
+    @test averaging_window(hourly) == (DateTime(2020, 4, 1), DateTime(2020, 4, 1))
+    @test window_center(hourly) == DateTime(2020, 4, 1)
     @test native_times(Metadata(:temperature; dataset = ERA5HourlySingleLevel(),
                                 dates = [DateTime(2020, 4, 1, h) for h in 0:2])) == [0, 3600, 7200]
 
@@ -286,15 +286,15 @@ end
 
     for (dataset, name) in monthly_datasets, stamp in (DateTime(2010, 7, 1), DateTime(2010, 7, 1, 12))
         metadatum = Metadatum(name; dataset, date = stamp)
-        @test sample_window(metadatum) == (DateTime(2010, 7, 1), DateTime(2010, 8, 1))
+        @test averaging_window(metadatum) == (DateTime(2010, 7, 1), DateTime(2010, 8, 1))
         @test window_center(metadatum) == DateTime(2010, 7, 16, 12)
     end
 
     # ERA5-Land monthly nodes sit mid-month, in phase with the single-level product.
     land = Metadatum(:temperature; dataset = ERA5MonthlyLand(), date = DateTime(2010, 7, 1))
     single_level = Metadatum(:temperature; dataset = ERA5MonthlySingleLevel(), date = DateTime(2010, 7, 1))
-    @test time_window_offset(land) == 15.5 * 86400
-    @test time_window_offset(land) == time_window_offset(single_level)
+    @test window_center(land) == DateTime(2010, 7, 16, 12)
+    @test window_center(land) == window_center(single_level)
 end
 
 @testset "ERA5 accumulation windows" begin
@@ -306,13 +306,13 @@ end
                  :mean_surface_sensible_heat_flux, :mean_surface_latent_heat_flux)
 
         metadatum = Metadatum(name; dataset = ERA5HourlySingleLevel(), date = DateTime(2020, 4, 1, 13))
-        @test sample_window(metadatum) == (DateTime(2020, 4, 1, 12), DateTime(2020, 4, 1, 13))
-        @test time_window_offset(metadatum) == -1800
+        @test averaging_window(metadatum) == (DateTime(2020, 4, 1, 12), DateTime(2020, 4, 1, 13))
+        @test window_center(metadatum) == DateTime(2020, 4, 1, 12, 30)
     end
 
     for name in (:temperature, :surface_pressure, :eastward_velocity, :significant_wave_height)
         metadatum = Metadatum(name; dataset = ERA5HourlySingleLevel(), date = DateTime(2020, 4, 1, 13))
-        @test time_window_offset(metadatum) == 0
+        @test window_center(metadatum) == DateTime(2020, 4, 1, 13)
     end
 
     radiation = Metadata(:downwelling_shortwave_radiation; dataset = ERA5HourlySingleLevel(),
@@ -320,7 +320,7 @@ end
     @test native_times(radiation) == [-1800, 1800, 5400]
 end
 
-@testset "JRA55 sample windows" begin
+@testset "JRA55 averaging windows" begin
     # The repeat-year files label each mean with the start of its interval: the three-hourly
     # fluxes, radiation, and precipitation run forwards three hours from the stamp, the daily
     # river and iceberg fluxes forwards a day.
@@ -328,89 +328,59 @@ end
                  :downwelling_longwave_radiation, :downwelling_shortwave_radiation)
 
         metadatum = Metadatum(name; dataset = RepeatYearJRA55(), date = DateTime(1990, 4, 1, 12))
-        @test sample_window(metadatum) == (DateTime(1990, 4, 1, 12), DateTime(1990, 4, 1, 15))
-        @test time_window_offset(metadatum) == 1.5 * 3600
+        @test averaging_window(metadatum) == (DateTime(1990, 4, 1, 12), DateTime(1990, 4, 1, 15))
+        @test window_center(metadatum) == DateTime(1990, 4, 1, 13, 30)
     end
 
     for name in (:river_freshwater_flux, :iceberg_freshwater_flux)
         metadatum = Metadatum(name; dataset = RepeatYearJRA55(), date = DateTime(1990, 4, 1))
-        @test sample_window(metadatum) == (DateTime(1990, 4, 1), DateTime(1990, 4, 2))
-        @test time_window_offset(metadatum) == 12 * 3600
+        @test averaging_window(metadatum) == (DateTime(1990, 4, 1), DateTime(1990, 4, 2))
+        @test window_center(metadatum) == DateTime(1990, 4, 1, 12)
     end
 
-    # The state variables are instantaneous in both products.
+    # A repeat year of three-hourly means tiles the year exactly, rather than falling short by
+    # the last interval as the node spacing alone suggests.
+    radiation = Metadata(:downwelling_shortwave_radiation; dataset = RepeatYearJRA55())
+    @test window_span(radiation) == Dates.value(Second(DateTime(1991, 1, 1) - DateTime(1990, 1, 1)))
+
+    # The state variables in both products, and every multi-year mean, sit at their stamps: the
+    # multi-year files already label each mean with the center of its interval.
     for dataset in (RepeatYearJRA55(), MultiYearJRA55()),
         name in (:temperature, :specific_humidity, :eastward_velocity, :sea_level_pressure)
 
         metadatum = Metadatum(name; dataset, date = DateTime(1990, 4, 1, 12))
-        @test time_window_offset(metadatum) == 0
+        @test window_center(metadatum) == DateTime(1990, 4, 1, 12)
     end
 
-    # The multi-year files already stamp their means at the window center, so every variable
-    # sits at its node as labelled.
     for name in (:rain_freshwater_flux, :downwelling_shortwave_radiation, :river_freshwater_flux)
         metadatum = Metadatum(name; dataset = MultiYearJRA55(), date = DateTime(1990, 4, 1, 1, 30))
-        @test time_window_offset(metadatum) == 0
+        @test window_center(metadatum) == DateTime(1990, 4, 1, 1, 30)
     end
 end
 
-@testset "Copernicus Marine daily windows" begin
+@testset "Daily averaging windows" begin
     # Copernicus Marine stamps the start of an averaging period, so a `P1D-m` daily mean runs
     # forwards a day from its stamp and its node sits at midday.
     glorys = Metadatum(:temperature; dataset = GLORYSDaily(), date = DateTime(2010, 7, 10))
-    @test sample_window(glorys) == (DateTime(2010, 7, 10), DateTime(2010, 7, 11))
-    @test time_window_offset(glorys) == 12 * 3600
+    @test averaging_window(glorys) == (DateTime(2010, 7, 10), DateTime(2010, 7, 11))
+    @test window_center(glorys) == DateTime(2010, 7, 10, 12)
+
+    # The cube92 daily files hold means over the day they are named for, while the ECCO2 monthly
+    # means keep their calendar-month window.
+    ecco = Metadatum(:temperature; dataset = ECCO2Daily(), date = DateTime(1993, 1, 1))
+    @test averaging_window(ecco) == (DateTime(1993, 1, 1), DateTime(1993, 1, 2))
+    @test window_center(ecco) == DateTime(1993, 1, 1, 12)
+    @test window_center(Metadatum(:temperature; dataset = ECCO2Monthly(),
+                                  date = DateTime(1993, 1, 1))) == DateTime(1993, 1, 16, 12)
+
+    # The GloFAS discharge is a mean over the day the dates label.
+    glofas = Metadatum(:river_discharge; dataset = GloFASReanalysis(), date = DateTime(2010, 7, 10))
+    @test averaging_window(glofas) == (DateTime(2010, 7, 10), DateTime(2010, 7, 11))
+    @test window_center(glofas) == DateTime(2010, 7, 10, 12)
 
     # The daily L4 altimetry maps are analyses valid at the stamp, not means over the day.
     aviso = Metadatum(:sea_level_anomaly; dataset = AVISODaily(), date = DateTime(2010, 7, 10))
-    @test time_window_offset(aviso) == 0
-end
-
-@testset "ECCO2 daily windows" begin
-    # The cube92 daily files hold means over the day they are named for, so their nodes sit at midday
-    # while the monthly means keep their calendar-month window.
-    daily = Metadatum(:temperature; dataset = ECCO2Daily(), date = DateTime(1993, 1, 1))
-    @test sample_window(daily) == (DateTime(1993, 1, 1), DateTime(1993, 1, 2))
-    @test time_window_offset(daily) == 12 * 3600
-
-    monthly = Metadatum(:temperature; dataset = ECCO2Monthly(), date = DateTime(1993, 1, 1))
-    @test window_center(monthly) == DateTime(1993, 1, 16, 12)
-end
-
-@testset "GloFAS daily windows" begin
-    # The discharge is a mean over the day the dates label, so its node sits at midday.
-    md = Metadatum(:river_discharge; dataset = GloFASReanalysis(), date = DateTime(2010, 7, 10))
-    @test sample_window(md) == (DateTime(2010, 7, 10), DateTime(2010, 7, 11))
-    @test time_window_offset(md) == 12 * 3600
-end
-
-@testset "Every dataset with a time axis declares a sample window" begin
-    # `sample_window` has no fallback, so a new adapter that forgets it raises a `MethodError`
-    # instead of silently placing window averages at their stamps.
-    @test !hasmethod(sample_window, Tuple{Any})
-
-    datasets = Dict(AVISODaily() => :sea_level_anomaly,
-                    AVISOMonthly() => :sea_level_anomaly,
-                    ECCO2Daily() => :temperature,
-                    ECCO2Monthly() => :temperature,
-                    ECCO4Monthly() => :temperature,
-                    EN4Monthly() => :temperature,
-                    ERA5HourlySingleLevel() => :temperature,
-                    ERA5MonthlySingleLevel() => :temperature,
-                    ERA5HourlyPressureLevels() => :temperature,
-                    ERA5MonthlyPressureLevels() => :temperature,
-                    ERA5HourlyLand() => :temperature,
-                    ERA5MonthlyLand() => :temperature,
-                    GLORYSDaily() => :temperature,
-                    GLORYSMonthly() => :temperature,
-                    RepeatYearJRA55() => :temperature,
-                    MultiYearJRA55() => :temperature,
-                    WOAMonthly() => :temperature)
-
-    for (dataset, name) in datasets
-        metadatum = Metadatum(name; dataset, date = DateTime(2010, 7, 1))
-        @test hasmethod(sample_window, Tuple{typeof(metadatum)})
-    end
+    @test window_center(aviso) == DateTime(2010, 7, 10)
 end
 
 @testset "Time coverage of window-averaged series" begin
@@ -418,14 +388,14 @@ end
                        dates = [DateTime(2010, m, 1) for m in 1:12])
 
     # Twelve monthly windows tile a year exactly, and the nodes fall half a month inside it.
-    @test sample_window_span(monthly) == Dates.value(Second(DateTime(2011, 1, 1) - DateTime(2010, 1, 1)))
+    @test window_span(monthly) == Dates.value(Second(DateTime(2011, 1, 1) - DateTime(2010, 1, 1)))
     @test uncovered_time_gaps(monthly) == (15.5 * 86400, 15.5 * 86400)
 
     # An instantaneous product covers exactly its own nodes, and leaves the cyclical period
     # to be inferred from their spacing.
     hourly = Metadata(:temperature; dataset = ERA5HourlySingleLevel(),
                       dates = [DateTime(2020, 4, 1, h) for h in 0:2])
-    @test isnothing(sample_window_span(hourly))
+    @test isnothing(window_span(hourly))
     @test uncovered_time_gaps(hourly) == (0, 0)
 
     # `Cyclical` fills the gaps by wrapping and says so; `Linear` extrapolates and refuses;
@@ -445,7 +415,7 @@ end
 
     # A single window still gives a cyclical period, where the node spacing Oceananigans
     # would infer does not exist.
-    @test sample_window_span(single) == Dates.value(Second(DateTime(2010, 8, 1) - DateTime(2010, 7, 1)))
+    @test window_span(single) == Dates.value(Second(DateTime(2010, 8, 1) - DateTime(2010, 7, 1)))
 end
 
 @testset "nan_convert_missing" begin

--- a/test/test_metadata.jl
+++ b/test/test_metadata.jl
@@ -320,6 +320,69 @@ end
     @test native_times(radiation) == [-1800, 1800, 5400]
 end
 
+@testset "JRA55 sample windows" begin
+    # The repeat-year files label each mean with the start of its interval: the three-hourly
+    # fluxes, radiation, and precipitation run forwards three hours from the stamp, the daily
+    # river and iceberg fluxes forwards a day.
+    for name in (:rain_freshwater_flux, :snow_freshwater_flux,
+                 :downwelling_longwave_radiation, :downwelling_shortwave_radiation)
+
+        metadatum = Metadatum(name; dataset = RepeatYearJRA55(), date = DateTime(1990, 4, 1, 12))
+        @test sample_window(metadatum) == (DateTime(1990, 4, 1, 12), DateTime(1990, 4, 1, 15))
+        @test time_window_offset(metadatum) == 1.5 * 3600
+    end
+
+    for name in (:river_freshwater_flux, :iceberg_freshwater_flux)
+        metadatum = Metadatum(name; dataset = RepeatYearJRA55(), date = DateTime(1990, 4, 1))
+        @test sample_window(metadatum) == (DateTime(1990, 4, 1), DateTime(1990, 4, 2))
+        @test time_window_offset(metadatum) == 12 * 3600
+    end
+
+    # The state variables are instantaneous in both products.
+    for dataset in (RepeatYearJRA55(), MultiYearJRA55()),
+        name in (:temperature, :specific_humidity, :eastward_velocity, :sea_level_pressure)
+
+        metadatum = Metadatum(name; dataset, date = DateTime(1990, 4, 1, 12))
+        @test time_window_offset(metadatum) == 0
+    end
+
+    # The multi-year files already stamp their means at the window center, so every variable
+    # sits at its node as labelled.
+    for name in (:rain_freshwater_flux, :downwelling_shortwave_radiation, :river_freshwater_flux)
+        metadatum = Metadatum(name; dataset = MultiYearJRA55(), date = DateTime(1990, 4, 1, 1, 30))
+        @test time_window_offset(metadatum) == 0
+    end
+end
+
+@testset "Every dataset with a time axis declares a sample window" begin
+    # `sample_window` has no fallback, so a new adapter that forgets it raises a `MethodError`
+    # instead of silently placing window averages at their stamps.
+    @test !hasmethod(sample_window, Tuple{Any})
+
+    datasets = Dict(AVISODaily() => :sea_level_anomaly,
+                    AVISOMonthly() => :sea_level_anomaly,
+                    ECCO2Daily() => :temperature,
+                    ECCO2Monthly() => :temperature,
+                    ECCO4Monthly() => :temperature,
+                    EN4Monthly() => :temperature,
+                    ERA5HourlySingleLevel() => :temperature,
+                    ERA5MonthlySingleLevel() => :temperature,
+                    ERA5HourlyPressureLevels() => :temperature,
+                    ERA5MonthlyPressureLevels() => :temperature,
+                    ERA5HourlyLand() => :temperature,
+                    ERA5MonthlyLand() => :temperature,
+                    GLORYSDaily() => :temperature,
+                    GLORYSMonthly() => :temperature,
+                    RepeatYearJRA55() => :temperature,
+                    MultiYearJRA55() => :temperature,
+                    WOAMonthly() => :temperature)
+
+    for (dataset, name) in datasets
+        metadatum = Metadatum(name; dataset, date = DateTime(2010, 7, 1))
+        @test hasmethod(sample_window, Tuple{typeof(metadatum)})
+    end
+end
+
 @testset "Time coverage of window-averaged series" begin
     monthly = Metadata(:temperature; dataset = EN4Monthly(),
                        dates = [DateTime(2010, m, 1) for m in 1:12])


### PR DESCRIPTION
Fixes #519 (the JRA55 half; #520 covered the ERA5 half).

Five products hold time averages but declared no window, so their samples sat at their stamps:

- `RepeatYearJRA55` labels its fluxes, radiation and precipitation with the start of the interval they average: three hours for the sub-daily means, a day for the river and iceberg fluxes. Its shortwave peaked 1.5 hours before solar noon, and a full repeat year wrapped at 364.875 days rather than 365. `MultiYearJRA55` stamps at the window center and is unchanged.
- `GLORYSDaily`, `ECCO2Daily` and `GloFASReanalysis` get a one-day forward window; each holds a mean over the day its dates label, so its node belongs at midday. Copernicus Marine stamps the start of an averaging period, GloFAS the end; the ECCO2 daily files disagree with the monthly ones about their own stamps, so the day each covers was settled against the same series served by APDRC, which matches bit for bit.
- `CopernicusAlbedoClimatology` gets `calendar_month_window`.

From the review: `sample_window` is now `averaging_window` and `sample_window_span` is `window_span`. `instantaneous_window`, `leading_window` and `trailing_window` are gone, since a product that averages can write its interval as `(md.dates, md.dates + Hour(3))`, and `time_window_offset` folds into `native_times`. A product of values at an instant keeps the default and declares nothing.

```julia
using NumericalEarth, Dates
using NumericalEarth.DataWrangling: window_center

md = Metadatum(:downwelling_shortwave_radiation; dataset=RepeatYearJRA55(), date=DateTime(1990, 4, 1, 12))
window_center(md)  # 1990-04-01T13:30, was 12:00
```

Windowed repeat-year series now trip the existing "interpolates only between…" coverage warning on the `Cyclical` path, as the ERA5 monthly products already do.
