### PR TITLE
Give ERA5-Land downloads a src-owned method so extension load order cannot break them

### DIFF
--- a/ext/NumericalEarthCopernicusClimateDataStoreExt.jl
+++ b/ext/NumericalEarthCopernicusClimateDataStoreExt.jl
@@ -383,16 +383,19 @@ cds_area(::Nothing) = nothing
 cds_area(area) = [area[3], area[2], area[1], area[4]]
 
 """
-    Downloads.download(meta::NumericalEarth.DataWrangling.Metadatum{<:ERA5LandDataset};
-                       skip_existing=true, additional_kw...)
+    NumericalEarth.DataWrangling.ERA5.download_era5_land(meta::NumericalEarth.DataWrangling.Metadatum{<:ERA5LandDataset};
+                                                         skip_existing=true, additional_kw...)
 
 Download a whole year of ERA5-Land data for one variable into a single yearly file,
 the first time any date within that year is requested; later dates in the same year
 find the file already on disk and skip (see `skip_existing`).
+
+Implements the `download_era5_land` stub declared in `src/DataWrangling/ERA5/ERA5_land.jl`,
+which owns `Downloads.download` for ERA5-Land metadata under any extension load order.
 """
-function Downloads.download(meta::NumericalEarth.DataWrangling.Metadatum{<:ERA5LandDataset};
-                            skip_existing = true,
-                            additional_kw...)
+function NumericalEarth.DataWrangling.ERA5.download_era5_land(meta::NumericalEarth.DataWrangling.Metadatum{<:ERA5LandDataset};
+                                                              skip_existing = true,
+                                                              additional_kw...)
 
     output_directory = meta.dir
     output_filename = NumericalEarth.DataWrangling.metadata_filename(meta)

--- a/src/DataWrangling/ERA5/ERA5_land.jl
+++ b/src/DataWrangling/ERA5/ERA5_land.jl
@@ -123,3 +123,48 @@ groups consecutive same-year dates together and opens each yearly file once
 function DataWrangling.build_filename(dataset::ERA5LandDataset, name, dates::AbstractArray, region)
     return DatewiseFilename([DataWrangling.metadata_filename(dataset, name, d, region) for d in dates])
 end
+
+#####
+##### Download interface
+#####
+##### These Land-specific methods are strictly more specific than the generic
+##### `Metadatum{<:ERA5Dataset}` methods defined by the CDS backend extensions,
+##### so ERA5-Land metadata routes here under any extension load order and can
+##### never fall into the single-level request builders (issue #530).
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the path of the yearly ERA5-Land file containing `metadatum`, downloading it
+via [`download_era5_land`](@ref) unless `skip_existing` (default `true`) finds it
+already on disk.
+"""
+function Downloads.download(metadatum::ERA5LandMetadatum; skip_existing = true, kw...)
+    path = metadata_path(metadatum)
+    skip_existing && isfile(path) && return path
+    return download_era5_land(metadatum; skip_existing, kw...)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Download ERA5-Land data for each date in `metadata`, returning the paths of the
+yearly files (repeated for dates that share a year).
+"""
+function Downloads.download(metadata::ERA5LandMetadata; kw...)
+    return [Downloads.download(metadatum; kw...) for metadatum in metadata]
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Download the yearly ERA5-Land file containing `metadatum` from the Copernicus
+Climate Data Store and return its path.
+
+Implemented in `ext/NumericalEarthCopernicusClimateDataStoreExt.jl` when
+CopernicusClimateDataStore is loaded; the fallback below fires only when the
+extension is not active.
+"""
+download_era5_land(metadatum; kw...) =
+    error("Downloading ERA5-Land requires the CopernicusClimateDataStore package; ",
+          "load it with `using CopernicusClimateDataStore`.")

--- a/src/DataWrangling/ERA5/ERA5_land.jl
+++ b/src/DataWrangling/ERA5/ERA5_land.jl
@@ -127,10 +127,6 @@ end
 #####
 ##### Download interface
 #####
-##### These Land-specific methods are strictly more specific than the generic
-##### `Metadatum{<:ERA5Dataset}` methods defined by the CDS backend extensions,
-##### so ERA5-Land metadata routes here under any extension load order and can
-##### never fall into the single-level request builders (issue #530).
 
 """
 $(TYPEDSIGNATURES)

--- a/test/test_copernicus_climate_datastore.jl
+++ b/test/test_copernicus_climate_datastore.jl
@@ -235,6 +235,28 @@ const CDSExt = Base.get_extension(NumericalEarth, :NumericalEarthCopernicusClima
         for dataset in (ERA5HourlyLand(), ERA5MonthlyLand())
             metadatum = Metadatum(:skin_temperature; dataset, date)
             @test hasmethod(Downloads.download, Tuple{typeof(metadatum)})
+
+            # Ownership (issue #530): `Downloads.download` for ERA5-Land metadata is the
+            # src method, which outranks any extension's generic `Metadatum{<:ERA5Dataset}`
+            # method under any load order; the CDS backend enters via `download_era5_land`.
+            @test which(Downloads.download, Tuple{typeof(metadatum)}).module ===
+                  NumericalEarth.DataWrangling.ERA5
+
+            metadata = Metadata(:skin_temperature; dataset, dates=[date, DateTime(2020, 6, 1)])
+            @test which(Downloads.download, Tuple{typeof(metadata)}).module ===
+                  NumericalEarth.DataWrangling.ERA5
+
+            # This extension implements the `download_era5_land` stub.
+            @test which(NumericalEarth.DataWrangling.ERA5.download_era5_land,
+                        Tuple{typeof(metadatum)}).module === CDSExt
+        end
+
+        # A file already on disk short-circuits the download without touching any backend.
+        mktempdir() do dir
+            metadatum = Metadatum(:skin_temperature; dataset=ERA5MonthlyLand(), date, dir)
+            path = NumericalEarth.DataWrangling.metadata_path(metadatum)
+            touch(path)
+            @test Downloads.download(metadatum) == path
         end
 
         # Land datasets have their own yearly-file download method and are NOT


### PR DESCRIPTION
Both ERA5 extensions define the same generic `Downloads.download(::Metadatum{<:ERA5Dataset})`, so whichever loads last owns every ERA5 download — with only CDSAPI loaded, ERA5-Land metadata fell into the single-level request builder and threw `KeyError: key :soil_temperature_level_3 not found`. ERA5-Land metadata now dispatches to Land-specific `Downloads.download` methods in src that outrank the extensions' generics under any load order.

- `src/DataWrangling/ERA5/ERA5_land.jl`: `Downloads.download(::ERA5LandMetadatum)` returns cached files directly, otherwise calls a new `download_era5_land` stub whose fallback errors with "load `CopernicusClimateDataStore`"; a `Metadata` method loops over metadatums.
- `ext/NumericalEarthCopernicusClimateDataStoreExt.jl`: the existing yearly-file month-chunked Land download now implements the stub instead of defining `Downloads.download` itself. The CDSAPI extension is unchanged.
- Tests (network-free): dispatch ownership via `which`, stub implementation module, and cached-file short-circuit.

Verified in a fresh env with the regional file cached, `region = BoundingBox(longitude = (-99.35, -95.65), latitude = (35.1, 38.1))`:

```julia
using NumericalEarth, Oceananigans, CDSAPI, Dates  # CDSAPI only — failed with KeyError before
m = Metadatum(:soil_temperature_level_3; dataset = ERA5MonthlyLand(), region, date = DateTime(2016, 8, 1))
Field(m)  # ✓ reads the cached yearly file
```

- CDSAPI only: `Field(m)` succeeds; `download(m; skip_existing=false)` throws the actionable CopernicusClimateDataStore message, not a KeyError
- CopernicusClimateDataStore only: `Field(m)` succeeds
- Both loaded (CDSAPI first): `Field(m)` succeeds

Remaining benign overlap: both extensions still define the generic single-level `Downloads.download(::Metadatum{<:ERA5Dataset})`, so last-loaded still wins there — both implementations work.

Fixes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)