### PR TITLE
GloFAS: update request to the current EWDS API

### DIFF
--- a/ext/NumericalEarthCDSAPIExt/NumericalEarthCDSAPIExt.jl
+++ b/ext/NumericalEarthCDSAPIExt/NumericalEarthCDSAPIExt.jl
@@ -19,7 +19,7 @@ using NumericalEarth.DataWrangling.ERA5: ERA5Dataset, ERA5Metadata, ERA5Metadatu
                                          batch_datetimes_for_cds, foreach_nc,
                                          split_era5_nc, split_era5_nc_by_datetime
 using NumericalEarth.DataWrangling.GloFAS: GloFASDataset, GloFASMetadata, GloFASMetadatum,
-                                           GloFAS_netcdf_variable_names
+                                           GloFAS_dataset_variable_names, GloFAS_netcdf_variable_names
 using NumericalEarth.DataWrangling.CopernicusLandAlbedo: ALBEDO_CDS_PRODUCT,
                                                          CopernicusAlbedoDatasetMetadata,
                                                          download_albedo_dekads!

--- a/ext/NumericalEarthCDSAPIExt/glofas.jl
+++ b/ext/NumericalEarthCDSAPIExt/glofas.jl
@@ -46,7 +46,7 @@ const GLOFAS_COORD_VARS = Set(["longitude", "latitude",
     build_glofas_request(dataset, datetimes, region) -> Dict{String, Any}
 
 Construct the EWDS request for a batch of GloFAS dates that share a `(year, month)`.
-GloFAS uses the `hyear`/`hmonth`/`hday` date keys (interpreted as a Cartesian product).
+GloFAS uses `year`/`month`/`day` date keys (interpreted as a Cartesian product).
 A `BoundingBox` `region` is sent as an `area` key so the EWDS subsets server-side.
 """
 function build_glofas_request(dataset, datetimes, region)
@@ -60,10 +60,11 @@ function build_glofas_request(dataset, datetimes, region)
         "system_version"     => [dataset.system_version],
         "hydrological_model" => ["lisflood"],
         "product_type"       => ["consolidated"],
-        "variable"           => ["river_discharge_in_the_last_24_hours"],
-        "hyear"              => years,
-        "hmonth"             => months,
-        "hday"               => days,
+        "timespan"           => ["time_mean"],
+        "variable"           => [GloFAS_dataset_variable_names[:river_discharge]],
+        "year"               => years,
+        "month"              => months,
+        "day"                => days,
         "data_format"        => "netcdf",
         "download_format"    => "unarchived",
     )
@@ -140,7 +141,9 @@ function download_glofas_month(name, dataset, dates; region, dir, skip_existing,
     dt0 = first(sorted_dts)
     tmp_path = joinpath(dir, "_tmp_glofas_$(Dates.year(dt0))$(lpad(Dates.month(dt0), 2, '0')).nc")
     nc_varname = GloFAS_netcdf_variable_names[name]
-    nc_triples = [(nc_varname, dt, path) for (dt, path) in pending]
+    # the EWDS stamps each daily mean at the END of its averaging window: the slice for
+    # request day D carries valid_time D+1 00:00 (mean over [D, D+1])
+    nc_triples = [(nc_varname, dt + Dates.Day(1), path) for (dt, path) in pending]
 
     @root begin
         glofas_retrieve(glofas_product(dataset), request, tmp_path)

--- a/src/DataWrangling/GloFAS/glofas_reanalysis.jl
+++ b/src/DataWrangling/GloFAS/glofas_reanalysis.jl
@@ -27,12 +27,12 @@ DataWrangling.all_dates(::GloFASReanalysis, variable) =
 
 # NumericalEarth name → CDS API variable name.
 GloFAS_dataset_variable_names = Dict(
-    :river_discharge => "river_discharge_in_the_last_24_hours",
+    :river_discharge => "average_river_discharge_in_the_last_24_hours",
 )
 
-# NumericalEarth name → NetCDF short variable name (as stored in downloaded files).
+# NumericalEarth name → NetCDF short variable name.
 GloFAS_netcdf_variable_names = Dict(
-    :river_discharge => "dis24",
+    :river_discharge => "avg_dis",
 )
 
 DataWrangling.available_variables(::GloFASDataset) = GloFAS_dataset_variable_names

--- a/test/test_cds_downloading.jl
+++ b/test/test_cds_downloading.jl
@@ -14,6 +14,7 @@ using NumericalEarth.DataWrangling.ERA5: ERA5HourlyPressureLevels, ERA5MonthlyPr
                                          ERA5_all_pressure_levels, ERA5PL_dataset_variable_names,
                                          ERA5PL_netcdf_variable_names, pressure_field
 using NumericalEarth.DataWrangling.ERA5: split_era5_nc_by_datetime, ERA5_COORD_VARS, ERA5_TIME_DIMNAMES
+using NumericalEarth.DataWrangling.GloFAS: GloFASReanalysis, GloFAS_dataset_variable_names
 # ERA5-owned batching / NetCDF helpers are exercised at their owner module, not through the
 # CDS extension (the extension no longer re-imports the ones it does not itself use).
 using NumericalEarth.DataWrangling.ERA5: max_dts_per_cds_request, is_zip, ncvar_copy!, ncvar_copy_tslice!,
@@ -1295,5 +1296,52 @@ end
 
             @test sort(received) == ["a.nc", "b.nc"]   # readme.txt filtered out
         end
+    end
+end
+
+#####
+##### GloFAS
+#####
+
+@testset "GloFAS CDSAPIExt build_glofas_request" begin
+    dataset = GloFASReanalysis()
+    bbox    = BoundingBox(longitude=(-62.0, -61.0), latitude=(-3.0, -2.0))
+    dt      = DateTime(2020, 1, 15)
+
+    @testset "Single date" begin
+        req = CDSExt.build_glofas_request(dataset, dt, nothing)
+
+        @test req["year"]     == ["2020"]
+        @test req["month"]    == ["01"]
+        @test req["day"]      == ["15"]
+        @test req["timespan"] == ["time_mean"]
+        @test req["variable"] == [GloFAS_dataset_variable_names[:river_discharge]]
+
+        @test req["system_version"]     == [dataset.system_version]
+        @test req["hydrological_model"] == ["lisflood"]
+        @test req["product_type"]       == ["consolidated"]
+        @test req["data_format"]        == "netcdf"
+        @test req["download_format"]    == "unarchived"
+
+        @test !haskey(req, "area")
+    end
+
+    @testset "Dates in one month collapse to a Cartesian product" begin
+        dts = [DateTime(2020, 1, 15), DateTime(2020, 1, 16), DateTime(2020, 1, 16)]
+        req = CDSExt.build_glofas_request(dataset, dts, nothing)
+
+        @test req["year"]  == ["2020"]
+        @test req["month"] == ["01"]
+        @test req["day"]   == ["15", "16"]
+    end
+
+    @testset "BoundingBox region is sent as area in [N, W, S, E] order" begin
+        req = CDSExt.build_glofas_request(dataset, dt, bbox)
+        @test req["area"] == [-1.8, -62.2, -3.2, -60.8]
+    end
+
+    @testset "Metadatum resolves the NetCDF short name" begin
+        metadatum = Metadatum(:river_discharge; dataset, date=dt)
+        @test NumericalEarth.DataWrangling.dataset_variable_name(metadatum) == "avg_dis"
     end
 end


### PR DESCRIPTION
Per [ECMWF/CEMS](https://confluence.ecmwf.int/spaces/CEMS/pages/699325478/Changes+to+the+EWDS+API+Request+to+download+GloFAS+Historical), the GloFAS Historical dataset EWDS API requests have been updated.

**Date parameters renamed**
`hyear` → `year`, `hmonth` → `month`, `hday` → `day`

**New mandatory parameter**
A `timespan` parameter now distinguishes instantaneous from time-mean variables and must be included in every request. We send `timespan = "time_mean"`.

**Discharge variable renamed**
`river_discharge_in_the_last_24_hours` → `average_river_discharge_in_the_last_24_hours`, and the NetCDF short name `dis24` → `avg_dis`.

This addresses #551.