### PR TITLE
Enable caching for `Field(metadatum, grid)` and rework `regrid_bathymetry` caching into the same framework

### DIFF
--- a/src/Bathymetry/Bathymetry.jl
+++ b/src/Bathymetry/Bathymetry.jl
@@ -4,7 +4,6 @@ export regrid_bathymetry, regrid_topography, ORCAGrid
 
 using Downloads: Downloads, download
 using ImageMorphology: ImageMorphology
-using JLD2: JLD2, jldopen
 using KernelAbstractions: @kernel, @index
 using Oceananigans: Oceananigans
 using Oceananigans.Architectures: architecture, CPU, on_architecture
@@ -15,13 +14,14 @@ using Oceananigans.Fields: Field, interior, interpolate!
 using Oceananigans.Grids: x_domain, y_domain, topology, Face, Center,
                           Flat, Periodic, Bounded,
                           RectilinearGrid, LatitudeLongitudeGrid, OrthogonalSphericalShellGrid
-using Oceananigans.Utils: launch!, worksize
+using Oceananigans.Utils: launch!
 using OffsetArrays: OffsetArrays, OffsetArray
 using NCDatasets: NCDatasets, Dataset
 using Printf: Printf
 
-using ..DataWrangling: DataWrangling, Metadatum, native_grid, metadata_path,
-                       dataset_variable_name, validate_dataset_coverage
+using ..DataWrangling: Metadatum, native_grid, metadata_path,
+                       dataset_variable_name, validate_dataset_coverage,
+                       FieldRegridding, load_field_cache, save_field_cache
 using ..DataWrangling.ETOPO: ETOPO2022
 
 include("regrid_bathymetry.jl")

--- a/src/Bathymetry/regrid_bathymetry.jl
+++ b/src/Bathymetry/regrid_bathymetry.jl
@@ -1,129 +1,15 @@
 
-# Scratch space for cached regridded bathymetry files
-bathymetry_cache_dir::String = ""
-function __init__()
-    global bathymetry_cache_dir = DataWrangling.download_cache("bathymetry_cache")
-end
-
-#####
-##### BathymetryRegridding configuration
-#####
-
-struct BathymetryRegridding
-    grid_type            :: String
-    grid_size            :: Tuple{Int, Int}
-    longitude            :: Tuple{Float64, Float64}
-    latitude             :: Tuple{Float64, Float64}
-    topology             :: Tuple{Symbol, Symbol}
-    float_type           :: Symbol
-    height_above_water   :: Union{Nothing, Float64}
-    minimum_depth        :: Float64
-    interpolation_passes :: Int
-    major_basins         :: Float64
-    dataset              :: String
-end
-
-function BathymetryRegridding(grid, metadata;
-                              height_above_water = nothing,
-                              minimum_depth = 0,
-                              interpolation_passes = 1,
-                              major_basins = 1)
-
-    Nx, Ny, _ = worksize(grid)
-    TX, TY, _ = topology(grid)
-    lon = x_domain(grid)
-    lat = y_domain(grid)
-    FT = eltype(grid)
-    grid_type_name = string(typeof(grid).name.wrapper)
-    dataset_name = string(typeof(metadata.dataset))
-    haw = isnothing(height_above_water) ? nothing : Float64(height_above_water)
-
-    return BathymetryRegridding(grid_type_name,
-                                (Nx, Ny),
-                                (Float64(lon[1]), Float64(lon[2])),
-                                (Float64(lat[1]), Float64(lat[2])),
-                                (Symbol(TX), Symbol(TY)),
-                                Symbol(FT),
-                                haw,
-                                Float64(minimum_depth),
-                                Int(interpolation_passes),
-                                Float64(major_basins),
-                                dataset_name)
-end
-
-function Base.:(==)(a::BathymetryRegridding, b::BathymetryRegridding)
-    return a.grid_type            == b.grid_type &&
-           a.grid_size            == b.grid_size &&
-           a.longitude            == b.longitude &&
-           a.latitude             == b.latitude &&
-           a.topology             == b.topology &&
-           a.float_type           == b.float_type &&
-           a.height_above_water   == b.height_above_water &&
-           a.minimum_depth        == b.minimum_depth &&
-           a.interpolation_passes == b.interpolation_passes &&
-           a.major_basins         == b.major_basins &&
-           a.dataset              == b.dataset
-end
-
-function Base.hash(c::BathymetryRegridding, h::UInt)
-    h = hash(c.grid_type, h)
-    h = hash(c.grid_size, h)
-    h = hash(c.longitude, h)
-    h = hash(c.latitude, h)
-    h = hash(c.topology, h)
-    h = hash(c.float_type, h)
-    h = hash(c.height_above_water, h)
-    h = hash(c.minimum_depth, h)
-    h = hash(c.interpolation_passes, h)
-    h = hash(c.major_basins, h)
-    h = hash(c.dataset, h)
-    return h
-end
-
-#####
-##### Cache file management
-#####
-
-function cache_filename(config::BathymetryRegridding)
-    Nx, Ny = config.grid_size
-    lon0, lon1 = config.longitude
-    lat0, lat1 = config.latitude
-    h = string(hash(config) % UInt32, base=16, pad=8)
-    return "bathymetry_$(Nx)x$(Ny)_$(lon0)_$(lon1)_$(lat0)_$(lat1)_$(h).jld2"
-end
-
-function load_bathymetry_cache(config::BathymetryRegridding)
-    filepath = joinpath(bathymetry_cache_dir, cache_filename(config))
-    isfile(filepath) || return nothing
-
-    try
-        jldopen(filepath, "r") do file
-            stored_config = file["config"]
-            if stored_config == config
-                @info "Loading cached bathymetry from $filepath"
-                return file["bottom_height"]
-            else
-                return nothing
-            end
-        end
-    catch err
-        @warn "Failed to load bathymetry cache from $filepath: $err"
-        return nothing
-    end
-end
-
-function save_bathymetry_cache(config::BathymetryRegridding, bottom_height::AbstractArray)
-    filepath = joinpath(bathymetry_cache_dir, cache_filename(config))
-    try
-        jldopen(filepath, "w") do file
-            file["config"] = config
-            file["bottom_height"] = bottom_height
-        end
-        @info "Saved bathymetry cache to $filepath"
-    catch err
-        @warn "Failed to save bathymetry cache to $filepath: $err"
-    end
-    return nothing
+# The bathymetry cache shares DataWrangling's keyed field cache, carrying the
+# processing parameters in the key's keyword slot. Parameters are normalized so
+# that, e.g., `minimum_depth = 0` and `minimum_depth = 0.0` key identically.
+function bathymetry_regridding_key(grid, metadata;
+                                   height_above_water, minimum_depth,
+                                   interpolation_passes, major_basins)
+    parameters = (; height_above_water = isnothing(height_above_water) ? nothing : Float64(height_above_water),
+                    minimum_depth = Float64(minimum_depth),
+                    interpolation_passes = Int(interpolation_passes),
+                    major_basins = Float64(major_basins))
+    return FieldRegridding(grid, metadata, parameters)
 end
 
 # methods specific to bathymetric datasets live within dataset modules
@@ -177,7 +63,8 @@ Keyword Arguments
                   If `Inf` then no basins are removed. Default: 1.
 
 - `cache`: If `true` (default), caches the regridded bathymetry to disk and reuses it on subsequent
-           calls with the same grid and parameters. Set to `false` to force recomputation.
+           calls with the same grid, parameters, and dataset file; a re-download of the dataset
+           invalidates the entry. Set to `false` to force recomputation.
 """
 function regrid_bathymetry(target_grid, metadata;
                            height_above_water = nothing,
@@ -188,13 +75,11 @@ function regrid_bathymetry(target_grid, metadata;
 
     validate_dataset_coverage(target_grid, metadata)
 
-    config = BathymetryRegridding(target_grid, metadata;
-                                  height_above_water, minimum_depth,
-                                  interpolation_passes, major_basins)
-
-    # Try loading from cache
     if cache
-        cached_data = load_bathymetry_cache(config)
+        config = bathymetry_regridding_key(target_grid, metadata;
+                                           height_above_water, minimum_depth,
+                                           interpolation_passes, major_basins)
+        cached_data = load_field_cache(config)
         if !isnothing(cached_data)
             target_z = Field{Center, Center, Nothing}(target_grid)
             set!(target_z, cached_data)
@@ -211,10 +96,12 @@ function regrid_bathymetry(target_grid, metadata;
                                   interpolation_passes,
                                   major_basins)
 
-    # Save to cache
     if cache
-        bottom_height = Array(interior(target_z, :, :, 1))
-        save_bathymetry_cache(config, bottom_height)
+        # rebuild the key: `download` may have just fetched the dataset file it stamps
+        config = bathymetry_regridding_key(target_grid, metadata;
+                                           height_above_water, minimum_depth,
+                                           interpolation_passes, major_basins)
+        save_field_cache(config, Array(interior(target_z, :, :, 1)))
     end
 
     return target_z
@@ -325,16 +212,16 @@ function regrid_bathymetry(target_grid::DistributedGrid, metadata;
     arch = architecture(target_grid)
     Nx, Ny, _ = size(global_grid)
 
-    config = BathymetryRegridding(global_grid, metadata;
-                                  height_above_water, minimum_depth,
-                                  interpolation_passes, major_basins)
-
     # download uses @root internally; all ranks must call it
     download(metadata)
 
+    config = cache ? bathymetry_regridding_key(global_grid, metadata;
+                                               height_above_water, minimum_depth,
+                                               interpolation_passes, major_basins) : nothing
+
     # Only rank 0 performs cache lookup and computation to avoid OOM
     bottom_height = if arch.local_rank == 0
-        cached_data = cache ? load_bathymetry_cache(config) : nothing
+        cached_data = cache ? load_field_cache(config) : nothing
         if !isnothing(cached_data)
             cached_data
         else
@@ -343,7 +230,7 @@ function regrid_bathymetry(target_grid::DistributedGrid, metadata;
                                               interpolation_passes, major_basins)
             bh = Array(bottom_field.data[1:Nx, 1:Ny, 1])
             if cache
-                save_bathymetry_cache(config, bh)
+                save_field_cache(config, bh)
             end
             bh
         end

--- a/src/Bathymetry/regrid_bathymetry.jl
+++ b/src/Bathymetry/regrid_bathymetry.jl
@@ -20,7 +20,8 @@ end
                       minimum_depth = 0,
                       major_basins = 1,
                       interpolation_passes = 1,
-                      cache = true)
+                      cache = true,
+                      overwrite_cache = false)
 
 Return bathymetry that corresponds to  `metadata` onto `target_grid`.
 
@@ -64,18 +65,23 @@ Keyword Arguments
 
 - `cache`: If `true` (default), caches the regridded bathymetry to disk and reuses it on subsequent
            calls with the same grid, parameters, and dataset file; a re-download of the dataset
-           invalidates the entry. Set to `false` to force recomputation.
+           invalidates the entry. If `false`, the cache is disabled entirely: nothing is read
+           or written.
+
+- `overwrite_cache`: If `true`, skip the cache lookup and overwrite the entry with a freshly
+                     regridded result. Default: `false`.
 """
 function regrid_bathymetry(target_grid, metadata;
                            height_above_water = nothing,
                            minimum_depth = 0,
                            interpolation_passes = 1,
                            major_basins = 1,
-                           cache = true)
+                           cache = true,
+                           overwrite_cache = false)
 
     validate_dataset_coverage(target_grid, metadata)
 
-    if cache
+    if cache && !overwrite_cache
         config = bathymetry_regridding_key(target_grid, metadata;
                                            height_above_water, minimum_depth,
                                            interpolation_passes, major_basins)
@@ -205,7 +211,8 @@ function regrid_bathymetry(target_grid::DistributedGrid, metadata;
                            minimum_depth = 0,
                            interpolation_passes = 1,
                            major_basins = 1,
-                           cache = true)
+                           cache = true,
+                           overwrite_cache = false)
 
     global_grid = reconstruct_global_grid(target_grid)
     global_grid = on_architecture(CPU(), global_grid)
@@ -221,7 +228,7 @@ function regrid_bathymetry(target_grid::DistributedGrid, metadata;
 
     # Only rank 0 performs cache lookup and computation to avoid OOM
     bottom_height = if arch.local_rank == 0
-        cached_data = cache ? load_field_cache(config) : nothing
+        cached_data = cache && !overwrite_cache ? load_field_cache(config) : nothing
         if !isnothing(cached_data)
             cached_data
         else

--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -28,7 +28,8 @@ using Oceananigans.Architectures: AbstractArchitecture, CPU, architecture,
 using Oceananigans.BoundaryConditions: fill_halo_regions!, FieldBoundaryConditions
 using Oceananigans.DistributedComputations: DistributedComputations, @root
 using Oceananigans.Grids: AbstractGrid, Center, Face, Flat, Bounded,
-                          LatitudeLongitudeGrid, RectilinearGrid, λnodes, φnodes
+                          LatitudeLongitudeGrid, RectilinearGrid, λnodes, φnodes,
+                          topology, x_domain, y_domain, z_domain
 using Oceananigans.Fields: Fields, Field, interpolate, interpolate!, interior, set!
 using Oceananigans.Grids: node
 using Oceananigans.OutputReaders: OnDisk, AbstractInMemoryBackend, Cyclical,
@@ -265,6 +266,7 @@ Base.size(dataset::AbstractStaticBathymetry, variable) = size(dataset)
 # Fundamentals
 include("metadata.jl")
 include("set_region_data.jl")
+include("field_cache.jl")
 include("metadata_field.jl")
 include("dataset_backend.jl")
 include("metadata_field_time_series.jl")

--- a/src/DataWrangling/field_cache.jl
+++ b/src/DataWrangling/field_cache.jl
@@ -1,9 +1,9 @@
 #####
-##### Cache for `Field(metadatum, grid)` reads — the dataset-agnostic analog of the
-##### regridded-bathymetry cache. The key covers everything that determines the
-##### result: the dataset (with its parameters), variable, date, region, the target
-##### grid geometry, the forwarded read keywords, and a size/mtime stamp of the
-##### local dataset file so a re-download invalidates the cache.
+##### Keyed disk cache for regridded fields, shared by `Field(metadatum, grid; cache = true)`
+##### and `regrid_bathymetry`. The key covers everything that determines the result: the
+##### dataset (with its parameters), variable, date, region, the target grid geometry, the
+##### forwarded read keywords or processing parameters, and a size/mtime stamp of the local
+##### dataset file so a re-download invalidates the cache.
 #####
 
 struct FieldRegridding
@@ -61,12 +61,12 @@ function FieldRegridding(grid, metadatum, read_keywords)
 end
 
 function Base.:(==)(a::FieldRegridding, b::FieldRegridding)
-    return all(getfield(a, name) == getfield(b, name) for name in fieldnames(FieldRegridding))
+    return all(getfield(a, field_name) == getfield(b, field_name) for field_name in fieldnames(FieldRegridding))
 end
 
 function Base.hash(c::FieldRegridding, h::UInt)
-    for name in fieldnames(FieldRegridding)
-        h = hash(getfield(c, name), h)
+    for field_name in fieldnames(FieldRegridding)
+        h = hash(getfield(c, field_name), h)
     end
     return h
 end

--- a/src/DataWrangling/field_cache.jl
+++ b/src/DataWrangling/field_cache.jl
@@ -1,0 +1,113 @@
+#####
+##### Cache for `Field(metadatum, grid)` reads — the dataset-agnostic analog of the
+##### regridded-bathymetry cache. The key covers everything that determines the
+##### result: the dataset (with its parameters), variable, date, region, the target
+##### grid geometry, the forwarded read keywords, and a size/mtime stamp of the
+##### local dataset file so a re-download invalidates the cache.
+#####
+
+struct FieldRegridding
+    grid_type     :: String
+    grid_size     :: NTuple{3, Int}
+    longitude     :: Tuple{Float64, Float64}
+    latitude      :: Tuple{Float64, Float64}
+    z_extent      :: Union{Nothing, Tuple{Float64, Float64}}
+    topology      :: NTuple{3, Symbol}
+    float_type    :: Symbol
+    location      :: NTuple{3, Symbol}
+    dataset       :: String
+    variable      :: Symbol
+    date          :: String
+    region        :: String
+    read_keywords :: String
+    file_stamp    :: Union{Nothing, Tuple{Int, Int}}
+end
+
+# The source stamp is best-effort: datasets that stream (Zarr, /vsicurl/ COGs) or
+# span several files have no single local path, and their caches are keyed by the
+# metadata alone.
+function field_cache_file_stamp(metadatum)
+    path = try
+        metadata_path(metadatum)
+    catch
+        return nothing
+    end
+    path isa AbstractString && isfile(path) || return nothing
+    return (Int(filesize(path)), round(Int, mtime(path)))
+end
+
+function FieldRegridding(grid, metadatum, read_keywords)
+    Nx, Ny, Nz = size(grid)
+    TX, TY, TZ = topology(grid)
+    lon = x_domain(grid)
+    lat = y_domain(grid)
+    z_extent = TZ === Flat ? nothing : Float64.(z_domain(grid))
+    LX, LY, LZ = location(metadatum)
+
+    return FieldRegridding(string(typeof(grid).name.wrapper),
+                           (Nx, Ny, Nz),
+                           (Float64(lon[1]), Float64(lon[2])),
+                           (Float64(lat[1]), Float64(lat[2])),
+                           z_extent,
+                           (Symbol(TX), Symbol(TY), Symbol(TZ)),
+                           Symbol(eltype(grid)),
+                           (Symbol(LX), Symbol(LY), Symbol(LZ)),
+                           sprint(show, metadatum.dataset),
+                           metadatum.name,
+                           string(metadatum.dates),
+                           bounding_box_suffix(metadatum.region),
+                           sprint(show, read_keywords),
+                           field_cache_file_stamp(metadatum))
+end
+
+function Base.:(==)(a::FieldRegridding, b::FieldRegridding)
+    return all(getfield(a, name) == getfield(b, name) for name in fieldnames(FieldRegridding))
+end
+
+function Base.hash(c::FieldRegridding, h::UInt)
+    for name in fieldnames(FieldRegridding)
+        h = hash(getfield(c, name), h)
+    end
+    return h
+end
+
+function field_cache_filename(config::FieldRegridding)
+    Nx, Ny, Nz = config.grid_size
+    h = string(hash(config) % UInt32, base = 16, pad = 8)
+    return "field_$(config.variable)_$(Nx)x$(Ny)x$(Nz)_$(h).jld2"
+end
+
+field_cache_path(config::FieldRegridding) =
+    joinpath(download_cache("field_cache"), field_cache_filename(config))
+
+function load_field_cache(config::FieldRegridding)
+    filepath = field_cache_path(config)
+    isfile(filepath) || return nothing
+    try
+        jldopen(filepath, "r") do file
+            if file["config"] == config
+                @info "Loading cached field from $filepath"
+                return file["data"]
+            else
+                return nothing
+            end
+        end
+    catch err
+        @warn "Failed to load field cache from $filepath: $err"
+        return nothing
+    end
+end
+
+function save_field_cache(config::FieldRegridding, data::AbstractArray)
+    filepath = field_cache_path(config)
+    try
+        jldopen(filepath, "w") do file
+            file["config"] = config
+            file["data"] = data
+        end
+        @info "Saved field cache to $filepath"
+    catch err
+        @warn "Failed to save field cache to $filepath: $err"
+    end
+    return nothing
+end

--- a/src/DataWrangling/metadata_field.jl
+++ b/src/DataWrangling/metadata_field.jl
@@ -366,18 +366,39 @@ end
 interpolate_physical!(to_field, from_field, metadata) = interpolate_physical!(to_field, from_field)
 
 """
-    Field(metadata::Metadatum, grid::AbstractGrid; kw...)
+    Field(metadata::Metadatum, grid::AbstractGrid; cache = false, kw...)
 
 Load `metadata` on its native grid and interpolate onto `grid` — the
 `Field` analog of `FieldTimeSeries(metadata, grid)`. Keyword arguments are
 forwarded to the native-grid `Field(metadata, arch; …)` (e.g. `inpainting`,
 `mask`, `halo`, `cache_inpainted_data`).
+
+With `cache = true` the regridded result is cached to disk and reused by later
+reads with the same dataset, variable, date, region, target-grid geometry, and
+read keywords — skipping the native materialization and regrid entirely. The
+key carries a size/mtime stamp of the local dataset file where one exists, so a
+re-download invalidates the cache; for streaming datasets with no local file,
+delete the stale entry from the `field_cache` scratch directory by hand after
+replacing data upstream.
 """
-function Oceananigans.Fields.Field(metadata::Metadatum, grid::AbstractGrid; kw...)
-    native = Field(metadata, architecture(grid); kw...)
+function Oceananigans.Fields.Field(metadata::Metadatum, grid::AbstractGrid; cache = false, kw...)
     LX, LY, LZ = location(metadata)
+    config = cache ? FieldRegridding(grid, metadata, values(kw)) : nothing
+
+    if cache
+        data = load_field_cache(config)
+        if !isnothing(data)
+            target = Field{LX, LY, LZ}(grid)
+            interior(target) .= on_architecture(architecture(grid), data)
+            fill_halo_regions!(target)
+            return target
+        end
+    end
+
+    native = Field(metadata, architecture(grid); kw...)
     target = Field{LX, LY, LZ}(grid)
     interpolate_physical!(target, native, metadata)
+    cache && save_field_cache(config, Array(interior(target)))
     return target
 end
 

--- a/src/DataWrangling/metadata_field.jl
+++ b/src/DataWrangling/metadata_field.jl
@@ -383,9 +383,9 @@ replacing data upstream.
 """
 function Oceananigans.Fields.Field(metadata::Metadatum, grid::AbstractGrid; cache = false, kw...)
     LX, LY, LZ = location(metadata)
-    config = cache ? FieldRegridding(grid, metadata, values(kw)) : nothing
 
     if cache
+        config = FieldRegridding(grid, metadata, values(kw))
         data = load_field_cache(config)
         if !isnothing(data)
             target = Field{LX, LY, LZ}(grid)
@@ -398,7 +398,11 @@ function Oceananigans.Fields.Field(metadata::Metadatum, grid::AbstractGrid; cach
     native = Field(metadata, architecture(grid); kw...)
     target = Field{LX, LY, LZ}(grid)
     interpolate_physical!(target, native, metadata)
-    cache && save_field_cache(config, Array(interior(target)))
+    if cache
+        # rebuild the key: the native read may have just downloaded the dataset file it stamps
+        config = FieldRegridding(grid, metadata, values(kw))
+        save_field_cache(config, Array(interior(target)))
+    end
     return target
 end
 

--- a/src/DataWrangling/metadata_field.jl
+++ b/src/DataWrangling/metadata_field.jl
@@ -366,7 +366,7 @@ end
 interpolate_physical!(to_field, from_field, metadata) = interpolate_physical!(to_field, from_field)
 
 """
-    Field(metadata::Metadatum, grid::AbstractGrid; cache = false, kw...)
+    Field(metadata::Metadatum, grid::AbstractGrid; cache = false, overwrite_cache = false, kw...)
 
 Load `metadata` on its native grid and interpolate onto `grid` — the
 `Field` analog of `FieldTimeSeries(metadata, grid)`. Keyword arguments are
@@ -375,16 +375,18 @@ forwarded to the native-grid `Field(metadata, arch; …)` (e.g. `inpainting`,
 
 With `cache = true` the regridded result is cached to disk and reused by later
 reads with the same dataset, variable, date, region, target-grid geometry, and
-read keywords — skipping the native materialization and regrid entirely. The
-key carries a size/mtime stamp of the local dataset file where one exists, so a
-re-download invalidates the cache; for streaming datasets with no local file,
-delete the stale entry from the `field_cache` scratch directory by hand after
-replacing data upstream.
+read keywords — skipping the native materialization and regrid entirely; with
+`cache = false` (default) the cache is disabled entirely and nothing is read or
+written. The key carries a size/mtime stamp of the local dataset file where one
+exists, so a re-download invalidates the cache. For streaming datasets with no
+local file, pass `overwrite_cache = true` after replacing data upstream: it
+skips the lookup and overwrites the entry with a freshly regridded result.
 """
-function Oceananigans.Fields.Field(metadata::Metadatum, grid::AbstractGrid; cache = false, kw...)
+function Oceananigans.Fields.Field(metadata::Metadatum, grid::AbstractGrid;
+                                   cache = false, overwrite_cache = false, kw...)
     LX, LY, LZ = location(metadata)
 
-    if cache
+    if cache && !overwrite_cache
         config = FieldRegridding(grid, metadata, values(kw))
         data = load_field_cache(config)
         if !isnothing(data)

--- a/test/test_bathymetry.jl
+++ b/test/test_bathymetry.jl
@@ -3,7 +3,7 @@ include("download_utils.jl")
 
 using JLD2
 using NumericalEarth.Bathymetry: remove_minor_basins!, bathymetry_regridding_key
-using NumericalEarth.DataWrangling: field_cache_filename
+using NumericalEarth.DataWrangling: field_cache_filename, save_field_cache
 using NumericalEarth.DataWrangling.ETOPO
 using Statistics
 
@@ -147,4 +147,19 @@ end
     # cache=false should still produce correct results
     result4 = regrid_bathymetry(grid; cache=false)
     @test parent(result1) == parent(result4)
+
+    # overwrite_cache=true skips the lookup and refreshes the entry
+    metadata = Metadatum(:bottom_height, dataset=ETOPO2022())
+    config = bathymetry_regridding_key(grid, metadata;
+                                       height_above_water = nothing, minimum_depth = 0,
+                                       interpolation_passes = 1, major_basins = 1)
+    save_field_cache(config, zeros(size(grid, 1), size(grid, 2)))
+    poisoned = regrid_bathymetry(grid; cache=true)
+    @test all(iszero, interior(poisoned))
+
+    result5 = regrid_bathymetry(grid; cache=true, overwrite_cache=true)
+    @test parent(result1) == parent(result5)
+
+    result6 = regrid_bathymetry(grid; cache=true)
+    @test parent(result1) == parent(result6)
 end

--- a/test/test_bathymetry.jl
+++ b/test/test_bathymetry.jl
@@ -2,11 +2,8 @@ include("runtests_setup.jl")
 include("download_utils.jl")
 
 using JLD2
-using NumericalEarth.Bathymetry: remove_minor_basins!,
-                                 BathymetryRegridding,
-                                 cache_filename,
-                                 load_bathymetry_cache,
-                                 save_bathymetry_cache
+using NumericalEarth.Bathymetry: remove_minor_basins!, bathymetry_regridding_key
+using NumericalEarth.DataWrangling: field_cache_filename
 using NumericalEarth.DataWrangling.ETOPO
 using Statistics
 
@@ -76,8 +73,8 @@ using Statistics
     end
 end
 
-@testset "BathymetryRegridding configuration" begin
-    @info "Testing BathymetryRegridding configuration..."
+@testset "Bathymetry cache key" begin
+    @info "Testing bathymetry cache keys..."
 
     grid = LatitudeLongitudeGrid(CPU();
                                  size = (100, 100, 10),
@@ -87,26 +84,33 @@ end
 
     metadata = Metadatum(:bottom_height, dataset=ETOPO2022())
 
+    key(; height_above_water = nothing, minimum_depth = 0, interpolation_passes = 1, major_basins = 1) =
+        bathymetry_regridding_key(grid, metadata; height_above_water, minimum_depth,
+                                  interpolation_passes, major_basins)
+
     # Test construction and equality
-    config1 = BathymetryRegridding(grid, metadata)
-    config2 = BathymetryRegridding(grid, metadata)
+    config1 = key()
+    config2 = key()
     @test config1 == config2
     @test hash(config1) == hash(config2)
 
     # Test that different parameters produce different configs
-    config3 = BathymetryRegridding(grid, metadata; interpolation_passes=5)
+    config3 = key(interpolation_passes = 5)
     @test config1 != config3
     @test hash(config1) != hash(config3)
 
-    config4 = BathymetryRegridding(grid, metadata; minimum_depth=10)
+    config4 = key(minimum_depth = 10)
     @test config1 != config4
 
-    # Test cache filename: same config → same filename
-    @test cache_filename(config1) == cache_filename(config2)
-    # Different config → different filename
-    @test cache_filename(config1) != cache_filename(config3)
+    # Integer and float parameter values key identically
+    @test key(minimum_depth = 10) == key(minimum_depth = 10.0)
 
-    # Test JLD2 round-trip of BathymetryRegridding
+    # Test cache filename: same config → same filename
+    @test field_cache_filename(config1) == field_cache_filename(config2)
+    # Different config → different filename
+    @test field_cache_filename(config1) != field_cache_filename(config3)
+
+    # Test JLD2 round-trip of the key
     tmpfile = tempname() * ".jld2"
     jldopen(tmpfile, "w") do file
         file["config"] = config1

--- a/test/test_field_cache.jl
+++ b/test/test_field_cache.jl
@@ -64,5 +64,16 @@ end
     uncached = Field(metadatum, grid)
     @test all(isequal.(parent(first_read), parent(uncached)))
 
+    # overwrite_cache = true skips the lookup and refreshes the entry
+    save_field_cache(config, zeros(size(grid)))
+    poisoned = Field(metadatum, grid; cache = true)
+    @test all(iszero, interior(poisoned))
+
+    refreshed = Field(metadatum, grid; cache = true, overwrite_cache = true)
+    @test all(isequal.(parent(refreshed), parent(first_read)))
+
+    reread = Field(metadatum, grid; cache = true)
+    @test all(isequal.(parent(reread), parent(first_read)))
+
     rm(field_cache_path(config); force = true)
 end

--- a/test/test_field_cache.jl
+++ b/test/test_field_cache.jl
@@ -1,0 +1,66 @@
+include("runtests_setup.jl")
+
+using NumericalEarth.DataWrangling: FieldRegridding, field_cache_filename, field_cache_path,
+                                    load_field_cache, save_field_cache
+
+@testset "Field cache keys" begin
+    grid = LatitudeLongitudeGrid(CPU();
+                                 size = (36, 18, 4),
+                                 longitude = (0, 90),
+                                 latitude = (-45, 45),
+                                 z = (-1000, 0))
+
+    metadatum = Metadatum(:temperature; dataset = EN4Monthly(), date = start_date)
+
+    config1 = FieldRegridding(grid, metadatum, (;))
+    config2 = FieldRegridding(grid, metadatum, (;))
+    @test config1 == config2
+    @test hash(config1) == hash(config2)
+    @test field_cache_filename(config1) == field_cache_filename(config2)
+
+    # Different grid geometry, read keywords, or date must key differently.
+    other_grid = LatitudeLongitudeGrid(CPU();
+                                       size = (18, 18, 4),
+                                       longitude = (0, 90),
+                                       latitude = (-45, 45),
+                                       z = (-1000, 0))
+    @test field_cache_filename(FieldRegridding(other_grid, metadatum, (;))) !=
+          field_cache_filename(config1)
+    @test field_cache_filename(FieldRegridding(grid, metadatum, (; inpainting = 7))) !=
+          field_cache_filename(config1)
+
+    other_datum = Metadatum(:salinity; dataset = EN4Monthly(), date = start_date)
+    @test field_cache_filename(FieldRegridding(grid, other_datum, (;))) !=
+          field_cache_filename(config1)
+
+    # A mismatched stored config is rejected rather than served.
+    save_field_cache(config1, zeros(4, 4, 4))
+    stale = FieldRegridding(grid, other_datum, (;))
+    @test isnothing(load_field_cache(stale))
+    @test load_field_cache(config1) == zeros(4, 4, 4)
+    rm(field_cache_path(config1); force = true)
+end
+
+@testset "Field cache round-trip" begin
+    grid = LatitudeLongitudeGrid(CPU();
+                                 size = (40, 30, 5),
+                                 longitude = (0, 60),
+                                 latitude = (-30, 30),
+                                 z = (-800, 0))
+
+    metadatum = Metadatum(:temperature; dataset = EN4Monthly(), date = start_date)
+
+    config = FieldRegridding(grid, metadatum, (;))
+    rm(field_cache_path(config); force = true)
+
+    first_read  = Field(metadatum, grid; cache = true)
+    @test isfile(field_cache_path(config))
+
+    second_read = Field(metadatum, grid; cache = true)
+    @test all(isequal.(parent(first_read), parent(second_read)))
+
+    uncached = Field(metadatum, grid)
+    @test all(isequal.(parent(first_read), parent(uncached)))
+
+    rm(field_cache_path(config); force = true)
+end

--- a/test/test_field_cache.jl
+++ b/test/test_field_cache.jl
@@ -50,6 +50,8 @@ end
 
     metadatum = Metadatum(:temperature; dataset = EN4Monthly(), date = start_date)
 
+    # Key the cache only after the dataset file exists — the key stamps it
+    download(metadatum)
     config = FieldRegridding(grid, metadatum, (;))
     rm(field_cache_path(config); force = true)
 


### PR DESCRIPTION
`Field(metadatum, grid)` re-runs the native materialization and regrid on every call — for high-resolution windows (OpenLandMap texture, WorldCover fractions) that is minutes per read of data that never changes. This adds an opt-in disk cache for the regridded result and rekeys `regrid_bathymetry`'s existing cache onto the same machinery.

- `Field(metadatum, grid; cache = true)` stores the regridded interior in a `field_cache` scratch space and reuses it when the key matches. The key covers everything that determines the result: dataset (with parameters), variable, date, region, target-grid geometry, field location, forwarded read keywords, and a size/mtime stamp of the local dataset file so a re-download invalidates the entry. Streaming datasets (Zarr, `/vsicurl/` windows) have no file to stamp, which is why this cache is opt-in. `overwrite_cache = true` skips the lookup and overwrites the entry with a fresh result — the refresh path for those datasets.
- `regrid_bathymetry` uses the same key and load/save path, carrying its processing parameters (`minimum_depth`, `interpolation_passes`, …) in the keyword slot; `BathymetryRegridding` is deleted. The bathymetry cache thereby gains re-download invalidation and parameter-aware dataset keys. Existing `bathymetry_cache` entries are orphaned and recompute once into `field_cache`.
- Load verifies the stored key against the request and falls back to recomputing on any mismatch or corrupt file.

```julia
sand = Field(Metadatum(:sand_fraction; dataset = OpenLandMapSoilDB(), region), grid; cache = true)
```

Round-trip and invalidation are tested in `test/test_field_cache.jl` (EN4) and `test/test_bathymetry.jl` (ETOPO), CPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
