### PR TITLE
Name the collection when the ECCO drive refuses an ECCO2 download

### DIFF
--- a/src/DataWrangling/ECCO/ECCO.jl
+++ b/src/DataWrangling/ECCO/ECCO.jl
@@ -273,20 +273,19 @@ function DataWrangling.metadata_url(m::Metadata{<:ECCO4Monthly})
     return ECCO4_url * dataset_variable_name(m) * "/" * year * "/" * m.filename
 end
 
-# The ECCO drive serves `Version4` and `Version5`, but every path under `ECCO2` — the quarter-degree
-# `cube92` fields and both ECCO-Darwin grids — answers `403 Forbidden` even to a signed-in account.
-# A bare `403` reads as bad credentials, so name the collection instead.
-is_ecco2_url(url) = occursin("/drive/files/ECCO2/", url)
+# The drive stopped serving its `ECCO2` directory, which holds the quarter-degree fields and both
+# ECCO-Darwin datasets whatever grid their name refers to. The download is still attempted in case it
+# returns, but a bare 403 reads as bad credentials, so say what it means instead.
+const ECCO2DriveDataset = Union{ECCO2Monthly, ECCO2Daily, ECCO2DarwinMonthly, ECCO4DarwinMonthly}
 
-function ecco_download_error(err, metadatum, url)
-    (err isa Downloads.RequestError && err.response.status == 403 && is_ecco2_url(url)) || return err
+function ecco_download_error(err, metadatum)
+    refused = err isa Downloads.RequestError && err.response.status == 403
+    (refused && metadatum.dataset isa ECCO2DriveDataset) || return err
 
-    return ErrorException("The ECCO drive returned 403 Forbidden for $(metadatum.name) at $url. \
-                           Every path under its `ECCO2` collection is forbidden even to a signed-in \
-                           account, so $(typeof(metadatum.dataset)) cannot currently be downloaded — \
-                           this is not a problem with `ECCO_USERNAME` or `ECCO_WEBDAV_PASSWORD`. \
-                           `ECCO4Monthly` is served from the drive's `Version4` collection and is \
-                           unaffected.")
+    return ErrorException("The ECCO drive refused $(typeof(metadatum.dataset)), whose files live in \
+                           the `ECCO2` directory it no longer serves. This is not a problem with \
+                           `ECCO_USERNAME` or `ECCO_WEBDAV_PASSWORD`. `ECCO4Monthly` reads from the \
+                           drive's `Version4` directory and is unaffected.")
 end
 
 function Downloads.download(metadata::ECCOMetadata)
@@ -327,7 +326,7 @@ function Downloads.download(metadata::ECCOMetadata)
                 try
                     Downloads.download(fileurl, filepath; downloader, progress=DownloadProgress())
                 catch err
-                    throw(ecco_download_error(err, metadatum, fileurl))
+                    throw(ecco_download_error(err, metadatum))
                 end
             end
         end

--- a/src/DataWrangling/ECCO/ECCO.jl
+++ b/src/DataWrangling/ECCO/ECCO.jl
@@ -276,6 +276,9 @@ end
 # The drive stopped serving its `ECCO2` directory, which holds the quarter-degree fields and both
 # ECCO-Darwin datasets whatever grid their name refers to. The download is still attempted in case it
 # returns, but a bare 403 reads as bad credentials, so say what it means instead.
+#
+# TODO: delete this and the note in README.md once the drive serves `ECCO2` again. JPL has announced
+# no timeline, so the check is here until a download succeeds.
 const ECCO2DriveDataset = Union{ECCO2Monthly, ECCO2Daily, ECCO2DarwinMonthly, ECCO4DarwinMonthly}
 
 function ecco_download_error(err, metadatum)

--- a/src/DataWrangling/ECCO/ECCO.jl
+++ b/src/DataWrangling/ECCO/ECCO.jl
@@ -273,6 +273,22 @@ function DataWrangling.metadata_url(m::Metadata{<:ECCO4Monthly})
     return ECCO4_url * dataset_variable_name(m) * "/" * year * "/" * m.filename
 end
 
+# The ECCO drive serves `Version4` and `Version5`, but every path under `ECCO2` — the quarter-degree
+# `cube92` fields and both ECCO-Darwin grids — answers `403 Forbidden` even to a signed-in account.
+# A bare `403` reads as bad credentials, so name the collection instead.
+is_ecco2_url(url) = occursin("/drive/files/ECCO2/", url)
+
+function ecco_download_error(err, metadatum, url)
+    (err isa Downloads.RequestError && err.response.status == 403 && is_ecco2_url(url)) || return err
+
+    return ErrorException("The ECCO drive returned 403 Forbidden for $(metadatum.name) at $url. \
+                           Every path under its `ECCO2` collection is forbidden even to a signed-in \
+                           account, so $(typeof(metadatum.dataset)) cannot currently be downloaded — \
+                           this is not a problem with `ECCO_USERNAME` or `ECCO_WEBDAV_PASSWORD`. \
+                           `ECCO4Monthly` is served from the drive's `Version4` collection and is \
+                           unaffected.")
+end
+
 function Downloads.download(metadata::ECCOMetadata)
     # Skip download if all files already exist
     all(isfile(metadata_path(m)) for m in metadata) && return metadata_path(metadata)
@@ -308,7 +324,11 @@ function Downloads.download(metadata::ECCOMetadata)
                     throw(ArgumentError(msg))
                 end
                 @info "Downloading ECCO data: $(metadatum.name) in $(metadatum.dir)..."
-                Downloads.download(fileurl, filepath; downloader, progress=DownloadProgress())
+                try
+                    Downloads.download(fileurl, filepath; downloader, progress=DownloadProgress())
+                catch err
+                    throw(ecco_download_error(err, metadatum, fileurl))
+                end
             end
         end
     end

--- a/src/DataWrangling/ECCO/README.md
+++ b/src/DataWrangling/ECCO/README.md
@@ -29,3 +29,13 @@ or within Julia by
 ENV["ECCO_USERNAME"] = "your_username"
 ENV["ECCO_WEBDAV_PASSWORD"] = "cRaZYpASSwORD"
 ```
+
+## The `ECCO2` collection is currently unavailable
+
+Every path under `https://ecco.jpl.nasa.gov/drive/files/ECCO2/` answers `403 Forbidden`, including
+to an account whose credentials the drive otherwise accepts. This covers `ECCO2Monthly`,
+`ECCO2Daily`, `ECCO2DarwinMonthly`, and `ECCO4DarwinMonthly`. The drive's `Version4` and `Version5`
+collections still serve normally, so `ECCO4Monthly` is unaffected, and NASA's CMR catalog lists no
+replacement for the quarter-degree `cube92` fields.
+
+Setting `ECCO_USERNAME` and `ECCO_WEBDAV_PASSWORD` as above will not restore access.

--- a/src/DataWrangling/ECCO/README.md
+++ b/src/DataWrangling/ECCO/README.md
@@ -30,12 +30,12 @@ ENV["ECCO_USERNAME"] = "your_username"
 ENV["ECCO_WEBDAV_PASSWORD"] = "cRaZYpASSwORD"
 ```
 
-## The `ECCO2` collection is currently unavailable
+## The `ECCO2` directory is no longer served
 
-Every path under `https://ecco.jpl.nasa.gov/drive/files/ECCO2/` answers `403 Forbidden`, including
-to an account whose credentials the drive otherwise accepts. This covers `ECCO2Monthly`,
-`ECCO2Daily`, `ECCO2DarwinMonthly`, and `ECCO4DarwinMonthly`. The drive's `Version4` and `Version5`
-collections still serve normally, so `ECCO4Monthly` is unaffected, and NASA's CMR catalog lists no
-replacement for the quarter-degree `cube92` fields.
-
-Setting `ECCO_USERNAME` and `ECCO_WEBDAV_PASSWORD` as above will not restore access.
+`https://ecco.jpl.nasa.gov/drive/files` lists only `NearRealTime`, `Version4`, and `Version5`, and
+every path beneath `files/ECCO2/` answers `403 Forbidden` to an account the drive otherwise accepts.
+This covers `ECCO2Monthly`, `ECCO2Daily`, `ECCO2DarwinMonthly`, and `ECCO4DarwinMonthly` — both
+ECCO-Darwin datasets are stored under `files/ECCO2/` whatever grid their name refers to.
+`ECCO4Monthly` reads from `files/Version4/` and is unaffected. Setting the variables above will not
+restore access. Downloads are still attempted, so these datasets will work again if the directory
+returns.

--- a/src/DataWrangling/ECCO/README.md
+++ b/src/DataWrangling/ECCO/README.md
@@ -38,4 +38,4 @@ This covers `ECCO2Monthly`, `ECCO2Daily`, `ECCO2DarwinMonthly`, and `ECCO4Darwin
 ECCO-Darwin datasets are stored under `files/ECCO2/` whatever grid their name refers to.
 `ECCO4Monthly` reads from `files/Version4/` and is unaffected. Setting the variables above will not
 restore access. Downloads are still attempted, so these datasets will work again if the directory
-returns.
+returns, at which point this note and the check in `ECCO.jl` can go.


### PR DESCRIPTION
Addresses #526.

The ECCO drive stopped serving its `ECCO2` directory, which holds `ECCO2Monthly`, `ECCO2Daily`, and both ECCO-Darwin datasets — those live there whatever grid their name refers to. Downloading one raised a bare `RequestError: HTTP/2 403`, which reads as bad credentials and sends people back to the README to re-copy a password that will not help.

```
The ECCO drive refused ECCO4DarwinMonthly, whose files live in the `ECCO2` directory it no longer
serves. This is not a problem with `ECCO_USERNAME` or `ECCO_WEBDAV_PASSWORD`. `ECCO4Monthly` reads
from the drive's `Version4` directory and is unaffected.
```

The download is still attempted, so these datasets recover on their own if the directory comes back. Other failures, and refusals from the collections the drive still serves, pass through untouched. The README gains the same note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
