### PR TITLE
Read prescribed surface field time series at their own cell

### DIFF
--- a/src/EarthSystemModels/InterfaceComputations/InterfaceComputations.jl
+++ b/src/EarthSystemModels/InterfaceComputations/InterfaceComputations.jl
@@ -2,9 +2,9 @@ module InterfaceComputations
 
 using Adapt: Adapt, adapt
 using Oceananigans: Oceananigans
-using Oceananigans.Fields: AbstractField, Field, Face, Center, FractionalIndices, interpolate
+using Oceananigans.Fields: AbstractField, Field, Face, Center
 using Oceananigans.Grids: Flat, topology
-using Oceananigans.OutputReaders: FieldTimeSeries, cpu_interpolating_time_indices
+using Oceananigans.OutputReaders: FieldTimeSeries, FlavorOfFTS, cpu_interpolating_time_indices
 using Oceananigans.Simulations: Simulation
 using Oceananigans.Utils: KernelParameters, worksize
 

--- a/src/EarthSystemModels/InterfaceComputations/atmosphere_land_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/atmosphere_land_fluxes.jl
@@ -168,11 +168,15 @@ end
 # `interpolate` as spatial fractional indices would also read the neighbor at
 # `(i + 1, j + 1)`, which does not exist in a `Flat` direction or at the last cell.
 #
-# TODO: move this blend into Oceananigans as `getindex(fts, i, j, k, ::TimeInterpolator)`.
-# `fts[i, j, k, Time(t)]` searches `fts.times` once per thread, so the flux kernels take a
-# `TimeInterpolator` precomputed on the host instead (as the prescribed-atmosphere path
-# does). Oceananigans accepts one only through `interpolate`, which interpolates in space
-# as well, so the two-snapshot blend is written out here. See CliMA/Oceananigans.jl#5885.
+# The indices are converted because `time_interpolator` reaches the kernel as an argument,
+# where its scalar fields can arrive as `CuTracedRNumber` rather than `Int`
+# (CliMA/Oceananigans.jl#4230).
+#
+# TODO: drop this blend once Oceananigans accepts a `TimeInterpolator` in `getindex`
+# (CliMA/Oceananigans.jl#5886), leaving `x[i, j, 1, time_interpolator]`. The flux kernels take
+# an interpolator precomputed on the host, as the prescribed-atmosphere path does, because
+# `fts[i, j, k, Time(t)]` recomputes the time indices in every thread; today Oceananigans
+# accepts one only through `interpolate`, which interpolates in space as well.
 @inline function surface_field_value(x::FlavorOfFTS, i, j, time_interpolator)
     ñ  = time_interpolator.fractional_index
     n₁ = convert(Int, time_interpolator.first_index)
@@ -187,7 +191,7 @@ end
 # Host-side: pair a prescribed-surface spec (LAI, vegetation fraction, …) with the time
 # index used to interpolate it. Constants and static fields pass through untouched
 # (`nothing` interpolator); a `FieldTimeSeries` keeps its time index precomputed on the
-# host, so the kernel never searches `times`.
+# host, so the kernel does not recompute it.
 @inline kernel_surface_field(surface_field, arch, time) = (surface_field, nothing)
 @inline function kernel_surface_field(surface_field::FieldTimeSeries, arch, time)
     time_interpolator = cpu_interpolating_time_indices(arch, surface_field.times,

--- a/src/EarthSystemModels/InterfaceComputations/atmosphere_land_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/atmosphere_land_fluxes.jl
@@ -159,35 +159,40 @@ end
 #####
 ##### Prescribed, possibly time-varying surface inputs.
 ##### `surface_field_value` reads the per-cell value from a `Number`, a static
-##### `Field`, or — for a `FieldTimeSeries` interpolated to the model clock — a
-##### kernel-friendly `PrescribedSurfaceData` bundle.
+##### `Field`, or a `FieldTimeSeries` interpolated to the model clock.
 #####
 
-struct PrescribedSurfaceData{D, B, T}
-    data          :: D
-    backend       :: B
-    time_indexing :: T
+@inline surface_field_value(x, i, j, time_interpolator) = state2dindex(x, i, j)
+
+# `i, j` name an exact cell, so the value is interpolated in time only. Passing them to
+# `interpolate` as spatial fractional indices would also read the neighbor at
+# `(i + 1, j + 1)`, which does not exist in a `Flat` direction or at the last cell.
+#
+# TODO: move this blend into Oceananigans as `getindex(fts, i, j, k, ::TimeInterpolator)`.
+# `fts[i, j, k, Time(t)]` searches `fts.times` once per thread, so the flux kernels take a
+# `TimeInterpolator` precomputed on the host instead (as the prescribed-atmosphere path
+# does). Oceananigans accepts one only through `interpolate`, which interpolates in space
+# as well, so the two-snapshot blend is written out here. See CliMA/Oceananigans.jl#5885.
+@inline function surface_field_value(x::FlavorOfFTS, i, j, time_interpolator)
+    ñ  = time_interpolator.fractional_index
+    n₁ = convert(Int, time_interpolator.first_index)
+    n₂ = convert(Int, time_interpolator.second_index)
+
+    @inbounds ψ₁ = x[i, j, 1, n₁]
+    @inbounds ψ₂ = x[i, j, 1, n₂]
+
+    return ifelse(n₁ == n₂, ψ₁, ψ₂ * ñ + ψ₁ * (1 - ñ))
 end
 
-Adapt.adapt_structure(to, p::PrescribedSurfaceData) =
-    PrescribedSurfaceData(adapt(to, p.data), adapt(to, p.backend), adapt(to, p.time_indexing))
-
-@inline surface_field_value(x, i, j, time_interpolator) = state2dindex(x, i, j)
-@inline surface_field_value(x::PrescribedSurfaceData, i, j, time_interpolator) =
-    interpolate(FractionalIndices(i, j, nothing), time_interpolator, x.data, x.backend, x.time_indexing)
-
-# Host-side: reduce a prescribed-surface spec (LAI, vegetation fraction, …) to a
-# kernel-friendly value plus the time index used to interpolate it. Constants and
-# static fields pass through untouched (`nothing` interpolator); a
-# `FieldTimeSeries` is reduced to its arrays and its time index is precomputed on
-# the host.
+# Host-side: pair a prescribed-surface spec (LAI, vegetation fraction, …) with the time
+# index used to interpolate it. Constants and static fields pass through untouched
+# (`nothing` interpolator); a `FieldTimeSeries` keeps its time index precomputed on the
+# host, so the kernel never searches `times`.
 @inline kernel_surface_field(surface_field, arch, time) = (surface_field, nothing)
 @inline function kernel_surface_field(surface_field::FieldTimeSeries, arch, time)
     time_interpolator = cpu_interpolating_time_indices(arch, surface_field.times,
                                                        surface_field.time_indexing, time)
-    bundle = PrescribedSurfaceData(surface_field.data, surface_field.backend,
-                                   surface_field.time_indexing)
-    return bundle, time_interpolator
+    return surface_field, time_interpolator
 end
 
 # The LAI spec lives on the canopy humidity formulation; other formulations carry

--- a/test/test_field_valued_lai.jl
+++ b/test/test_field_valued_lai.jl
@@ -7,7 +7,7 @@ using Oceananigans.OutputReaders: FieldTimeSeries
 using Oceananigans.TimeSteppers: update_state!
 using NumericalEarth.EarthSystemModels.InterfaceComputations:
     CanopyConductanceHumidity, JarvisConductance,
-    surface_field_value, kernel_surface_field, PrescribedSurfaceData,
+    surface_field_value, kernel_surface_field,
     interface_vegetation_state
 using NumericalEarth.Lands: SlabLand, SlabEnergy, SaturatedSurface
 using NumericalEarth.Atmospheres: PrescribedAtmosphere
@@ -49,7 +49,7 @@ using NumericalEarth.Atmospheres: PrescribedAtmosphere
         _,      titpmid = kernel_surface_field(lai_fts, arch, 50.0)
         _,      titp1   = kernel_surface_field(lai_fts, arch, 100.0)
 
-        @test bundle isa PrescribedSurfaceData
+        @test bundle === lai_fts
         @test surface_field_value(bundle, 1, 1, titp0)   ≈ FT(1)
         @test surface_field_value(bundle, 1, 1, titpmid) ≈ FT(3)   # midpoint
         @test surface_field_value(bundle, 1, 1, titp1)   ≈ FT(5)


### PR DESCRIPTION
`surface_field_value` reads a prescribed surface input (LAI, tile fraction) at cell `(i, j)`, interpolated to the model clock. For a `FieldTimeSeries` input it went through Oceananigans' combined space-and-time `interpolate`:

```julia
interpolate(FractionalIndices(i, j, nothing), time_interpolator, x.data, x.backend, x.time_indexing)
```

`FractionalIndices` holds positions in index space, where `2.7` means "70% of the way from cell 2 to cell 3", and `interpolator` expands each component into `(left, right, weight)`. Handed the integer `i`, that is `(i, i + 1, 0)`: the weight on `i + 1` is zero, so the value is correct, but the blend still reads cell `i + 1`. In a `Flat` direction the array spans `1:1` and that cell does not exist — and `Flat` dimensions take no halo, so there is no version of that call which stays in bounds on a column grid.

`_interpolate` is `@inbounds`, so this normally reads past the array and multiplies by zero. `Pkg.test` runs with `--check-bounds=yes`, which turns it into the error in `test_field_valued_lai`:

```
BoundsError: attempt to access 1×1×1×2 OffsetArray(::Array{Float64, 4}, 1:1, 1:1, 1:1, 1:2) at index [1, 2, 1, 1]
```

`i, j` already name an exact cell, so read that cell at the two bracketing snapshots and blend in time, keeping Oceananigans' `n₁ == n₂` endpoint handling. Values are unchanged. Zero weight is not harmless either — the corner is still multiplied, so a NaN neighbor (an unfilled halo, an ocean-masked LAI map) would propagate.

This also removes `PrescribedSurfaceData`. It held `(data, backend, time_indexing)` to get a `FieldTimeSeries` into a kernel, but `adapt` already reduces one to `GPUAdaptedFieldTimeSeries`, which is those same fields plus `times` — so the series can be passed directly. `getindex(::FlavorOfFTS, i, j, k, n::Int)` applies `memory_index` itself, which drops that call too. The remaining hand-rolled piece is the two-snapshot blend, marked TODO against CliMA/Oceananigans.jl#5886, which reduces this method to `x[i, j, 1, time_interpolator]`.

This is one of the two errors in `test_field_valued_lai`. The other comes from out-of-range exchange-grid halo fractional indices, fixed on `main` in #547 — that testset stays red here until `main` is merged into `xk/slab-canopy`.