### PR TITLE
Reduce building_morphometry in latitude bands when the region raster exceeds a memory limit

### DIFF
--- a/ext/NumericalEarthArchGDALExt/NumericalEarthArchGDALExt.jl
+++ b/ext/NumericalEarthArchGDALExt/NumericalEarthArchGDALExt.jl
@@ -19,7 +19,7 @@ using NumericalEarth.DataWrangling.ASTERGED: asterged_short_name, asterged_versi
                                              broadband_map, place_tile!,
                                              OGAWA_SCHMUGGE_2004_BROADBAND_COEFFICIENTS
 using NumericalEarth.DataWrangling.GloBFP3D: GlobalBuildingFootprints3DMetadatum,
-                                             GLOBFP3D_FIGSHARE_ARTICLE_IDS,
+                                             GLOBFP3D_FIGSHARE_ARTICLE_IDS, NoIntersectingTilesError,
                                              globfp3d_parse_tile_bounds,
                                              globfp3d_native_cell_size
 using NumericalEarth.DataWrangling.GHSL: GHSBuiltS, GHSLMetadatum, native_resolution,

--- a/ext/NumericalEarthArchGDALExt/NumericalEarthArchGDALExt.jl
+++ b/ext/NumericalEarthArchGDALExt/NumericalEarthArchGDALExt.jl
@@ -19,7 +19,7 @@ using NumericalEarth.DataWrangling.ASTERGED: asterged_short_name, asterged_versi
                                              broadband_map, place_tile!,
                                              OGAWA_SCHMUGGE_2004_BROADBAND_COEFFICIENTS
 using NumericalEarth.DataWrangling.GloBFP3D: GlobalBuildingFootprints3DMetadatum,
-                                             GLOBFP3D_FIGSHARE_ARTICLE_IDS, NoIntersectingTilesError,
+                                             GLOBFP3D_FIGSHARE_ARTICLE_IDS,
                                              globfp3d_parse_tile_bounds,
                                              globfp3d_native_cell_size
 using NumericalEarth.DataWrangling.GHSL: GHSBuiltS, GHSLMetadatum, native_resolution,

--- a/ext/NumericalEarthArchGDALExt/globfp3d.jl
+++ b/ext/NumericalEarthArchGDALExt/globfp3d.jl
@@ -144,7 +144,7 @@ function NumericalEarth.DataWrangling.GloBFP3D.globfp3d_rasterize_to_netcdf(
     cache_dir = joinpath(dirname(nc_path), "tiles")
     catalog = globfp3d_tile_catalog(cache_dir)
     tiles = filter(e -> bounding_box_intersects(e, region), catalog)
-    isempty(tiles) && throw(NoIntersectingTilesError(region))
+    isempty(tiles) && return nothing   # no file: `Downloads.download` reports no intersecting tiles
 
     Δ = globfp3d_native_cell_size(dataset)
     grid = native_region_grid(region, Δ, Δ)

--- a/ext/NumericalEarthArchGDALExt/globfp3d.jl
+++ b/ext/NumericalEarthArchGDALExt/globfp3d.jl
@@ -144,8 +144,7 @@ function NumericalEarth.DataWrangling.GloBFP3D.globfp3d_rasterize_to_netcdf(
     cache_dir = joinpath(dirname(nc_path), "tiles")
     catalog = globfp3d_tile_catalog(cache_dir)
     tiles = filter(e -> bounding_box_intersects(e, region), catalog)
-    isempty(tiles) &&
-        error("No 3D-GloBFP tiles intersect the requested region $(summary(region)).")
+    isempty(tiles) && throw(NoIntersectingTilesError(region))
 
     Δ = globfp3d_native_cell_size(dataset)
     grid = native_region_grid(region, Δ, Δ)

--- a/src/DataWrangling/GloBFP3D/GloBFP3D.jl
+++ b/src/DataWrangling/GloBFP3D/GloBFP3D.jl
@@ -4,8 +4,7 @@ export GlobalBuildingFootprints3D, building_morphometry
 
 using Downloads: Downloads
 using Oceananigans: Center, Face
-using Oceananigans.Architectures: architecture, on_architecture
-using Oceananigans.Fields: Field, interior
+using Oceananigans.Fields: Field, set!
 using Oceananigans.Grids: LatitudeLongitudeGrid, λnodes, φnodes
 using Oceananigans.DistributedComputations: @root
 
@@ -239,11 +238,10 @@ function reduced_morphometry(target_grid, metadatum)
 end
 
 function morphometry_fields(reduced, target_grid)
-    arch = architecture(target_grid)
     return map(reduced) do array
         field = Field{Center, Center, Nothing}(target_grid)
-        interior(field) .= on_architecture(arch, reshape(array, size(array, 1), size(array, 2), 1))
-        field
+        set!(field, array)
+        return field
     end
 end
 
@@ -265,8 +263,9 @@ function morphometry_latitude_bands(target_grid, region, Δ, maximum_raster_cell
     band_region(j₁, j₂) = BoundingBox(longitude = region.longitude,
                                       latitude = (max(φfaces[j₁] - padding * Δ, south),
                                                   min(φfaces[j₂ + 1] + padding * Δ, north)))
-    band_cells(j₁, j₂) = let raster = native_region_grid(band_region(j₁, j₂), Δ, Δ)
-        raster.Nx * raster.Ny
+    function band_cells(j₁, j₂)
+        raster = native_region_grid(band_region(j₁, j₂), Δ, Δ)
+        return raster.Nx * raster.Ny
     end
 
     # Rows the single-pass raster reaches, including its 2-cell snap pad beyond the region;
@@ -319,13 +318,13 @@ function building_morphometry(target_grid::LatitudeLongitudeGrid; dataset = Glob
     raster = native_region_grid(region, Δ, Δ)
     if raster.Nx * raster.Ny <= maximum_raster_cells
         reduced = reduced_morphometry(target_grid, metadatum)
-        isnothing(reduced) &&
-            error("No 3D-GloBFP tiles intersect the requested region $(summary(region)).")
+        isnothing(reduced) && error("No 3D-GloBFP tiles intersect the requested region $(summary(region)).")
         return morphometry_fields(reduced, target_grid)
     end
 
     # A band bounding box also selects the footprint tiles to burn: pad it by ~200 m of native
-    # cells so buildings overhanging a tile just outside the band still land in the band's rows.
+    # cells (`cld` is ceiling division) so buildings overhanging a tile just outside the band
+    # still land in the band's rows.
     padding = cld(200, globfp3d_native_resolution(dataset))
     bands = morphometry_latitude_bands(target_grid, region, Δ, maximum_raster_cells, padding)
     @info string(summary(dataset), ": reducing the ", raster.Nx, " × ", raster.Ny,

--- a/src/DataWrangling/GloBFP3D/GloBFP3D.jl
+++ b/src/DataWrangling/GloBFP3D/GloBFP3D.jl
@@ -229,9 +229,20 @@ end
 const morphometry_names = (:mean_building_height, :building_height_deviation, :maximum_building_height,
                            :plan_area_index, :frontal_area_index, :gross_building_height)
 
-# Download, read, and reduce the fine raster of one `region` onto (the covered rows of) `target_grid`.
-function reduced_morphometry(target_grid, dataset, region)
-    metadatum = Metadatum(:building_height; dataset, region)
+"""
+    NoIntersectingTilesError(region)
+
+No 3D-GloBFP tile intersects `region`: the dataset has no building footprints there.
+"""
+struct NoIntersectingTilesError{R} <: Exception
+    region :: R
+end
+
+Base.showerror(io::IO, error::NoIntersectingTilesError) =
+    print(io, "No 3D-GloBFP tiles intersect the requested region ", summary(error.region), ".")
+
+# Download, read, and reduce the fine raster of one metadatum onto (the covered rows of) `target_grid`.
+function reduced_morphometry(target_grid, metadatum)
     Downloads.download(metadatum)
     height = DataWrangling.retrieve_data(metadatum)
     longitudes, latitudes = DataWrangling.read_file_coords(metadatum)
@@ -305,16 +316,20 @@ over `region`. Returns a NamedTuple of `Field`s:
 
 A `region` whose native raster exceeds `maximum_raster_cells` (default `400_000_000` cells,
 3.2 GB of `Float64`) is processed in latitude bands sized to the limit, so memory stays bounded
-regardless of the region size.
+regardless of the region size. Each band's raster file is deleted once reduced (the downloaded
+footprint tiles stay cached), so disk usage stays bounded too.
 
 Downloading and rasterizing the footprints requires `using ArchGDAL`.
 """
 function building_morphometry(target_grid::LatitudeLongitudeGrid; dataset = GlobalBuildingFootprints3D(),
                               region, maximum_raster_cells = 400_000_000)
+    metadatum = Metadatum(:building_height; dataset, region)
+    DataWrangling.validate_dataset_coverage(nothing, metadatum)
+
     Δ = globfp3d_native_cell_size(dataset)
     raster = native_region_grid(region, Δ, Δ)
     raster.Nx * raster.Ny <= maximum_raster_cells &&
-        return morphometry_fields(reduced_morphometry(target_grid, dataset, region), target_grid)
+        return morphometry_fields(reduced_morphometry(target_grid, metadatum), target_grid)
 
     # A band bounding box also selects the footprint tiles to burn: pad it by ~200 m of native
     # cells so buildings overhanging a tile just outside the band still land in the band's rows.
@@ -327,20 +342,25 @@ function building_morphometry(target_grid::LatitudeLongitudeGrid; dataset = Glob
     Nx = size(target_grid, 1)
     Ny = size(target_grid, 2)
     accumulated = NamedTuple{morphometry_names}(ntuple(_ -> zeros(Float64, Nx, Ny), length(morphometry_names)))
+    any_tiles = false
     for (b, band) in enumerate(bands)
         @info string("Reducing latitude band ", b, " of ", length(bands),
                      " (target rows ", band.rows, ", ", latitude_summary(band.region.latitude), ")...")
+        band_metadatum = Metadatum(:building_height; dataset, region = band.region)
         reduced = try
-            reduced_morphometry(target_grid, dataset, band.region)
+            reduced_morphometry(target_grid, band_metadatum)
         catch exception
             # An all-water/unbuilt band intersects no tiles and reduces to zero, as in a single pass.
-            (exception isa ErrorException && occursin("No 3D-GloBFP tiles intersect", exception.msg)) || rethrow()
+            exception isa NoIntersectingTilesError || rethrow()
             continue
         end
+        any_tiles = true
+        @root rm(metadata_path(band_metadatum); force = true)
         for name in morphometry_names
             accumulated[name][:, band.rows] .= reduced[name][:, band.rows]
         end
     end
+    any_tiles || throw(NoIntersectingTilesError(region))
 
     return morphometry_fields(accumulated, target_grid)
 end

--- a/src/DataWrangling/GloBFP3D/GloBFP3D.jl
+++ b/src/DataWrangling/GloBFP3D/GloBFP3D.jl
@@ -229,21 +229,10 @@ end
 const morphometry_names = (:mean_building_height, :building_height_deviation, :maximum_building_height,
                            :plan_area_index, :frontal_area_index, :gross_building_height)
 
-"""
-    NoIntersectingTilesError(region)
-
-No 3D-GloBFP tile intersects `region`: the dataset has no building footprints there.
-"""
-struct NoIntersectingTilesError{R} <: Exception
-    region :: R
-end
-
-Base.showerror(io::IO, error::NoIntersectingTilesError) =
-    print(io, "No 3D-GloBFP tiles intersect the requested region ", summary(error.region), ".")
-
-# Download, read, and reduce the fine raster of one metadatum onto (the covered rows of) `target_grid`.
+# Download, read, and reduce the fine raster of one metadatum onto (the covered rows of)
+# `target_grid`. Returns `nothing` when no tiles intersect the metadatum's region.
 function reduced_morphometry(target_grid, metadatum)
-    Downloads.download(metadatum)
+    isnothing(Downloads.download(metadatum)) && return nothing
     height = DataWrangling.retrieve_data(metadatum)
     longitudes, latitudes = DataWrangling.read_file_coords(metadatum)
     return reduce_morphometry(height, longitudes, latitudes, target_grid)
@@ -298,9 +287,12 @@ function morphometry_latitude_bands(target_grid, region, Δ, maximum_raster_cell
     return [(rows = rows, region = band_region(first(rows), last(rows))) for rows in ranges]
 end
 
+# ~3.2 GB of Float64: the largest raster reduced in one pass unless `single_pass` forces it.
+const maximum_single_pass_cells = 400_000_000
+
 """
     building_morphometry(target_grid; dataset = GlobalBuildingFootprints3D(), region,
-                         maximum_raster_cells = 400_000_000)
+                         single_pass = false)
 
 Per-cell building morphometry on `target_grid` (a `LatitudeLongitudeGrid`, coarser than the
 `dataset` rasterization resolution), aggregated from the fine 3D-GloBFP building-height raster
@@ -314,30 +306,41 @@ over `region`. Returns a NamedTuple of `Field`s:
 - `frontal_area_index` `λᶠ` — windward wall area from height steps, direction-averaged:
   `(Σₓ|δh|·dy + Σᵧ|δh|·dx) / (4·A)`, with `A` the cell area.
 
-A `region` whose native raster exceeds `maximum_raster_cells` (default `400_000_000` cells,
-3.2 GB of `Float64`) is processed in latitude bands sized to the limit, so memory stays bounded
-regardless of the region size. Each band's raster file is deleted once reduced (the downloaded
-footprint tiles stay cached), so disk usage stays bounded too.
+A `region` whose native raster exceeds an internal single-pass budget (400M cells, 3.2 GB of
+`Float64`) is reduced in latitude bands sized to that budget, reproducing the single pass exactly
+while memory stays bounded regardless of the region size; band raster files are deleted once
+reduced (the downloaded footprint tiles stay cached). Pass `single_pass = true` to force one pass
+over the whole `region` regardless of its raster size.
 
 Downloading and rasterizing the footprints requires `using ArchGDAL`.
 """
 function building_morphometry(target_grid::LatitudeLongitudeGrid; dataset = GlobalBuildingFootprints3D(),
-                              region, maximum_raster_cells = 400_000_000)
+                              region, single_pass = false)
     metadatum = Metadatum(:building_height; dataset, region)
     DataWrangling.validate_dataset_coverage(nothing, metadatum)
 
     Δ = globfp3d_native_cell_size(dataset)
     raster = native_region_grid(region, Δ, Δ)
-    raster.Nx * raster.Ny <= maximum_raster_cells &&
-        return morphometry_fields(reduced_morphometry(target_grid, metadatum), target_grid)
+    if single_pass || raster.Nx * raster.Ny <= maximum_single_pass_cells
+        reduced = reduced_morphometry(target_grid, metadatum)
+        isnothing(reduced) &&
+            error("No 3D-GloBFP tiles intersect the requested region $(summary(region)).")
+        return morphometry_fields(reduced, target_grid)
+    end
+
+    return banded_building_morphometry(target_grid, dataset, region, maximum_single_pass_cells)
+end
+
+function banded_building_morphometry(target_grid, dataset, region, maximum_raster_cells)
+    Δ = globfp3d_native_cell_size(dataset)
+    raster = native_region_grid(region, Δ, Δ)
 
     # A band bounding box also selects the footprint tiles to burn: pad it by ~200 m of native
     # cells so buildings overhanging a tile just outside the band still land in the band's rows.
     padding = cld(200, globfp3d_native_resolution(dataset))
     bands = morphometry_latitude_bands(target_grid, region, Δ, maximum_raster_cells, padding)
-    @info string(summary(dataset), ": the raster over ", summary(region), " has ",
-                 raster.Nx, " × ", raster.Ny, " cells, above maximum_raster_cells = ",
-                 maximum_raster_cells, "; reducing in ", length(bands), " latitude bands.")
+    @info string(summary(dataset), ": reducing the ", raster.Nx, " × ", raster.Ny,
+                 " cell raster over ", summary(region), " in ", length(bands), " latitude bands.")
 
     Nx = size(target_grid, 1)
     Ny = size(target_grid, 2)
@@ -347,20 +350,17 @@ function building_morphometry(target_grid::LatitudeLongitudeGrid; dataset = Glob
         @info string("Reducing latitude band ", b, " of ", length(bands),
                      " (target rows ", band.rows, ", ", latitude_summary(band.region.latitude), ")...")
         band_metadatum = Metadatum(:building_height; dataset, region = band.region)
-        reduced = try
-            reduced_morphometry(target_grid, band_metadatum)
-        catch exception
-            # An all-water/unbuilt band intersects no tiles and reduces to zero, as in a single pass.
-            exception isa NoIntersectingTilesError || rethrow()
-            continue
-        end
+        reduced = reduced_morphometry(target_grid, band_metadatum)
+        # An all-water/unbuilt band intersects no tiles and reduces to zero, as in a single pass.
+        isnothing(reduced) && continue
         any_tiles = true
         @root rm(metadata_path(band_metadatum); force = true)
         for name in morphometry_names
             accumulated[name][:, band.rows] .= reduced[name][:, band.rows]
         end
     end
-    any_tiles || throw(NoIntersectingTilesError(region))
+    isempty(bands) || any_tiles ||
+        error("No 3D-GloBFP tiles intersect the requested region $(summary(region)).")
 
     return morphometry_fields(accumulated, target_grid)
 end
@@ -396,7 +396,8 @@ function Downloads.download(metadatum::GlobalBuildingFootprints3DMetadatum)
     @root if !isfile(nc_path)
         globfp3d_rasterize_to_netcdf(metadatum, nc_path)
     end
-    return nc_path
+    # No file after rasterizing means no tiles intersect the region: an all-water/unbuilt window.
+    return isfile(nc_path) ? nc_path : nothing
 end
 
 # Implemented in ext/NumericalEarthArchGDALExt/globfp3d.jl.

--- a/src/DataWrangling/GloBFP3D/GloBFP3D.jl
+++ b/src/DataWrangling/GloBFP3D/GloBFP3D.jl
@@ -287,12 +287,9 @@ function morphometry_latitude_bands(target_grid, region, Δ, maximum_raster_cell
     return [(rows = rows, region = band_region(first(rows), last(rows))) for rows in ranges]
 end
 
-# ~3.2 GB of Float64: the largest raster reduced in one pass unless `single_pass` forces it.
-const maximum_single_pass_cells = 400_000_000
-
 """
     building_morphometry(target_grid; dataset = GlobalBuildingFootprints3D(), region,
-                         single_pass = false)
+                         maximum_raster_cells = 400_000_000)
 
 Per-cell building morphometry on `target_grid` (a `LatitudeLongitudeGrid`, coarser than the
 `dataset` rasterization resolution), aggregated from the fine 3D-GloBFP building-height raster
@@ -306,34 +303,26 @@ over `region`. Returns a NamedTuple of `Field`s:
 - `frontal_area_index` `λᶠ` — windward wall area from height steps, direction-averaged:
   `(Σₓ|δh|·dy + Σᵧ|δh|·dx) / (4·A)`, with `A` the cell area.
 
-A `region` whose native raster exceeds an internal single-pass budget (400M cells, 3.2 GB of
-`Float64`) is reduced in latitude bands sized to that budget, reproducing the single pass exactly
-while memory stays bounded regardless of the region size; band raster files are deleted once
-reduced (the downloaded footprint tiles stay cached). Pass `single_pass = true` to force one pass
-over the whole `region` regardless of its raster size.
+A `region` whose native raster exceeds `maximum_raster_cells` (default `400_000_000` cells,
+3.2 GB of `Float64`) is reduced in latitude bands sized to the limit, reproducing the single
+pass exactly while memory stays bounded regardless of the region size; band raster files are
+deleted once reduced (the downloaded footprint tiles stay cached).
 
 Downloading and rasterizing the footprints requires `using ArchGDAL`.
 """
 function building_morphometry(target_grid::LatitudeLongitudeGrid; dataset = GlobalBuildingFootprints3D(),
-                              region, single_pass = false)
+                              region, maximum_raster_cells = 400_000_000)
     metadatum = Metadatum(:building_height; dataset, region)
     DataWrangling.validate_dataset_coverage(nothing, metadatum)
 
     Δ = globfp3d_native_cell_size(dataset)
     raster = native_region_grid(region, Δ, Δ)
-    if single_pass || raster.Nx * raster.Ny <= maximum_single_pass_cells
+    if raster.Nx * raster.Ny <= maximum_raster_cells
         reduced = reduced_morphometry(target_grid, metadatum)
         isnothing(reduced) &&
             error("No 3D-GloBFP tiles intersect the requested region $(summary(region)).")
         return morphometry_fields(reduced, target_grid)
     end
-
-    return banded_building_morphometry(target_grid, dataset, region, maximum_single_pass_cells)
-end
-
-function banded_building_morphometry(target_grid, dataset, region, maximum_raster_cells)
-    Δ = globfp3d_native_cell_size(dataset)
-    raster = native_region_grid(region, Δ, Δ)
 
     # A band bounding box also selects the footprint tiles to burn: pad it by ~200 m of native
     # cells so buildings overhanging a tile just outside the band still land in the band's rows.

--- a/src/DataWrangling/GloBFP3D/GloBFP3D.jl
+++ b/src/DataWrangling/GloBFP3D/GloBFP3D.jl
@@ -9,8 +9,8 @@ using Oceananigans.Fields: Field, interior
 using Oceananigans.Grids: LatitudeLongitudeGrid, λnodes, φnodes
 using Oceananigans.DistributedComputations: @root
 
-using ..DataWrangling: DataWrangling, AbstractStaticDataset, Metadatum,
-                       metadata_path, BoundingBox, bounding_box_suffix
+using ..DataWrangling: DataWrangling, AbstractStaticDataset, Metadatum, metadata_path,
+                       BoundingBox, bounding_box_suffix, latitude_summary, native_region_grid
 
 import Oceananigans
 
@@ -226,8 +226,70 @@ function reduce_morphometry(height, longitudes, latitudes, target_grid::Latitude
               plan_area_index, frontal_area_index, gross_building_height)
 end
 
+const morphometry_names = (:mean_building_height, :building_height_deviation, :maximum_building_height,
+                           :plan_area_index, :frontal_area_index, :gross_building_height)
+
+# Download, read, and reduce the fine raster of one `region` onto (the covered rows of) `target_grid`.
+function reduced_morphometry(target_grid, dataset, region)
+    metadatum = Metadatum(:building_height; dataset, region)
+    Downloads.download(metadatum)
+    height = DataWrangling.retrieve_data(metadatum)
+    longitudes, latitudes = DataWrangling.read_file_coords(metadatum)
+    return reduce_morphometry(height, longitudes, latitudes, target_grid)
+end
+
+function morphometry_fields(reduced, target_grid)
+    arch = architecture(target_grid)
+    return map(reduced) do array
+        field = Field{Center, Center, Nothing}(target_grid)
+        interior(field) .= on_architecture(arch, reshape(array, size(array, 1), size(array, 2), 1))
+        field
+    end
+end
+
 """
-    building_morphometry(target_grid; dataset = GlobalBuildingFootprints3D(), region)
+    morphometry_latitude_bands(target_grid, region, Δ, maximum_raster_cells, padding)
+
+Split the rows of `target_grid` covered by `region` into contiguous latitude bands whose native
+rasters (cell size `Δ` degrees) hold at most `maximum_raster_cells` cells each (a band never
+narrower than one row). Returns a vector of `(; rows, region)`: the target-grid row range and the
+`BoundingBox` to rasterize for it — the full `region` longitude, and the rows' latitude interval
+widened by `padding` native cells but clamped to the `region` latitude, so every band raster is a
+sub-window of the single-pass raster and band rows reduce identically to a single pass.
+"""
+function morphometry_latitude_bands(target_grid, region, Δ, maximum_raster_cells, padding)
+    Ny = size(target_grid, 2)
+    φfaces = φnodes(target_grid, Face())
+    south, north = region.latitude
+
+    band_region(j₁, j₂) = BoundingBox(longitude = region.longitude,
+                                      latitude = (max(φfaces[j₁] - padding * Δ, south),
+                                                  min(φfaces[j₂ + 1] + padding * Δ, north)))
+    band_cells(j₁, j₂) = let raster = native_region_grid(band_region(j₁, j₂), Δ, Δ)
+        raster.Nx * raster.Ny
+    end
+
+    # Rows the single-pass raster reaches, including its 2-cell snap pad beyond the region;
+    # rows farther out reduce to zero in a single pass too and are left out of every band.
+    j₁ = findfirst(j -> φfaces[j + 1] > south - 2Δ, 1:Ny)
+    j₊ = findlast(j -> φfaces[j] < north + 2Δ, 1:Ny)
+
+    ranges = UnitRange{Int}[]
+    while !isnothing(j₁) && !isnothing(j₊) && j₁ <= j₊
+        j₂ = j₁
+        while j₂ < j₊ && band_cells(j₁, j₂ + 1) <= maximum_raster_cells
+            j₂ += 1
+        end
+        push!(ranges, j₁:j₂)
+        j₁ = j₂ + 1
+    end
+
+    return [(rows = rows, region = band_region(first(rows), last(rows))) for rows in ranges]
+end
+
+"""
+    building_morphometry(target_grid; dataset = GlobalBuildingFootprints3D(), region,
+                         maximum_raster_cells = 400_000_000)
 
 Per-cell building morphometry on `target_grid` (a `LatitudeLongitudeGrid`, coarser than the
 `dataset` rasterization resolution), aggregated from the fine 3D-GloBFP building-height raster
@@ -241,22 +303,46 @@ over `region`. Returns a NamedTuple of `Field`s:
 - `frontal_area_index` `λᶠ` — windward wall area from height steps, direction-averaged:
   `(Σₓ|δh|·dy + Σᵧ|δh|·dx) / (4·A)`, with `A` the cell area.
 
+A `region` whose native raster exceeds `maximum_raster_cells` (default `400_000_000` cells,
+3.2 GB of `Float64`) is processed in latitude bands sized to the limit, so memory stays bounded
+regardless of the region size.
+
 Downloading and rasterizing the footprints requires `using ArchGDAL`.
 """
-function building_morphometry(target_grid::LatitudeLongitudeGrid; dataset = GlobalBuildingFootprints3D(), region)
-    metadatum = Metadatum(:building_height; dataset, region)
-    Downloads.download(metadatum)
-    height = DataWrangling.retrieve_data(metadatum)
-    longitudes, latitudes = DataWrangling.read_file_coords(metadatum)
+function building_morphometry(target_grid::LatitudeLongitudeGrid; dataset = GlobalBuildingFootprints3D(),
+                              region, maximum_raster_cells = 400_000_000)
+    Δ = globfp3d_native_cell_size(dataset)
+    raster = native_region_grid(region, Δ, Δ)
+    raster.Nx * raster.Ny <= maximum_raster_cells &&
+        return morphometry_fields(reduced_morphometry(target_grid, dataset, region), target_grid)
 
-    reduced = reduce_morphometry(height, longitudes, latitudes, target_grid)
+    # A band bounding box also selects the footprint tiles to burn: pad it by ~200 m of native
+    # cells so buildings overhanging a tile just outside the band still land in the band's rows.
+    padding = cld(200, globfp3d_native_resolution(dataset))
+    bands = morphometry_latitude_bands(target_grid, region, Δ, maximum_raster_cells, padding)
+    @info string(summary(dataset), ": the raster over ", summary(region), " has ",
+                 raster.Nx, " × ", raster.Ny, " cells, above maximum_raster_cells = ",
+                 maximum_raster_cells, "; reducing in ", length(bands), " latitude bands.")
 
-    arch = architecture(target_grid)
-    return map(reduced) do array
-        field = Field{Center, Center, Nothing}(target_grid)
-        interior(field) .= on_architecture(arch, reshape(array, size(array, 1), size(array, 2), 1))
-        field
+    Nx = size(target_grid, 1)
+    Ny = size(target_grid, 2)
+    accumulated = NamedTuple{morphometry_names}(ntuple(_ -> zeros(Float64, Nx, Ny), length(morphometry_names)))
+    for (b, band) in enumerate(bands)
+        @info string("Reducing latitude band ", b, " of ", length(bands),
+                     " (target rows ", band.rows, ", ", latitude_summary(band.region.latitude), ")...")
+        reduced = try
+            reduced_morphometry(target_grid, dataset, band.region)
+        catch exception
+            # An all-water/unbuilt band intersects no tiles and reduces to zero, as in a single pass.
+            (exception isa ErrorException && occursin("No 3D-GloBFP tiles intersect", exception.msg)) || rethrow()
+            continue
+        end
+        for name in morphometry_names
+            accumulated[name][:, band.rows] .= reduced[name][:, band.rows]
+        end
     end
+
+    return morphometry_fields(accumulated, target_grid)
 end
 
 #####

--- a/test/test_globfp3d.jl
+++ b/test/test_globfp3d.jl
@@ -3,8 +3,7 @@ include("runtests_setup.jl")
 using NumericalEarth.DataWrangling.GloBFP3D: reduce_morphometry, globfp3d_parse_tile_bounds,
                                              globfp3d_native_cell_size, globfp3d_native_resolution,
                                              globfp3d_rasterize_to_netcdf,
-                                             morphometry_latitude_bands, morphometry_names,
-                                             NoIntersectingTilesError
+                                             morphometry_latitude_bands, morphometry_names
 using NumericalEarth.DataWrangling: BoundingBox, Metadatum, native_region_grid,
                                     bounding_box_intersects, longitude_interfaces, latitude_interfaces,
                                     dataset_variable_name, validate_dataset_coverage,
@@ -130,13 +129,8 @@ end
 end
 
 @testset "GloBFP3D error paths" begin
-    dataset = GlobalBuildingFootprints3D()
-    region = BoundingBox(longitude = (-74.02, -73.93), latitude = (40.70, 40.82))
-    message = sprint(showerror, NoIntersectingTilesError(region))
-    @test occursin("No 3D-GloBFP tiles intersect", message)
-    @test occursin(summary(region), message)
-
     # An unbounded region fails validation before any raster sizing or download.
+    dataset = GlobalBuildingFootprints3D()
     target = LatitudeLongitudeGrid(CPU(), Float64; size = (4, 4),
                                    longitude = (-74.02, -73.93), latitude = (40.70, 40.82),
                                    topology = (Bounded, Bounded, Flat))

--- a/test/test_globfp3d.jl
+++ b/test/test_globfp3d.jl
@@ -2,7 +2,8 @@ include("runtests_setup.jl")
 
 using NumericalEarth.DataWrangling.GloBFP3D: reduce_morphometry, globfp3d_parse_tile_bounds,
                                              globfp3d_native_cell_size, globfp3d_native_resolution,
-                                             globfp3d_rasterize_to_netcdf
+                                             globfp3d_rasterize_to_netcdf,
+                                             morphometry_latitude_bands, morphometry_names
 using NumericalEarth.DataWrangling: BoundingBox, Metadatum, native_region_grid,
                                     bounding_box_intersects, longitude_interfaces, latitude_interfaces,
                                     dataset_variable_name, validate_dataset_coverage,
@@ -75,6 +76,56 @@ using Oceananigans.Fields: location
     @test m1.mean_building_height[1, 1]  ≈ 20
     @test m1.plan_area_index[1, 1]     ≈ 1
     @test m1.frontal_area_index[1, 1]    == 0
+end
+
+@testset "GloBFP3D banded morphometry equivalence" begin
+    # A synthetic fine raster on the native lattice stands in for the rasterized footprints:
+    # reducing it band by band with the banding machinery must reproduce the single pass.
+    dataset = GlobalBuildingFootprints3D(resolution = 2000)   # coarse, so the synthetic raster stays small
+    Δ = globfp3d_native_cell_size(dataset)
+    region = BoundingBox(longitude = (-99.35, -95.65), latitude = (35.1, 38.1))
+    raster = native_region_grid(region, Δ, Δ)
+
+    height = [50 * abs(sin(3i + 7j)) * (mod(i + j, 3) > 0) for i in 1:raster.Nx, j in 1:raster.Ny]
+    longitude = [raster.west  + (i - 1/2) * raster.Δλ for i in 1:raster.Nx]
+    latitude  = [raster.south + (j - 1/2) * raster.Δφ for j in 1:raster.Ny]
+
+    target = LatitudeLongitudeGrid(CPU(), Float64; size = (33, 30),
+                                   longitude = (-99.1497, -95.8263), latitude = (35.2730, 37.9410),
+                                   topology = (Bounded, Bounded, Flat))
+
+    single = reduce_morphometry(height, longitude, latitude, target)
+    @test keys(single) == morphometry_names
+
+    maximum_raster_cells = raster.Nx * (raster.Ny ÷ 5)
+    padding = 3
+    bands = morphometry_latitude_bands(target, region, Δ, maximum_raster_cells, padding)
+    @test length(bands) >= 3
+
+    # The grid sits strictly inside the region: the bands partition all its rows contiguously.
+    @test first(first(bands).rows) == 1
+    @test last(last(bands).rows) == size(target, 2)
+    @test all(first(bands[k + 1].rows) == last(bands[k].rows) + 1 for k in 1:length(bands) - 1)
+
+    accumulated = map(zero, single)
+    for band in bands
+        window = native_region_grid(band.region, Δ, Δ)
+        @test window.Nx * window.Ny <= maximum_raster_cells || length(band.rows) == 1
+        i₀ = round(Int, (window.west  - raster.west)  / Δ)
+        j₀ = round(Int, (window.south - raster.south) / Δ)
+        @test i₀ == 0 && window.Nx == raster.Nx      # bands span the full region longitude
+        @test 0 <= j₀ && j₀ + window.Ny <= raster.Ny # each band raster is a sub-window of the single-pass raster
+        band_height   = height[:, j₀ + 1 : j₀ + window.Ny]
+        band_latitude = [window.south + (j - 1/2) * Δ for j in 1:window.Ny]
+        reduced = reduce_morphometry(band_height, longitude, band_latitude, target)
+        for name in morphometry_names
+            accumulated[name][:, band.rows] .= reduced[name][:, band.rows]
+        end
+    end
+
+    for name in morphometry_names
+        @test isapprox(accumulated[name], single[name], rtol = 1e-12, atol = 1e-12)
+    end
 end
 
 @testset "GloBFP3D native aggregation grid" begin

--- a/test/test_globfp3d.jl
+++ b/test/test_globfp3d.jl
@@ -3,7 +3,8 @@ include("runtests_setup.jl")
 using NumericalEarth.DataWrangling.GloBFP3D: reduce_morphometry, globfp3d_parse_tile_bounds,
                                              globfp3d_native_cell_size, globfp3d_native_resolution,
                                              globfp3d_rasterize_to_netcdf,
-                                             morphometry_latitude_bands, morphometry_names
+                                             morphometry_latitude_bands, morphometry_names,
+                                             NoIntersectingTilesError
 using NumericalEarth.DataWrangling: BoundingBox, Metadatum, native_region_grid,
                                     bounding_box_intersects, longitude_interfaces, latitude_interfaces,
                                     dataset_variable_name, validate_dataset_coverage,
@@ -126,6 +127,20 @@ end
     for name in morphometry_names
         @test isapprox(accumulated[name], single[name], rtol = 1e-12, atol = 1e-12)
     end
+end
+
+@testset "GloBFP3D error paths" begin
+    dataset = GlobalBuildingFootprints3D()
+    region = BoundingBox(longitude = (-74.02, -73.93), latitude = (40.70, 40.82))
+    message = sprint(showerror, NoIntersectingTilesError(region))
+    @test occursin("No 3D-GloBFP tiles intersect", message)
+    @test occursin(summary(region), message)
+
+    # An unbounded region fails validation before any raster sizing or download.
+    target = LatitudeLongitudeGrid(CPU(), Float64; size = (4, 4),
+                                   longitude = (-74.02, -73.93), latitude = (40.70, 40.82),
+                                   topology = (Bounded, Bounded, Flat))
+    @test_throws "must be used with a bounded region" building_morphometry(target; dataset, region = BoundingBox())
 end
 
 @testset "GloBFP3D native aggregation grid" begin

--- a/test/test_globfp3d_downloading.jl
+++ b/test/test_globfp3d_downloading.jl
@@ -1,7 +1,8 @@
 include("runtests_setup.jl")
 
 using ArchGDAL  # loads NumericalEarthArchGDALExt (the OGR read + rasterize path)
-using NumericalEarth.DataWrangling: BoundingBox, Metadatum
+using NumericalEarth.DataWrangling: BoundingBox, Metadatum, native_region_grid
+using NumericalEarth.DataWrangling.GloBFP3D: globfp3d_native_cell_size
 
 # Network-gated: downloads the figshare tile catalog plus one 3D-GloBFP tile archive
 # (hundreds of MB). Excluded from the default suite in runtests.jl, mirroring the
@@ -34,4 +35,27 @@ using NumericalEarth.DataWrangling: BoundingBox, Metadatum
     @test any(>(0), σʰ)
     @test all(λᶠ .≥ 0)
     @test Array(interior(morphometry.gross_building_height, :, :, 1)) ≈ λᵖ .* h
+
+    # Reducing the same region in latitude bands must reproduce the single pass exactly.
+    Δ = globfp3d_native_cell_size(dataset)
+    raster = native_region_grid(region, Δ, Δ)
+    maximum_raster_cells = raster.Nx * (raster.Ny ÷ 4)
+    @test raster.Nx * raster.Ny > maximum_raster_cells    # the limit really forces bands
+
+    banded = building_morphometry(target_grid; dataset, region, maximum_raster_cells)
+    for name in keys(morphometry)
+        @test Array(interior(banded[name], :, :, 1)) == Array(interior(morphometry[name], :, :, 1))
+    end
+end
+
+@testset "3D-GloBFP region with no tiles" begin
+    dataset = GlobalBuildingFootprints3D()
+    # Open ocean south of Hawaii: the tile catalog covers built-up land only, so no tile
+    # intersects and `building_morphometry` errors instead of returning empty fields.
+    region = BoundingBox(longitude = (-150.0, -149.99), latitude = (10.0, 10.01))
+    target_grid = LatitudeLongitudeGrid(CPU(), Float64; size = (2, 2),
+                                        longitude = region.longitude, latitude = region.latitude,
+                                        topology = (Bounded, Bounded, Flat))
+
+    @test_throws ErrorException building_morphometry(target_grid; dataset, region)
 end


### PR DESCRIPTION
`building_morphometry` materialized the footprint raster over the whole `region` at the dataset's `resolution`, so a 3.7° × 3.0° region at 3 m (~122 GB as `Float64`) was OOM-killed. It now accepts `maximum_raster_cells` (default 400M cells, 3.2 GB) and reduces larger regions in contiguous latitude bands sized to the limit, so memory stays bounded regardless of region size. Fixes #529.

- Each band rasterizes a `BoundingBox` spanning the full region longitude and the band rows' latitudes, padded by ~200 m of native cells and clamped to the region — every band raster is a sub-window of the single-pass raster, so band rows reduce identically (the pad keeps cross-cell height gradients and tile selection at band edges intact).
- Regions within the limit take the exact single-pass path as before; the returned NamedTuple of `Field`s is unchanged.
- Band rasters are deleted once reduced (the downloaded footprint tiles stay cached), so disk usage stays bounded too.
- `Downloads.download` on a 3D-GloBFP metadatum returns `nothing` when no tiles intersect its region: all-water bands are skipped with an `isnothing` check, and a region with no tiles at all still errors.

```julia
grid = LatitudeLongitudeGrid(size = (990, 990), latitude = (35.273, 37.941), longitude = (-99.1497, -95.8263),
                             topology = (Bounded, Bounded, Flat))
region = BoundingBox(longitude = (-99.35, -95.65), latitude = (35.1, 38.1))
building_morphometry(grid; dataset = GlobalBuildingFootprints3D(), region)  # previously OOM-killed at 3 m
```

**Equivalence** — over the region above with `GlobalBuildingFootprints3D(resolution = 20)` (native raster 20576 × 16684 ≈ 343M cells): single pass vs `maximum_raster_cells = 90_000_000` (4 bands) gives max |banded − single| = **0.0** for all six returned fields, i.e. bitwise identical. A 3 m Manhattan window forced into 5 bands is also bitwise identical to its single pass. A synthetic-raster unit test in `test_globfp3d.jl` exercises the banding and band-window reduction without network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
