### PR TITLE
GPU-safe canopy height field fill

### DIFF
--- a/ext/NumericalEarthArchGDALExt/NumericalEarthArchGDALExt.jl
+++ b/ext/NumericalEarthArchGDALExt/NumericalEarthArchGDALExt.jl
@@ -9,6 +9,7 @@ using NetworkOptions: NetworkOptions
 using NumericalEarth: NumericalEarth
 
 using Oceananigans: Center, CPU
+using Oceananigans.Architectures: architecture, on_architecture
 using Oceananigans.Fields: Field, interior
 using Oceananigans.Grids: λnodes, φnodes
 

--- a/ext/NumericalEarthArchGDALExt/ethcanopy.jl
+++ b/ext/NumericalEarthArchGDALExt/ethcanopy.jl
@@ -135,7 +135,7 @@ end
 # array matches the grid's cell count.
 function canopy_field(grid, data)
     h = Field{Center, Center, Nothing}(grid)
-    interior(h, :, :, 1) .= data
+    interior(h) .= on_architecture(architecture(grid), reshape(data, size(data, 1), size(data, 2), 1))
     return h
 end
 


### PR DESCRIPTION
`canopy_field` wrote the warped array into the output with `interior(h, :, :, 1) .= data`, a host `Matrix{Float32}` broadcast into a device array — on a GPU grid the broadcast kernel fails to compile (`GPU compilation of ... gpu_broadcast_kernel_cartesian ... Extruded{Matrix{Float32}}`). Route the fill through `on_architecture`, matching the GloBFP morphometry fill.

```julia
using NumericalEarth, Oceananigans, ArchGDAL, CUDA
grid = LatitudeLongitudeGrid(GPU(); size = (100, 100), latitude = (36, 37), longitude = (-98, -97),
                             topology = (Bounded, Bounded, Flat))
canopy_height_field(grid, ETHSentinel2CanopyHeight())   # GPU compilation error without this PR
```

Exercised on Tesla T4 GPU grids at 990² and 1200².

🤖 Generated with [Claude Code](https://claude.com/claude-code)
