### PR TITLE
Sellers soil surface resistance for the moist-soil branch of CanopyAirSpace

### DIFF
--- a/docs/src/NumericalEarth.bib
+++ b/docs/src/NumericalEarth.bib
@@ -193,6 +193,17 @@
   doi     = {10.1111/j.1365-2486.2012.02790.x}
 }
 
+@article{sellers1992,
+  author  = {Sellers, Piers J. and Heiser, Mark D. and Hall, Forrest G.},
+  title   = {Relations between surface conductance and spectral vegetation indices at intermediate (100 m$^2$ to 15 km$^2$) length scales},
+  journal = {Journal of Geophysical Research: Atmospheres},
+  volume  = {97},
+  number  = {D17},
+  pages   = {19033--19059},
+  year    = {1992},
+  doi     = {10.1029/92JD01096}
+}
+
 @article{zeng2005undercanopy,
   author  = {Zeng, Xubin and Dickinson, Robert E. and Barlage, Michael and Dai, Yongjiu and Wang, Guiling and Oleson, Keith},
   title   = {Treatment of undercanopy turbulence in land models},

--- a/src/EarthSystemModels/EarthSystemModels.jl
+++ b/src/EarthSystemModels/EarthSystemModels.jl
@@ -27,6 +27,7 @@ export
     ConstantUndercanopyConductance,
     AreaIndexUndercanopyConductance,
     FrictionVelocityUndercanopyConductance,
+    SellersSoilResistance,
     TiledLandInterface,
     bare_canopy_air_space,
     leaf_area_index_cover_fraction,

--- a/src/EarthSystemModels/InterfaceComputations/InterfaceComputations.jl
+++ b/src/EarthSystemModels/InterfaceComputations/InterfaceComputations.jl
@@ -59,6 +59,7 @@ export
     ConstantUndercanopyConductance,
     AreaIndexUndercanopyConductance,
     FrictionVelocityUndercanopyConductance,
+    SellersSoilResistance,
     TiledLandInterface,
     bare_canopy_air_space,
     leaf_area_index_cover_fraction,

--- a/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
+++ b/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
@@ -242,6 +242,53 @@ undercanopy_conductance_model(x::Number, FT) = ConstantUndercanopyConductance(co
 undercanopy_conductance_model(x::AbstractUndercanopyConductance, FT) = x
 
 """
+    SellersSoilResistance(FT = Oceananigans.defaults.FloatType;
+                          intercept = 8.206, slope = 4.255)
+
+Soil surface resistance for the moist-soil (vanishing dry layer) evaporation branch
+of a [`CanopyAirSpace`](@ref),
+
+```math
+rˢ = e^{a - b 𝒮},
+```
+
+with the surface saturation `𝒮` ([Sellers et al. (1992)](@cite sellers1992)). Even a
+saturated soil surface resists evaporation (`rˢ(1) ≈ 52` s m⁻¹), so the moist branch
+no longer behaves like open water: without it, the saturated-skin branch evaporates
+through the undercanopy aerodynamic conductance alone.
+
+```jldoctest
+using NumericalEarth
+
+SellersSoilResistance()
+
+# output
+SellersSoilResistance(a=8.206, b=4.255)
+```
+"""
+struct SellersSoilResistance{FT}
+    intercept :: FT
+    slope     :: FT
+end
+
+SellersSoilResistance(FT::Type = Oceananigans.defaults.FloatType;
+                      intercept = 8.206, slope = 4.255) =
+    SellersSoilResistance(convert(FT, intercept), convert(FT, slope))
+
+Base.summary(r::SellersSoilResistance) =
+    string("SellersSoilResistance(a=", prettysummary(r.intercept),
+           ", b=", prettysummary(r.slope), ")")
+Base.show(io::IO, r::SellersSoilResistance) = print(io, summary(r))
+
+@inline soil_surface_resistance(::Nothing, 𝒮) = zero(𝒮)
+@inline function soil_surface_resistance(r::SellersSoilResistance, 𝒮)
+    FT = typeof(𝒮)
+    a  = convert(FT, r.intercept)
+    b  = convert(FT, r.slope)
+    return exp(a - b * clamp(𝒮, zero(FT), one(FT)))
+end
+
+"""
     struct CanopyAirSpace
 
 Two-source canopy + soil surface with a diagnostic canopy-air node. Solves the
@@ -263,12 +310,15 @@ Fields:
   a `Number` (m s⁻¹, wrapped as [`ConstantUndercanopyConductance`](@ref)), an
   [`AreaIndexUndercanopyConductance`](@ref) (PALADYN: canopy density and wind), or a
   [`FrictionVelocityUndercanopyConductance`](@ref) (CLM5: canopy density and `u★`).
+- `wet_soil_resistance` : soil surface resistance in series with `gᵘᶜ` on the moist-soil
+  (vanishing dry layer) vapor branch (a [`SellersSoilResistance`](@ref), the default), or
+  `nothing` for an unresisted saturated skin.
 - `inner_iterations`, `relaxation` : damped-Newton settings for the coupled solve.
 - `interception` : wet-canopy vapor branch parameters (a [`CanopyInterception`](@ref)),
   or `nothing` for a dry canopy (the default; recovers the current CAS bit-for-bit).
 - `phase` : saturation phase (Liquid).
 """
-struct CanopyAirSpace{S, C, RF, FT, U, I, Φ}
+struct CanopyAirSpace{S, C, RF, FT, U, W, I, Φ}
     soil                      :: S
     canopy                    :: C
     soil_skin_flux             :: RF
@@ -280,6 +330,7 @@ struct CanopyAirSpace{S, C, RF, FT, U, I, Φ}
     clumping                  :: FT
     leaf_boundary_conductance :: FT
     undercanopy_conductance   :: U
+    wet_soil_resistance       :: W
     inner_iterations          :: Int
     relaxation                :: FT
     interception              :: I
@@ -298,6 +349,7 @@ function CanopyAirSpace(FT=Oceananigans.defaults.FloatType;
                         clumping                  = 1,
                         leaf_boundary_conductance = 0.02,
                         undercanopy_conductance   = 0.013,
+                        wet_soil_resistance       = SellersSoilResistance(FT),
                         inner_iterations          = 40,
                         relaxation                = 1//2,
                         interception              = nothing,
@@ -309,6 +361,7 @@ function CanopyAirSpace(FT=Oceananigans.defaults.FloatType;
                           convert(FT, extinction), convert(FT, clumping),
                           convert(FT, leaf_boundary_conductance),
                           undercanopy_conductance_model(undercanopy_conductance, FT),
+                          wet_soil_resistance,
                           inner_iterations, convert(FT, relaxation), interception, phase)
 end
 
@@ -320,7 +373,8 @@ Adapt.adapt_structure(to, c::CanopyAirSpace) =
     CanopyAirSpace(adapt(to, c.soil), adapt(to, c.canopy), c.soil_skin_flux,
                    c.leaf_albedo, c.ground_albedo, c.canopy_emissivity_max, c.ground_emissivity,
                    c.extinction, c.clumping, c.leaf_boundary_conductance,
-                   c.undercanopy_conductance, c.inner_iterations, c.relaxation,
+                   c.undercanopy_conductance, c.wet_soil_resistance,
+                   c.inner_iterations, c.relaxation,
                    c.interception, c.phase)
 
 # Materialization / identity — delegate to the sub-models so the per-cell interface
@@ -391,7 +445,10 @@ uses the `Δ`-multiplied Kirchhoff form so it stays finite as the flux vanishes.
 
     gˡʰ = ρᵃᵗ * cᵖ * LAI * c.leaf_boundary_conductance
     gᵍʰ = ρᵃᵗ * cᵖ * gᵘᶜ
-    gᵍʷ = ρᵃᵗ * gᵘᶜ   # undercanopy vapor conductance (wet-soil limit)
+    # Moist-soil vapor conductance: the undercanopy aerodynamic path in series with the
+    # soil surface resistance, so a vanishing dry layer does not evaporate like open water.
+    rᵍʷ = soil_surface_resistance(c.wet_soil_resistance, Ψₛ.hydrology.saturation)
+    gᵍʷ = ρᵃᵗ * gᵘᶜ / (1 + gᵘᶜ * rᵍʷ)
     Λ   = convert(FT, skin_conductance(c.soil_skin_flux))
 
     # Leaf boundary-layer vapor mass conductance `gʷ = ρᵃᵗ·LAI·gᵇ`: in series with the

--- a/src/EarthSystemModels/InterfaceComputations/tiled_land_interface.jl
+++ b/src/EarthSystemModels/InterfaceComputations/tiled_land_interface.jl
@@ -70,6 +70,7 @@ function bare_canopy_air_space(c::CanopyAirSpace; undercanopy_conductance = c.un
                           c.leaf_albedo, c.ground_albedo, c.canopy_emissivity_max, c.ground_emissivity,
                           c.extinction, c.clumping, c.leaf_boundary_conductance,
                           undercanopy_conductance_model(undercanopy_conductance, FT),
+                          c.wet_soil_resistance,
                           c.inner_iterations, c.relaxation, nothing, c.phase)
 end
 

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -65,6 +65,7 @@ export
     ConstantUndercanopyConductance,
     AreaIndexUndercanopyConductance,
     FrictionVelocityUndercanopyConductance,
+    SellersSoilResistance,
     TiledLandInterface,
     bare_canopy_air_space,
     leaf_area_index_cover_fraction,


### PR DESCRIPTION
With a vanishing dry layer the soil branch of `CanopyAirSpace` evaporates a saturated skin through the undercanopy aerodynamic conductance alone, so moist soil behaves like open water: in HI-SCALE SGP runs (LAI ≈ 2–3) the shaded ground evaporated 300–460 W m⁻², sustained by downward sensible heat from the canopy air, pinning the domain Bowen ratio near zero. This PR puts the empirical [Sellers et al. (1992)](https://doi.org/10.1029/92JD01096) FIFE surface resistance in series with that conductance on the moist-soil vapor branch:

```
rˢ(𝒮) = exp(8.206 − 4.255 𝒮)   [s m⁻¹]
gᵍʷ = ρ gᵘᶜ / (1 + gᵘᶜ rˢ)  ≡  ρ / (1/gᵘᶜ + rˢ)
```

Against the default undercanopy resistance `1/gᵘᶜ = 77 s m⁻¹`:

| 𝒮 | rˢ (s m⁻¹) | soil evaporation vs unresisted |
|-----|-----|------|
| 1.0 | 52 | 0.60 |
| 0.7 | 186 | 0.29 |
| 0.4 | 668 | 0.10 |

## Public API

- New `SellersSoilResistance` (exported): `rˢ = exp(intercept − slope·𝒮)`, defaults 8.206 and 4.255, saturation clamped to [0, 1].
- `CanopyAirSpace(wet_soil_resistance = ...)`: a `SellersSoilResistance` (the default) or `nothing`, which restores the previous unresisted behavior bit-for-bit.
- On by default, so moist-soil results change (less soil evaporation, warmer skins). The `Adapt` rule (#531) and `bare_canopy_air_space` carry the field, so GPU runs and the bare tile of a `TiledLandInterface` get the same physics.

## Limitations (addressed by #543)

- The fit is an *effective soil-plus-litter* resistance, not pore-scale soil physics: the FIFE prairie sites carried standing dead grass and litter, which [Sakaguchi and Zeng (2009)](https://doi.org/10.1029/2008JD010834) identify as the source of the fit's wet-end value (litter-free wet soil measures near zero). #543 makes the litter resistance explicit and turns this fit into an opt-in alternative.
- The resistance applies to the wet branch only, and the dry-layer branch bypasses the undercanopy conductance entirely, so soil evaporation rebounds ≈ 3× as the soil dries through the branch handoff before the deepening dry layer chokes it again. #543 puts both branches in series with the same ground path, making evaporation monotone in drying.
- The resistance also damps downward vapor flux, so dew deposition on moist soil is reduced by the same factor (×0.6 at saturation); CLM-lineage models drop the soil resistance for dew.

## MWE

2×2 cells, LAI 2, u = 4 m s⁻¹:

```julia
using NumericalEarth, Oceananigans
using Oceananigans.TimeSteppers: update_state!

grid = LatitudeLongitudeGrid(size = (2, 2, 1), latitude = (36, 37), longitude = (-98, -97),
                             z = (-1, 0), topology = (Bounded, Bounded, Bounded))
atmosphere = PrescribedAtmosphere(grid; surface_layer_height = 10, boundary_layer_height = 512)
fill!(parent(atmosphere.temperature), 300)
fill!(parent(atmosphere.specific_humidity), 0.01)
fill!(parent(atmosphere.velocities.u), 4)
fill!(parent(atmosphere.pressure), 101325)

land = SlabLand(grid)
set!(land; T = 300, M = 150)   # saturated bucket (capacity 150)

leaf_area_index = Field{Center, Center, Nothing}(grid)
set!(leaf_area_index, 2)

canopy_air_space = CanopyAirSpace(;
    soil = DryLayerHumidity(; dry_layer_depth = StorageBasedDryLayerDepth(maximum_dry_layer_depth = 0.05,
                                                                          dry_layer_onset_saturation = 0.4),
                            vapor_exchange = DryLayerVaporPistonVelocity(minimum_dry_layer_depth = 1e-3,
                                                                         molecular_diffusivity = 2.4e-5),
                            thermal_exchange_depth = 0.05, porosity = 0.4),
    canopy = CanopyConductanceHumidity(; leaf_area_index))    # or wet_soil_resistance = nothing

model = AtmosphereLandModel(atmosphere, land;
                            atmosphere_land_interface_temperature = canopy_air_space,
                            atmosphere_land_interface_specific_humidity = canopy_air_space,
                            radiation = nothing)
update_state!(model)
Array(interior(model.interfaces.atmosphere_land_interface.fluxes.latent_heat))[1, 1, 1]
```

gives 170.6 W m⁻² unresisted vs 153.2 W m⁻² resisted at saturation 1.0, and 170.7 vs 106.5 W m⁻² at saturation 0.66 (`M = 100`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
