### PR TITLE
GPU Adapt rules for the canopy humidity formulations

### DIFF
--- a/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
+++ b/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
@@ -316,6 +316,13 @@ Base.summary(::CanopyAirSpace) = "CanopyAirSpace"
 Base.show(io::IO, c::CanopyAirSpace) =
     print(io, "CanopyAirSpace(soil=", summary(c.soil), ", canopy=", summary(c.canopy), ")")
 
+Adapt.adapt_structure(to, c::CanopyAirSpace) =
+    CanopyAirSpace(adapt(to, c.soil), adapt(to, c.canopy), c.soil_skin_flux,
+                   c.leaf_albedo, c.ground_albedo, c.canopy_emissivity_max, c.ground_emissivity,
+                   c.extinction, c.clumping, c.leaf_boundary_conductance,
+                   c.undercanopy_conductance, c.inner_iterations, c.relaxation,
+                   c.interception, c.phase)
+
 # Materialization / identity — delegate to the sub-models so the per-cell interface
 # state carries the soil saturation, bulk temperature, and LAI the branches read.
 @inline interface_phase(c::CanopyAirSpace) = interface_phase(c.soil)

--- a/src/EarthSystemModels/InterfaceComputations/canopy_conductance.jl
+++ b/src/EarthSystemModels/InterfaceComputations/canopy_conductance.jl
@@ -109,6 +109,11 @@ function CanopyConductanceHumidity(FT=Oceananigans.defaults.FloatType;
                                      convert(FT, atmospheric_co2), phase)
 end
 
+Adapt.adapt_structure(to, q::CanopyConductanceHumidity) =
+    CanopyConductanceHumidity(adapt(to, q.leaf_area_index),
+                              q.photosynthesis, q.conductance, q.moisture_stress,
+                              q.absorbed_par, q.atmospheric_co2, q.phase)
+
 Base.summary(::CanopyConductanceHumidity{L, P, C, S, A, Q, Φ}) where {L, P, C, S, A, Q, Φ} =
     string("CanopyConductanceHumidity{", Φ === AtmosphericThermodynamics.Liquid ? "Liquid" : "Ice", "}")
 Base.show(io::IO, q::CanopyConductanceHumidity) = print(io, summary(q))

--- a/src/EarthSystemModels/InterfaceComputations/composite_surface_humidity.jl
+++ b/src/EarthSystemModels/InterfaceComputations/composite_surface_humidity.jl
@@ -57,6 +57,9 @@ end
 
 CompositeSurfaceHumidity(; soil, canopy) = CompositeSurfaceHumidity(soil, canopy)
 
+Adapt.adapt_structure(to, q::CompositeSurfaceHumidity) =
+    CompositeSurfaceHumidity(adapt(to, q.soil), adapt(to, q.canopy))
+
 Base.summary(q::CompositeSurfaceHumidity) =
     string("CompositeSurfaceHumidity(soil=", summary(q.soil), ", canopy=", summary(q.canopy), ")")
 Base.show(io::IO, q::CompositeSurfaceHumidity) = print(io, summary(q))

--- a/src/EarthSystemModels/InterfaceComputations/interface_states.jl
+++ b/src/EarthSystemModels/InterfaceComputations/interface_states.jl
@@ -11,6 +11,11 @@ struct InterfaceProperties{Q, T, V}
     velocity_formulation :: V
 end
 
+Adapt.adapt_structure(to, p::InterfaceProperties) =
+    InterfaceProperties(adapt(to, p.specific_humidity_formulation),
+                        adapt(to, p.temperature_formulation),
+                        adapt(to, p.velocity_formulation))
+
 #####
 ##### Interface specific humidity formulations
 #####


### PR DESCRIPTION
A `Field`-valued `leaf_area_index` makes `CanopyConductanceHumidity` — and everything holding it: `CanopyAirSpace`, `CompositeSurfaceHumidity`, `InterfaceProperties` — non-isbits, so the coupled flux kernel fails to compile on CUDA:

```
KernelError: passing non-bitstype argument
Argument 12 ... InterfaceProperties{CanopyAirSpace{..., CanopyConductanceHumidity{Field{...
```

This adds `Adapt.adapt_structure` for the four types (the LAI field adapts to its device view; everything else passes through), making the Field-LAI path usable on GPU grids.

```julia
using NumericalEarth, Oceananigans, CUDA
using Oceananigans.TimeSteppers: update_state!

grid = LatitudeLongitudeGrid(GPU(); size = (2, 2, 1), latitude = (36, 37), longitude = (-98, -97),
                             z = (-1, 0), topology = (Bounded, Bounded, Bounded))
atmosphere = PrescribedAtmosphere(grid; surface_layer_height = 10, boundary_layer_height = 512)
fill!(parent(atmosphere.temperature), 300); fill!(parent(atmosphere.specific_humidity), 0.01)
fill!(parent(atmosphere.velocities.u), 4);  fill!(parent(atmosphere.pressure), 101325)
land = SlabLand(grid); set!(land; T = 300, M = 50)

leaf_area_index = Field{Center, Center, Nothing}(grid); set!(leaf_area_index, 2)
cas = CanopyAirSpace(; canopy = CanopyConductanceHumidity(; leaf_area_index),
    soil = DryLayerHumidity(; dry_layer_depth = StorageBasedDryLayerDepth(maximum_dry_layer_depth = 0.05,
                                                                          dry_layer_onset_saturation = 1.0),
                            vapor_exchange = DryLayerVaporPistonVelocity(minimum_dry_layer_depth = 1e-3,
                                                                         molecular_diffusivity = 2.4e-5),
                            thermal_exchange_depth = 0.05, porosity = 0.4))
model = AtmosphereLandModel(atmosphere, land; radiation = nothing,
                            atmosphere_land_interface_temperature = cas,
                            atmosphere_land_interface_specific_humidity = cas)
update_state!(model)   # KernelError without this PR; runs with it
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
