### PR TITLE
Re-solve the canopy-air node against the final skins before the exit diagnostics

### DIFF
--- a/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
+++ b/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
@@ -468,6 +468,17 @@ uses the `Δ`-multiplied Kirchhoff form so it stays finite as the flux vanishes.
     qᵉ  = ifelse(Gᵉ⁺ > tiny, (fᵈ * Gᵉ * qᵉ + (1 - fᵈ) * gᵍʷ * qᵍ⁺) / Gᵉ⁺, qᵍ⁺)
     Gᵉ  = Gᵉ⁺
     gˡʷ = leaf_vapor_conductance(gᶜ, gʷ, fʷ)
+
+    # Re-solve the node against the final skins: inside the loop the node update
+    # precedes the skin updates, so it exits one iterate stale and the flux shares
+    # below would miss closure against the atmospheric flux.
+    Dᵀ  = (gᵍʰ + gˡʰ) * Δθᵃ + 𝒬ᵀ
+    Tᵃᶜ★ = ((gᵍʰ * Tᵍ + gˡʰ * Tᵛ) * Δθᵃ + 𝒬ᵀ * θᵃᵗ) / Dᵀ
+    Tᵃᶜ = ifelse((Dᵀ == 0) | !isfinite(Tᵃᶜ★), Tᵃᶜ, Tᵃᶜ★)
+    Dᵠ  = (Gᵉ + gˡʷ) * Δqᵃ + Jᵃ
+    qᵃᶜ★ = ((Gᵉ * qᵉ + gˡʷ * qᵛ) * Δqᵃ + Jᵃ * qᵃᵗ) / Dᵠ
+    qᵃᶜ = ifelse((Dᵠ == 0) | !isfinite(qᵃᶜ★), qᵃᶜ, qᵃᶜ★)
+
     LWꜜᵍ = (1 - εᵛ) * LWd + εᵛ * σ * Tᵛ^4
     LWꜛᵍ = εᵍ * σ * Tᵍ^4 + (1 - εᵍ) * LWꜜᵍ
     LWu   = (1 - εᵛ) * LWꜛᵍ + εᵛ * σ * Tᵛ^4

--- a/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
+++ b/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
@@ -350,6 +350,32 @@ Adapt.adapt_structure(to, c::CanopyAirSpace) =
     return (1 - fʷ) * gᵈ + fʷ * gʷ
 end
 
+# Leaf vapor conductance `gˡʷ` and leaf-saturated humidity `qᵛ` at the leaf temperature `Tᵛ`.
+@inline function leaf_vapor_terms(canopy, Tᵛ, gʷ, fʷ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
+    gᶜ, qᵛ = canopy_conductance_terms(canopy, Tᵛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
+    return leaf_vapor_conductance(gᶜ, gʷ, fʷ), qᵛ
+end
+
+# Soil vapor conductance and front humidity at the soil-skin temperature `Tᵍ`: the dry-layer
+# series branch (front qᵉ through Gᵉ) blended with the saturated-skin wet branch (qᵍ⁺ through
+# the undercanopy conductance gᵍʷ), weight `fᵈ` from the soil model.
+@inline function soil_vapor_terms(soil, Tᵍ, gᵍʷ, Ψₛ, Ψₐ, ℙₐ)
+    Gᵉ, qᵉ, fᵈ, qᵍ⁺ = dry_layer_terms(soil, Tᵍ, Ψₛ, Ψₐ, ℙₐ)
+    Gᵉ⁺ = fᵈ * Gᵉ + (1 - fᵈ) * gᵍʷ
+    qᵉ⁺ = ifelse(Gᵉ⁺ > eps(eltype(Ψₛ)), (fᵈ * Gᵉ * qᵉ + (1 - fᵈ) * gᵍʷ * qᵍ⁺) / Gᵉ⁺, qᵍ⁺)
+    return Gᵉ⁺, qᵉ⁺
+end
+
+# Δ-multiplied Kirchhoff node (as the humidity node in CompositeSurfaceHumidity): the ground
+# branch `(gᵍ, xᵍ)` and the leaf branch `(gᵛ, xᵛ)` in parallel behind the aerodynamic branch
+# `(𝒥, Δ, xᵃᵗ)`. Falls back to the previous iterate `x⁻` where the aerodynamic and surface
+# conductances cancel (`D ≈ 0`) before the outer MO loop is consistent, keeping the node finite.
+@inline function canopy_air_node(gᵍ, xᵍ, gᵛ, xᵛ, 𝒥, Δ, xᵃᵗ, x⁻)
+    D  = (gᵍ + gᵛ) * Δ + 𝒥
+    x★ = ((gᵍ * xᵍ + gᵛ * xᵛ) * Δ + 𝒥 * xᵃᵗ) / D
+    return ifelse((D == 0) | !isfinite(x★), x⁻, x★)
+end
+
 # dqᵛ⁺/dT by centered difference — the Newton derivative of each balance's latent term.
 @inline function saturation_humidity_slope(ℂᵃᵗ, T, pᵃᵗ, phase)
     δ = convert(typeof(T), 1//100)
@@ -365,7 +391,8 @@ Solve the coupled diagnostic state `(Tᵛ, Tᵍ, Tᵃᶜ, qᵃᶜ)` for one cell
 previous fixed-point iterate (carrying the MO scales and the previous node values),
 `Ψᵢ.T` is the bulk reservoir `Tˡᵃ`, and `Ψᵣ` the interface radiation state. A short
 damped-Newton inner loop advances the two skin balances against the node; the node
-uses the `Δ`-multiplied Kirchhoff form so it stays finite as the flux vanishes.
+uses the `Δ`-multiplied Kirchhoff form so it stays finite as the flux vanishes, and is
+re-solved against the final skins on exit so the returned flux partition closes.
 """
 @inline function canopy_air_space_solve(c::CanopyAirSpace, Ψₛ, Ψₐ, Ψᵢ, Ψᵣ, ℙₐ)
     ℂᵃᵗ = ℙₐ.thermodynamics_parameters
@@ -420,27 +447,11 @@ uses the `Δ`-multiplied Kirchhoff form so it stays finite as the flux vanishes.
     tiny = eps(FT)
 
     for _ in 1:c.inner_iterations
-        gᶜ, qᵛ   = canopy_conductance_terms(c.canopy, Tᵛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
-        Gᵉ, qᵉ, fᵈ, qᵍ⁺ = dry_layer_terms(c.soil, Tᵍ, Ψₛ, Ψₐ, ℙₐ)
+        gˡʷ, qᵛ = leaf_vapor_terms(c.canopy, Tᵛ, gʷ, fʷ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
+        Gᵉ, qᵉ  = soil_vapor_terms(c.soil, Tᵍ, gᵍʷ, Ψₛ, Ψₐ, ℙₐ)
 
-        # Blend the dry-layer series soil branch (front qᵉ through Gᵉ) with the
-        # saturated-skin wet branch (qᵍ⁺ through the undercanopy conductance gᵍʷ),
-        # weight `fᵈ` from the soil model.
-        Gᵉ⁺ = fᵈ * Gᵉ + (1 - fᵈ) * gᵍʷ
-        qᵉ  = ifelse(Gᵉ⁺ > tiny, (fᵈ * Gᵉ * qᵉ + (1 - fᵈ) * gᵍʷ * qᵍ⁺) / Gᵉ⁺, qᵍ⁺)
-        Gᵉ  = Gᵉ⁺
-
-        gˡʷ = leaf_vapor_conductance(gᶜ, gʷ, fʷ)
-
-        # Δ-multiplied Kirchhoff node (as the humidity node in CompositeSurfaceHumidity);
-        # guard the transient case where the aerodynamic and surface conductances cancel
-        # (Dᵀ ≈ 0) before the outer MO loop is consistent, keeping the node finite.
-        Dᵀ  = (gᵍʰ + gˡʰ) * Δθᵃ + 𝒬ᵀ
-        Tᵃᶜ★ = ((gᵍʰ * Tᵍ + gˡʰ * Tᵛ) * Δθᵃ + 𝒬ᵀ * θᵃᵗ) / Dᵀ
-        Tᵃᶜ = ifelse((Dᵀ == 0) | !isfinite(Tᵃᶜ★), Tᵃᶜ, Tᵃᶜ★)
-        Dᵠ  = (Gᵉ + gˡʷ) * Δqᵃ + Jᵃ
-        qᵃᶜ★ = ((Gᵉ * qᵉ + gˡʷ * qᵛ) * Δqᵃ + Jᵃ * qᵃᵗ) / Dᵠ
-        qᵃᶜ = ifelse((Dᵠ == 0) | !isfinite(qᵃᶜ★), qᵃᶜ, qᵃᶜ★)
+        Tᵃᶜ = canopy_air_node(gᵍʰ, Tᵍ, gˡʰ, Tᵛ, 𝒬ᵀ, Δθᵃ, θᵃᵗ, Tᵃᶜ)
+        qᵃᶜ = canopy_air_node(Gᵉ, qᵉ, gˡʷ, qᵛ, Jᵃ, Δqᵃ, qᵃᵗ, qᵃᶜ)
 
         LWꜜᵍ     = (1 - εᵛ) * LWd + εᵛ * σ * Tᵛ^4
         LWꜛᵍ     = εᵍ * σ * Tᵍ^4 + (1 - εᵍ) * LWꜜᵍ
@@ -462,22 +473,12 @@ uses the `Δ`-multiplied Kirchhoff form so it stays finite as the flux vanishes.
 
     # Converged diagnostics: per-surface flux shares, the skin→slab conduction, and
     # the effective radiating (LST) temperature σ Teff⁴ ≡ LWu (upwelling to space).
-    gᶜ, qᵛ   = canopy_conductance_terms(c.canopy, Tᵛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
-    Gᵉ, qᵉ, fᵈ, qᵍ⁺ = dry_layer_terms(c.soil, Tᵍ, Ψₛ, Ψₐ, ℙₐ)
-    Gᵉ⁺ = fᵈ * Gᵉ + (1 - fᵈ) * gᵍʷ
-    qᵉ  = ifelse(Gᵉ⁺ > tiny, (fᵈ * Gᵉ * qᵉ + (1 - fᵈ) * gᵍʷ * qᵍ⁺) / Gᵉ⁺, qᵍ⁺)
-    Gᵉ  = Gᵉ⁺
-    gˡʷ = leaf_vapor_conductance(gᶜ, gʷ, fʷ)
-
-    # Re-solve the node against the final skins: inside the loop the node update
-    # precedes the skin updates, so it exits one iterate stale and the flux shares
-    # below would miss closure against the atmospheric flux.
-    Dᵀ  = (gᵍʰ + gˡʰ) * Δθᵃ + 𝒬ᵀ
-    Tᵃᶜ★ = ((gᵍʰ * Tᵍ + gˡʰ * Tᵛ) * Δθᵃ + 𝒬ᵀ * θᵃᵗ) / Dᵀ
-    Tᵃᶜ = ifelse((Dᵀ == 0) | !isfinite(Tᵃᶜ★), Tᵃᶜ, Tᵃᶜ★)
-    Dᵠ  = (Gᵉ + gˡʷ) * Δqᵃ + Jᵃ
-    qᵃᶜ★ = ((Gᵉ * qᵉ + gˡʷ * qᵛ) * Δqᵃ + Jᵃ * qᵃᵗ) / Dᵠ
-    qᵃᶜ = ifelse((Dᵠ == 0) | !isfinite(qᵃᶜ★), qᵃᶜ, qᵃᶜ★)
+    # The node is re-solved against the final skins: inside the loop it updates ahead of
+    # them, so the loop exits one iterate stale and the shares below would miss closure.
+    gˡʷ, qᵛ = leaf_vapor_terms(c.canopy, Tᵛ, gʷ, fʷ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
+    Gᵉ, qᵉ  = soil_vapor_terms(c.soil, Tᵍ, gᵍʷ, Ψₛ, Ψₐ, ℙₐ)
+    Tᵃᶜ = canopy_air_node(gᵍʰ, Tᵍ, gˡʰ, Tᵛ, 𝒬ᵀ, Δθᵃ, θᵃᵗ, Tᵃᶜ)
+    qᵃᶜ = canopy_air_node(Gᵉ, qᵉ, gˡʷ, qᵛ, Jᵃ, Δqᵃ, qᵃᵗ, qᵃᶜ)
 
     LWꜜᵍ = (1 - εᵛ) * LWd + εᵛ * σ * Tᵛ^4
     LWꜛᵍ = εᵍ * σ * Tᵍ^4 + (1 - εᵍ) * LWꜜᵍ

--- a/test/test_canopy_air_space.jl
+++ b/test/test_canopy_air_space.jl
@@ -87,14 +87,15 @@ end
         @test Es ≈ -Gᶜ atol = 1e-6
 
         # Two-source flux shares: the leaf/ground sensible and latent shares are finite
-        # and sum to the atmosphere-facing totals (node continuity).
+        # and sum to the atmosphere-facing totals (node continuity). The node is re-solved
+        # against the final skins, so the partition closes to the outer fixed-point tolerance.
         Hᵛ  = Array(interior(Ts.canopy_sensible_heat))[1, 1, 1]
         Hᵍ  = Array(interior(Ts.soil_sensible_heat))[1, 1, 1]
         LEᵛ = Array(interior(Ts.canopy_latent_heat))[1, 1, 1]
         LEᵍ = Array(interior(Ts.soil_latent_heat))[1, 1, 1]
         @test all(isfinite, (Hᵛ, Hᵍ, LEᵛ, LEᵍ))
-        @test Hᵛ + Hᵍ ≈ 𝒬ᵀ rtol = 1e-2
-        @test LEᵛ + LEᵍ ≈ 𝒬ᵛ rtol = 1e-2
+        @test Hᵛ + Hᵍ ≈ 𝒬ᵀ rtol = 1e-6
+        @test LEᵛ + LEᵍ ≈ 𝒬ᵛ rtol = 1e-6
         # Sunlit dense canopy: transpiration is the larger latent source.
         @test LEᵛ > LEᵍ
 


### PR DESCRIPTION
Inside `canopy_air_space_solve` the node `(Tᵃᶜ, qᵃᶜ)` updates before the two skin balances, so the loop exits with a node one iterate behind the skins. The returned flux partition then misses closure (`Hᵛ + Hᵍ − H` = 4–13 W m⁻², about 5%, in the HI-SCALE SGP runs), and more inner iterations do not shrink the gap.

- Re-solves the node once against the final skins before the exit diagnostics, so the partition closes and the returned node matches the skins the next outer iterate sees.
- The converged atmosphere-facing flux is unchanged; only the partition and the node tighten.

MWE (single cell, 600/350 W m⁻² downwelling shortwave/longwave, LAI 2):

```julia
using NumericalEarth, Oceananigans
using Oceananigans.TimeSteppers: update_state!

grid = LatitudeLongitudeGrid(size = (2, 2, 1), latitude = (36, 37), longitude = (-98, -97),
                             z = (-1, 0), topology = (Bounded, Bounded, Bounded))
atmosphere = PrescribedAtmosphere(grid; surface_layer_height = 10, boundary_layer_height = 512)
fill!(parent(atmosphere.temperature), 300); fill!(parent(atmosphere.specific_humidity), 0.01)
fill!(parent(atmosphere.velocities.u), 4);  fill!(parent(atmosphere.pressure), 101325)
radiation = PrescribedRadiation(grid)
set!(radiation; downwelling_shortwave = 600, downwelling_longwave = 350)
land = SlabLand(grid); set!(land; T = 302, M = 100)
leaf_area_index = Field{Center, Center, Nothing}(grid); set!(leaf_area_index, 2)

canopy_air_space = CanopyAirSpace(;
    soil = DryLayerHumidity(; dry_layer_depth = StorageBasedDryLayerDepth(maximum_dry_layer_depth = 0.05,
                                                                          dry_layer_onset_saturation = 1.0),
                            vapor_exchange = DryLayerVaporPistonVelocity(minimum_dry_layer_depth = 1e-3,
                                                                         molecular_diffusivity = 2.4e-5),
                            thermal_exchange_depth = 0.05, porosity = 0.4),
    canopy = CanopyConductanceHumidity(; leaf_area_index))

model = AtmosphereLandModel(atmosphere, land;
                            atmosphere_land_interface_temperature = canopy_air_space,
                            atmosphere_land_interface_specific_humidity = canopy_air_space,
                            radiation)
update_state!(model)

iface = model.interfaces.atmosphere_land_interface
value(f) = Array(interior(f))[1, 1, 1]
value(iface.temperature.canopy_sensible_heat) + value(iface.temperature.soil_sensible_heat) -
    value(iface.fluxes.sensible_heat)
```

With this change the residual prints 0.0 W m⁻² (latent likewise: `LEᵛ + LEᵍ − LE = 0.0` at `LE = 158.9` W m⁻²).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
