### PR TITLE
Litter resistance in series on the CanopyAirSpace ground vapor path

### DIFF
--- a/docs/src/NumericalEarth.bib
+++ b/docs/src/NumericalEarth.bib
@@ -193,6 +193,17 @@
   doi     = {10.1111/j.1365-2486.2012.02790.x}
 }
 
+@article{sakaguchi2009,
+  author  = {Sakaguchi, Koichi and Zeng, Xubin},
+  title   = {Effects of soil wetness, plant litter, and under-canopy atmospheric stability on ground evaporation in the Community Land Model (CLM3.5)},
+  journal = {Journal of Geophysical Research: Atmospheres},
+  volume  = {114},
+  number  = {D1},
+  pages   = {D01107},
+  year    = {2009},
+  doi     = {10.1029/2008JD010834}
+}
+
 @article{sellers1992,
   author  = {Sellers, Piers J. and Heiser, Mark D. and Hall, Forrest G.},
   title   = {Relations between surface conductance and spectral vegetation indices at intermediate (100 m$^2$ to 15 km$^2$) length scales},

--- a/src/EarthSystemModels/EarthSystemModels.jl
+++ b/src/EarthSystemModels/EarthSystemModels.jl
@@ -28,6 +28,7 @@ export
     AreaIndexUndercanopyConductance,
     FrictionVelocityUndercanopyConductance,
     SellersSoilResistance,
+    LitterResistance,
     TiledLandInterface,
     bare_canopy_air_space,
     leaf_area_index_cover_fraction,

--- a/src/EarthSystemModels/InterfaceComputations/InterfaceComputations.jl
+++ b/src/EarthSystemModels/InterfaceComputations/InterfaceComputations.jl
@@ -60,6 +60,7 @@ export
     AreaIndexUndercanopyConductance,
     FrictionVelocityUndercanopyConductance,
     SellersSoilResistance,
+    LitterResistance,
     TiledLandInterface,
     bare_canopy_air_space,
     leaf_area_index_cover_fraction,

--- a/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
+++ b/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
@@ -245,17 +245,21 @@ undercanopy_conductance_model(x::AbstractUndercanopyConductance, FT) = x
     SellersSoilResistance(FT = Oceananigans.defaults.FloatType;
                           intercept = 8.206, slope = 4.255)
 
-Soil surface resistance for the moist-soil (vanishing dry layer) evaporation branch
-of a [`CanopyAirSpace`](@ref),
+Empirical ground-surface resistance for the moist-soil (vanishing dry layer) evaporation
+branch of a [`CanopyAirSpace`](@ref),
 
 ```math
 rˢ = e^{a - b 𝒮},
 ```
 
-with the surface saturation `𝒮` ([Sellers et al. (1992)](@cite sellers1992)). Even a
-saturated soil surface resists evaporation (`rˢ(1) ≈ 52` s m⁻¹), so the moist branch
-no longer behaves like open water: without it, the saturated-skin branch evaporates
-through the undercanopy aerodynamic conductance alone.
+with the surface saturation `𝒮`, fit by [Sellers et al. (1992)](@cite sellers1992) to the
+FIFE prairie flux stations (`rˢ(1) ≈ 52` s m⁻¹). The FIFE sites carried standing dead
+grass and plant litter, so the moist-soil end of the fit is an *effective* soil-plus-litter
+resistance rather than pore-scale soil physics: chamber measurements of litter-free wet
+soil find near-zero surface resistance, and [Sakaguchi and Zeng (2009)](@cite sakaguchi2009)
+attribute the moist-soil remainder to the litter layer. Use this fit as a bundled
+alternative to an explicit [`LitterResistance`](@ref) (pass `litter_resistance = nothing`);
+combining both double-counts the litter effect.
 
 ```jldoctest
 using NumericalEarth
@@ -289,6 +293,59 @@ Base.show(io::IO, r::SellersSoilResistance) = print(io, summary(r))
 end
 
 """
+    LitterResistance(FT = Oceananigans.defaults.FloatType;
+                     litter_area_index = 1, transfer_coefficient = 0.004)
+
+Plant-litter resistance to ground evaporation
+([Sakaguchi and Zeng (2009)](@cite sakaguchi2009), Eq. 13),
+
+```math
+rˡ = \\frac{1 - e^{-Lˡ}}{C u★},
+```
+
+with the litter area index `Lˡ` (m² m⁻²), a turbulent transfer coefficient `C`, and the
+friction velocity `u★` standing in for the wind speed in the canopy air space. Dead
+leaves and stems blanket the ground under vegetation; the litter is too porous for
+capillary rise to wet its top, so it evaporates little itself while blocking turbulent
+and diffusive vapor exchange with the soil below. The resistance vanishes without litter
+(`Lˡ = 0`) and saturates at `1/(C u★)` under a thick blanket — 500–1200 s m⁻¹ under
+mid-latitude forests, larger in calm air. The default `Lˡ = 1` is the minimum stem-plus-
+litter area of the global surface dataset behind the fit; the snow-burial reduction of
+the original scheme is omitted (no snow model). Applies to vegetated ground: the bare
+tile of a [`TiledLandInterface`](@ref) drops it (see [`bare_canopy_air_space`](@ref)).
+
+```jldoctest
+using NumericalEarth
+
+LitterResistance()
+
+# output
+LitterResistance(Lˡ=1.0, C=0.004)
+```
+"""
+struct LitterResistance{FT}
+    litter_area_index    :: FT
+    transfer_coefficient :: FT
+end
+
+LitterResistance(FT::Type = Oceananigans.defaults.FloatType;
+                 litter_area_index = 1, transfer_coefficient = 0.004) =
+    LitterResistance(convert(FT, litter_area_index), convert(FT, transfer_coefficient))
+
+Base.summary(r::LitterResistance) =
+    string("LitterResistance(Lˡ=", prettysummary(r.litter_area_index),
+           ", C=", prettysummary(r.transfer_coefficient), ")")
+Base.show(io::IO, r::LitterResistance) = print(io, summary(r))
+
+@inline litter_resistance(::Nothing, u★) = zero(u★)
+@inline function litter_resistance(r::LitterResistance, u★)
+    FT = typeof(u★)
+    Lˡ = convert(FT, r.litter_area_index)
+    C  = convert(FT, r.transfer_coefficient)
+    return (1 - exp(-Lˡ)) / max(C * u★, eps(FT))
+end
+
+"""
     struct CanopyAirSpace
 
 Two-source canopy + soil surface with a diagnostic canopy-air node. Solves the
@@ -310,15 +367,19 @@ Fields:
   a `Number` (m s⁻¹, wrapped as [`ConstantUndercanopyConductance`](@ref)), an
   [`AreaIndexUndercanopyConductance`](@ref) (PALADYN: canopy density and wind), or a
   [`FrictionVelocityUndercanopyConductance`](@ref) (CLM5: canopy density and `u★`).
-- `wet_soil_resistance` : soil surface resistance in series with `gᵘᶜ` on the moist-soil
-  (vanishing dry layer) vapor branch (a [`SellersSoilResistance`](@ref), the default), or
-  `nothing` for an unresisted saturated skin.
+- `wet_soil_resistance` : soil surface resistance on the moist-soil (vanishing dry layer)
+  vapor branch (a [`SellersSoilResistance`](@ref)), or `nothing` (the default: above the
+  dry-layer onset the soil itself does not limit evaporation, and the litter layer and
+  undercanopy path carry the resistance).
+- `litter_resistance` : plant-litter resistance in series on both ground vapor branches
+  (a [`LitterResistance`](@ref), the default), or `nothing` for litter-free ground
+  ([`bare_canopy_air_space`](@ref) drops it on the bare tile).
 - `inner_iterations`, `relaxation` : damped-Newton settings for the coupled solve.
 - `interception` : wet-canopy vapor branch parameters (a [`CanopyInterception`](@ref)),
   or `nothing` for a dry canopy (the default; recovers the current CAS bit-for-bit).
 - `phase` : saturation phase (Liquid).
 """
-struct CanopyAirSpace{S, C, RF, FT, U, W, I, Φ}
+struct CanopyAirSpace{S, C, RF, FT, U, W, L, I, Φ}
     soil                      :: S
     canopy                    :: C
     soil_skin_flux             :: RF
@@ -331,6 +392,7 @@ struct CanopyAirSpace{S, C, RF, FT, U, W, I, Φ}
     leaf_boundary_conductance :: FT
     undercanopy_conductance   :: U
     wet_soil_resistance       :: W
+    litter_resistance         :: L
     inner_iterations          :: Int
     relaxation                :: FT
     interception              :: I
@@ -349,7 +411,8 @@ function CanopyAirSpace(FT=Oceananigans.defaults.FloatType;
                         clumping                  = 1,
                         leaf_boundary_conductance = 0.02,
                         undercanopy_conductance   = 0.013,
-                        wet_soil_resistance       = SellersSoilResistance(FT),
+                        wet_soil_resistance       = nothing,
+                        litter_resistance         = LitterResistance(FT),
                         inner_iterations          = 40,
                         relaxation                = 1//2,
                         interception              = nothing,
@@ -361,7 +424,7 @@ function CanopyAirSpace(FT=Oceananigans.defaults.FloatType;
                           convert(FT, extinction), convert(FT, clumping),
                           convert(FT, leaf_boundary_conductance),
                           undercanopy_conductance_model(undercanopy_conductance, FT),
-                          wet_soil_resistance,
+                          wet_soil_resistance, litter_resistance,
                           inner_iterations, convert(FT, relaxation), interception, phase)
 end
 
@@ -373,7 +436,7 @@ Adapt.adapt_structure(to, c::CanopyAirSpace) =
     CanopyAirSpace(adapt(to, c.soil), adapt(to, c.canopy), c.soil_skin_flux,
                    c.leaf_albedo, c.ground_albedo, c.canopy_emissivity_max, c.ground_emissivity,
                    c.extinction, c.clumping, c.leaf_boundary_conductance,
-                   c.undercanopy_conductance, c.wet_soil_resistance,
+                   c.undercanopy_conductance, c.wet_soil_resistance, c.litter_resistance,
                    c.inner_iterations, c.relaxation,
                    c.interception, c.phase)
 
@@ -411,10 +474,12 @@ end
 end
 
 # Soil vapor conductance and front humidity at the soil-skin temperature `Tᵍ`: the dry-layer
-# series branch (front qᵉ through Gᵉ) blended with the saturated-skin wet branch (qᵍ⁺ through
-# the undercanopy conductance gᵍʷ), weight `fᵈ` from the soil model.
-@inline function soil_vapor_terms(soil, Tᵍ, gᵍʷ, Ψₛ, Ψₐ, ℙₐ)
+# branch (front qᵉ through Gᵉ, in series with the litter + undercanopy path `gᵖ`; Sakaguchi &
+# Zeng 2009, Eq. 18b, matching the sensible path which already crosses gᵘᶜ via gᵍʰ) blended
+# with the saturated-skin wet branch (qᵍ⁺ through gᵍʷ), weight `fᵈ` from the soil model.
+@inline function soil_vapor_terms(soil, Tᵍ, gᵍʷ, gᵖ, Ψₛ, Ψₐ, ℙₐ)
     Gᵉ, qᵉ, fᵈ, qᵍ⁺ = dry_layer_terms(soil, Tᵍ, Ψₛ, Ψₐ, ℙₐ)
+    Gᵉ = Gᵉ * gᵖ / (gᵖ + Gᵉ)
     Gᵉ⁺ = fᵈ * Gᵉ + (1 - fᵈ) * gᵍʷ
     qᵉ⁺ = ifelse(Gᵉ⁺ > eps(eltype(Ψₛ)), (fᵈ * Gᵉ * qᵉ + (1 - fᵈ) * gᵍʷ * qᵍ⁺) / Gᵉ⁺, qᵍ⁺)
     return Gᵉ⁺, qᵉ⁺
@@ -472,10 +537,14 @@ re-solved against the final skins on exit so the returned flux partition closes.
 
     gˡʰ = ρᵃᵗ * cᵖ * LAI * c.leaf_boundary_conductance
     gᵍʰ = ρᵃᵗ * cᵖ * gᵘᶜ
-    # Moist-soil vapor conductance: the undercanopy aerodynamic path in series with the
-    # soil surface resistance, so a vanishing dry layer does not evaporate like open water.
-    rᵍʷ = soil_surface_resistance(c.wet_soil_resistance, Ψₛ.hydrology.saturation)
-    gᵍʷ = ρᵃᵗ * gᵘᶜ / (1 + gᵘᶜ * rᵍʷ)
+    # Ground vapor path (Sakaguchi & Zeng 2009, Eq. 18): the litter resistance rˡ and — on
+    # the moist-soil branch — the soil surface resistance rˢ sit in series with the
+    # undercanopy aerodynamic path, so a vanishing dry layer does not evaporate like open
+    # water. The dry branch crosses the same litter + undercanopy path `gᵖ`.
+    rˡ  = litter_resistance(c.litter_resistance, Ψₛ.fluxes.u★)
+    rˢ  = soil_surface_resistance(c.wet_soil_resistance, Ψₛ.hydrology.saturation)
+    gᵖ  = ρᵃᵗ * gᵘᶜ / (1 + gᵘᶜ * rˡ)
+    gᵍʷ = ρᵃᵗ * gᵘᶜ / (1 + gᵘᶜ * (rˡ + rˢ))
     Λ   = convert(FT, skin_conductance(c.soil_skin_flux))
 
     # Leaf boundary-layer vapor mass conductance `gʷ = ρᵃᵗ·LAI·gᵇ`: in series with the
@@ -505,7 +574,7 @@ re-solved against the final skins on exit so the returned flux partition closes.
 
     for _ in 1:c.inner_iterations
         gˡʷ, qᵛ = leaf_vapor_terms(c.canopy, Tᵛ, gʷ, fʷ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
-        Gᵉ, qᵉ  = soil_vapor_terms(c.soil, Tᵍ, gᵍʷ, Ψₛ, Ψₐ, ℙₐ)
+        Gᵉ, qᵉ  = soil_vapor_terms(c.soil, Tᵍ, gᵍʷ, gᵖ, Ψₛ, Ψₐ, ℙₐ)
 
         Tᵃᶜ = canopy_air_node(gᵍʰ, Tᵍ, gˡʰ, Tᵛ, 𝒬ᵀ, Δθᵃ, θᵃᵗ, Tᵃᶜ)
         qᵃᶜ = canopy_air_node(Gᵉ, qᵉ, gˡʷ, qᵛ, Jᵃ, Δqᵃ, qᵃᵗ, qᵃᶜ)
@@ -533,7 +602,7 @@ re-solved against the final skins on exit so the returned flux partition closes.
     # The node is re-solved against the final skins: inside the loop it updates ahead of
     # them, so the loop exits one iterate stale and the shares below would miss closure.
     gˡʷ, qᵛ = leaf_vapor_terms(c.canopy, Tᵛ, gʷ, fʷ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
-    Gᵉ, qᵉ  = soil_vapor_terms(c.soil, Tᵍ, gᵍʷ, Ψₛ, Ψₐ, ℙₐ)
+    Gᵉ, qᵉ  = soil_vapor_terms(c.soil, Tᵍ, gᵍʷ, gᵖ, Ψₛ, Ψₐ, ℙₐ)
     Tᵃᶜ = canopy_air_node(gᵍʰ, Tᵍ, gˡʰ, Tᵛ, 𝒬ᵀ, Δθᵃ, θᵃᵗ, Tᵃᶜ)
     qᵃᶜ = canopy_air_node(Gᵉ, qᵉ, gˡʷ, qᵛ, Jᵃ, Δqᵃ, qᵃᵗ, qᵃᶜ)
 

--- a/src/EarthSystemModels/InterfaceComputations/tiled_land_interface.jl
+++ b/src/EarthSystemModels/InterfaceComputations/tiled_land_interface.jl
@@ -55,22 +55,28 @@ zero_leaf_area_index_canopy(q::CanopyConductanceHumidity) =
                               q.moisture_stress, q.absorbed_par, q.atmospheric_co2, q.phase)
 
 """
-    bare_canopy_air_space(vegetated::CanopyAirSpace; undercanopy_conductance)
+    bare_canopy_air_space(vegetated::CanopyAirSpace;
+                          undercanopy_conductance, wet_soil_resistance, litter_resistance)
 
 Derive the bare-soil tile from the vegetated `CanopyAirSpace`: the same soil vapor branch,
 skin conduction, albedos, emissivities, and optics, but with a canopy-free (LAI = 0) leaf
-branch and no interception. The soil then talks straight to the atmosphere (all shortwave
-reaches the ground, the ground sees the sky, no transpiration). `undercanopy_conductance`
-sets the soil↔canopy-air coupling for the bare tile (defaults to the vegetated value; a
-larger value pushes the soil resistance toward the pure-aerodynamic limit).
+branch, no interception, and no litter (litter blankets vegetated ground only, so
+`litter_resistance` defaults to `nothing` here). The soil then talks straight to the
+atmosphere (all shortwave reaches the ground, the ground sees the sky, no transpiration).
+`undercanopy_conductance` sets the soil↔canopy-air coupling for the bare tile (defaults to
+the vegetated value; a larger value pushes the soil resistance toward the pure-aerodynamic
+limit), and `wet_soil_resistance` the moist-soil surface resistance (defaults to the
+vegetated value).
 """
-function bare_canopy_air_space(c::CanopyAirSpace; undercanopy_conductance = c.undercanopy_conductance)
+function bare_canopy_air_space(c::CanopyAirSpace; undercanopy_conductance = c.undercanopy_conductance,
+                               wet_soil_resistance = c.wet_soil_resistance,
+                               litter_resistance = nothing)
     FT = typeof(c.leaf_albedo)
     return CanopyAirSpace(c.soil, zero_leaf_area_index_canopy(c.canopy), c.soil_skin_flux,
                           c.leaf_albedo, c.ground_albedo, c.canopy_emissivity_max, c.ground_emissivity,
                           c.extinction, c.clumping, c.leaf_boundary_conductance,
                           undercanopy_conductance_model(undercanopy_conductance, FT),
-                          c.wet_soil_resistance,
+                          wet_soil_resistance, litter_resistance,
                           c.inner_iterations, c.relaxation, nothing, c.phase)
 end
 

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -66,6 +66,7 @@ export
     AreaIndexUndercanopyConductance,
     FrictionVelocityUndercanopyConductance,
     SellersSoilResistance,
+    LitterResistance,
     TiledLandInterface,
     bare_canopy_air_space,
     leaf_area_index_cover_fraction,

--- a/test/test_canopy_air_space.jl
+++ b/test/test_canopy_air_space.jl
@@ -12,6 +12,7 @@ using NumericalEarth.EarthSystemModels.InterfaceComputations:
     AirLandInterfaceState, InterfaceFluxScales, InterfaceVelocities, AirLandRadiationState,
     ConstantUndercanopyConductance, AreaIndexUndercanopyConductance,
     FrictionVelocityUndercanopyConductance, undercanopy_conductance,
+    SellersSoilResistance, LitterResistance, soil_surface_resistance, litter_resistance,
     bare_canopy_air_space, CanopyAirSpaceDiagnostics
 using NumericalEarth.Atmospheres: PrescribedAtmosphere, AtmosphereThermodynamicsParameters
 using NumericalEarth.Lands: SlabLand, SlabEnergy, BucketHydrology
@@ -197,11 +198,12 @@ end
         vapor_exchange = DryLayerVaporPistonVelocity(FT; minimum_dry_layer_depth = 1e-3,
                             molecular_diffusivity = 2.4e-5, tortuosity = PowerLawTortuosity()),
         thermal_exchange_depth = 0.05, porosity = 0.4)
-    # Bare soil (LAI = 0) isolates the soil branch from the canopy.
+    # Bare soil (LAI = 0, no litter) isolates the soil branch from the canopy.
     bare(gᵘᶜ) = CanopyAirSpace(FT; soil,
         canopy = CanopyConductanceHumidity(FT; leaf_area_index = 0.0,
                             moisture_stress = CriticalSaturation(0.5), absorbed_par = InteractiveAbsorbedPAR(FT)),
-        soil_skin_flux = SoilConductiveFlux(1.5, 0.05), undercanopy_conductance = gᵘᶜ)
+        soil_skin_flux = SoilConductiveFlux(1.5, 0.05), undercanopy_conductance = gᵘᶜ,
+        litter_resistance = nothing)
 
     Ψₐ  = (z = FT(10), u = FT(3), v = FT(0), T = FT(305), p = FT(101325), q = FT(0.006), h_bℓ = FT(600))
     Ψᵢ  = (u = FT(0), v = FT(0), T = FT(298))
@@ -223,6 +225,74 @@ end
     ρᵃᵗ = AtmosphericThermodynamics.air_density(ℂ, Ψₐ.T, Ψₐ.p, Ψₐ.q)
     @test fᵈ > 0.99
     @test fᵈ * Gᵉ + (1 - fᵈ) * (ρᵃᵗ * 0.5) ≈ Gᵉ rtol = 0.02
+end
+
+# Ground-surface resistances: the Sakaguchi & Zeng (2009) litter layer sits in series on
+# both ground vapor branches (the default), and the Sellers et al. (1992) FIFE fit is the
+# bundled soil-plus-litter alternative on the moist-soil branch.
+@testset "Ground-surface resistances (litter layer, Sellers fit)" begin
+    for FT in (Float32, Float64)
+        # Sellers et al. (1992), Eq. (19): rˢ = exp(8.206 − 4.255 𝒮), saturation clamped.
+        r = SellersSoilResistance(FT)
+        @test soil_surface_resistance(r, FT(1)) ≈ exp(FT(8.206) - FT(4.255))   # ≈ 52 s m⁻¹
+        @test soil_surface_resistance(r, FT(2)) == soil_surface_resistance(r, FT(1))
+        @test soil_surface_resistance(r, FT(0.4)) > soil_surface_resistance(r, FT(0.7))
+        @test soil_surface_resistance(nothing, FT(0.5)) == 0
+
+        # Sakaguchi & Zeng (2009), Eq. (13): rˡ = (1 − e^{−Lˡ}) / (C u★).
+        l = LitterResistance(FT)
+        @test litter_resistance(l, FT(0.3)) ≈ (1 - exp(-FT(1))) / (FT(0.004) * FT(0.3))  # ≈ 527 s m⁻¹
+        @test litter_resistance(LitterResistance(FT; litter_area_index = 0), FT(0.3)) == 0
+        @test litter_resistance(l, FT(0.1)) > litter_resistance(l, FT(0.3))   # calm air blocks more
+        @test isfinite(litter_resistance(l, FT(0)))
+        @test litter_resistance(nothing, FT(0.3)) == 0
+    end
+
+    FT = Float64
+    ℂ  = AtmosphereThermodynamicsParameters(FT)
+    ℙₐ = (thermodynamics_parameters = ℂ, gravitational_acceleration = FT(9.81))
+    soil = DryLayerHumidity(FT;
+        dry_layer_depth = StorageBasedDryLayerDepth(FT; maximum_dry_layer_depth = 0.015,
+                            dry_layer_onset_saturation = 0.5, dry_layer_exponent = 2),
+        vapor_exchange = DryLayerVaporPistonVelocity(FT; minimum_dry_layer_depth = 1e-3,
+                            molecular_diffusivity = 2.4e-5, tortuosity = ConstantTortuosity()),
+        thermal_exchange_depth = 0.05, porosity = 0.4)
+    canopy = CanopyConductanceHumidity(FT; leaf_area_index = 0.0,   # LAI = 0 isolates the ground branch
+                            moisture_stress = CriticalSaturation(0.5), absorbed_par = InteractiveAbsorbedPAR(FT))
+    cas(; kw...) = CanopyAirSpace(FT; soil, canopy, kw...)
+    Ψₐ  = (z = FT(10), u = FT(3), v = FT(0), T = FT(305), p = FT(101325), q = FT(0.006), h_bℓ = FT(600))
+    Ψᵢ  = (u = FT(0), v = FT(0), T = FT(298))
+    Ψᵣ  = AirLandRadiationState(FT(5.670374e-8), FT(0), FT(0), FT(600), FT(350))
+    flx = InterfaceFluxScales(FT(0.26), FT(1e-3), FT(-1e-3)); vel = InterfaceVelocities(FT(0), FT(0))
+    Ψ(𝒮) = AirLandInterfaceState(flx, vel, FT(300), FT(0.012), (saturation = FT(𝒮),),
+            (temperature = FT(300),), (leaf_area_index = FT(0),))
+    LEᵍ(c, 𝒮) = canopy_air_space_solve(c, Ψ(𝒮), Ψₐ, Ψᵢ, Ψᵣ, ℙₐ).LEᵍ
+
+    unresisted = cas(litter_resistance = nothing)
+    sellers    = cas(litter_resistance = nothing, wet_soil_resistance = SellersSoilResistance(FT))
+    litter     = cas()   # the default configuration
+
+    # Each resistance suppresses moist-soil evaporation; at u★ = 0.26 the litter layer
+    # (rˡ ≈ 608 s m⁻¹) blocks more than the Sellers fit (rˢ(0.9) ≈ 113 s m⁻¹).
+    @test LEᵍ(litter, 0.9) < LEᵍ(sellers, 0.9) < LEᵍ(unresisted, 0.9)
+
+    # With the litter + undercanopy path in series on both branches, soil evaporation no
+    # longer rebounds as the soil dries through the wet → dry-layer handoff (the Sellers-only
+    # configuration rebounds because the young dry layer is far more conductive than the fit).
+    E = [LEᵍ(litter, 𝒮) for 𝒮 in 0.50:-0.03:0.14]
+    @test issorted(E, rev = true)
+
+    # The litter layer is vegetated-ground physics: the bare tile drops it and keeps the
+    # override knobs for both ground-surface resistances.
+    @test bare_canopy_air_space(litter).litter_resistance === nothing
+    @test bare_canopy_air_space(litter; litter_resistance = LitterResistance(FT)).litter_resistance isa LitterResistance
+    @test bare_canopy_air_space(sellers).wet_soil_resistance isa SellersSoilResistance
+    @test bare_canopy_air_space(sellers; wet_soil_resistance = nothing).wet_soil_resistance === nothing
+
+    # Every resistance configuration keeps the coupled solve inferred.
+    for c in (unresisted, sellers, litter)
+        @inferred canopy_air_space_solve(c, Ψ(0.5), Ψₐ, Ψᵢ, Ψᵣ, ℙₐ)
+    end
 end
 
 # A CanopyAirSpace in both interface slots is a combined formulation: one shared solve returns

--- a/test/test_tiled_land.jl
+++ b/test/test_tiled_land.jl
@@ -109,9 +109,12 @@ scalar(field) = Array(interior(field))[1, 1, 1]
         @test scalar(bare.temperature.canopy_latent_heat) == 0
         @test scalar(bare.temperature.canopy_sensible_heat) == 0
 
-        # Sunlit veg tile: shaded soil skin cooler than the leaf; more latent than the bare tile.
+        # Sunlit veg tile: shaded soil skin cooler than the leaf; transpiration dominates the
+        # tile's latent flux; and the shaded, litter-covered ground evaporates far less than
+        # the sunlit bare tile.
         @test scalar(veg.temperature.soil_skin) < scalar(veg.temperature.canopy)
-        @test scalar(veg.fluxes.latent_heat) > scalar(bare.fluxes.latent_heat)
+        @test scalar(veg.temperature.canopy_latent_heat) > scalar(veg.temperature.soil_latent_heat)
+        @test scalar(veg.temperature.soil_latent_heat) < scalar(bare.temperature.soil_latent_heat)
 
         # --- Endpoint reduction: f=1 → veg tile, f=0 → bare tile (bit-for-bit). ---
         m1 = tiled_land_model(arch, cas; fraction = 1.0)


### PR DESCRIPTION
#535 landed a `SellersSoilResistance` on the moist-soil branch of `CanopyAirSpace`. This PR completes the ground-vapor-path treatment of [Sakaguchi & Zeng (2009)](https://doi.org/10.1029/2008JD010834), Eq. 18: an explicit plant-litter resistance (their Eq. 13) in series with the undercanopy aerodynamic path on both ground branches, replacing the Sellers fit as the default.

## The litter resistance, physically

Litter is dead plant material with pores far too large for capillary suction, so the layer cannot wick liquid water up from the moist soil beneath: its top stays dry even over saturated soil, and the evaporation front stays pinned at the soil surface below it. Vapor must then cross the litter's sheltered air spaces before reaching the canopy air — a resistance in series on the vapor path (and only the vapor path: the thin layer is taken isothermal with the topsoil, so the sensible exchange `gᵍʰ` is untouched). Without it, forest-floor evaporation models run several-fold hot (Ogée & Brunet 2002 overestimate 7× over three weeks; Schaap & Bouten 1997 measure litter resistance exceeding the aerodynamic resistance under Douglas fir).

`rˡ = (1 − e^{−Lˡ})/(C u★)` depends on exactly two things:

- *How much of the ground the litter blankets.* `1 − e^{−Lˡ}` is Beer–Lambert self-shading in the litter area index `Lˡ` (m² of dead material per m² of ground): `e^{−Lˡ}` is the gap fraction seen through the layer. No litter → no resistance; beyond a few layers coverage saturates, so extra litter cannot block much more.
- *How hard the canopy air ventilates it.* `1/(C u★)` is the same aerodynamic form as the dense-canopy undercanopy conductance `gᵘᶜ = Cₛ u★` (Dickinson et al. 1993, whence `C = 0.004`): canopy-top shear sets the eddies that flush the litter's pore spaces. Wind sweeps vapor out (`rˡ` small); calm air leaves molecular diffusion through a tortuous path (`rˡ` → thousands of s m⁻¹, the 0–4000 s m⁻¹ range of Sakaguchi & Zeng's simulations).

Two dependencies are deliberately absent. Soil saturation: hydraulic disconnection is the mechanism, so the barrier does not weaken as the soil wets — the soil-moisture limitation belongs to the dry-layer branch. Litter wetness: rain-wetted litter evaporates from the interception store (Sakaguchi & Zeng's convention, litter being part of the stem/canopy interception pool), so only the dry-litter barrier is modeled.

## Public API

- New `LitterResistance` (exported): `rˡ = (1 − e^{−Lˡ})/(C u★)`, defaults `Lˡ = 1`, `C = 0.004` (≈ 530 s m⁻¹ at `u★ = 0.3`); on by default. Dead litter blankets vegetated ground: too porous for capillary rise to wet its top, it evaporates little itself while blocking vapor exchange with the soil below.
- `wet_soil_resistance` now defaults to `nothing`: the Sellers FIFE fit was measured over prairie with standing dead grass and litter, so it is an effective soil-plus-litter resistance — keep it only with `litter_resistance = nothing`, or the litter is double-counted.
- Both ground branches now cross `gᵘᶜ` in series (the sensible path always did), so soil evaporation is monotone in drying — no ≈ 3× rebound at the wet → dry-layer handoff.
- `bare_canopy_air_space` drops the litter on the bare tile (litter is vegetated-ground physics) and gains `wet_soil_resistance` / `litter_resistance` overrides.

In the #535 MWE (LAI 2, saturated bucket), latent heat goes from 171 W m⁻² unresisted to 109 W m⁻² with the default litter, converging with the unresisted path at saturation 0.2 as the dry layer takes over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
