### PR TITLE
Checkpoint SlabLand's coupler-written forcing fields

### DIFF
--- a/src/Lands/slab_land.jl
+++ b/src/Lands/slab_land.jl
@@ -238,16 +238,24 @@ end
 # cross-component contexts (coupling, the all-components notation table).
 Oceananigans.prognostic_fields(land::SlabLand) = (; T = land.temperature, M = land.water_storage)
 
+# The coupler-written flux/forcing fields are staggered state: computed at the
+# end of each coupled step and consumed by the next `time_step!(land, Δt)`, so
+# exact restarts must carry them alongside the prognostic fields.
 function Oceananigans.prognostic_state(land::SlabLand)
     return (; clock         = prognostic_state(land.clock),
               temperature   = prognostic_state(land.temperature),
-              water_storage = prognostic_state(land.water_storage))
+              water_storage = prognostic_state(land.water_storage),
+              fluxes        = map(prognostic_state, land.fluxes))
 end
 
 function Oceananigans.restore_prognostic_state!(land::SlabLand, state)
     restore_prognostic_state!(land.clock,         state.clock)
     restore_prognostic_state!(land.temperature,   state.temperature)
     restore_prognostic_state!(land.water_storage, state.water_storage)
+    forcing = hasproperty(state, :fluxes) ? state.fluxes : (;)
+    for name in keys(land.fluxes)
+        hasproperty(forcing, name) && restore_prognostic_state!(land.fluxes[name], forcing[name])
+    end
     update_state!(land)
     return land
 end

--- a/test/test_slab_land.jl
+++ b/test/test_slab_land.jl
@@ -399,6 +399,60 @@ end
     end
 end
 
+@testset "SlabLand coupled checkpoint round-trip" begin
+    # The coupler-written forcing fields (`land.fluxes`) are computed at the end
+    # of each coupled step and consumed by the next `time_step!(land, Δt)`, so a
+    # restored model must carry them to be step-for-step identical to the
+    # uninterrupted run.
+    using Oceananigans.TimeSteppers: time_step!
+    using NumericalEarth.Atmospheres: PrescribedAtmosphere
+    using NumericalEarth.Radiations: PrescribedRadiation, SurfaceRadiationProperties
+    using NumericalEarth.Lands: BucketHydrology, SlabEnergy
+
+    function coupled_slab_model(arch)
+        grid = LatitudeLongitudeGrid(arch, Float64; size = 1, latitude = 10, longitude = 10,
+                                     z = (-1, 0), topology = (Flat, Flat, Bounded))
+        atmosphere = PrescribedAtmosphere(grid; surface_layer_height = 10, boundary_layer_height = 512)
+        fill!(parent(atmosphere.temperature), 300.0)
+        fill!(parent(atmosphere.specific_humidity), 0.008)
+        fill!(parent(atmosphere.velocities.u), 3.0)
+        fill!(parent(atmosphere.pressure), 101325.0)
+        land = SlabLand(grid; hydrology = BucketHydrology(Float64; maximum_water_storage = 150.0),
+                        energy = SlabEnergy(Float64))
+        set!(land; T = 298.0)
+        fill!(parent(land.water_storage), 90.0)
+        radiation = PrescribedRadiation(grid; ocean_surface = nothing, sea_ice_surface = nothing,
+                                        land_surface = SurfaceRadiationProperties(0.2, 0.95))
+        fill!(parent(radiation.downwelling_shortwave), 600.0)
+        fill!(parent(radiation.downwelling_longwave), 350.0)
+        update_state!(radiation)
+        model = AtmosphereLandModel(atmosphere, land; radiation)
+        update_state!(model.land)
+        update_state!(model)
+        return model
+    end
+
+    for arch in test_architectures
+        m1 = coupled_slab_model(arch)
+        m2 = coupled_slab_model(arch)
+        for _ in 1:6
+            time_step!(m1, 300.0)
+        end
+        restore_prognostic_state!(m2, deepcopy(prognostic_state(m1)))
+        for _ in 1:6
+            time_step!(m1, 300.0)
+            time_step!(m2, 300.0)
+        end
+        v(f) = Array(interior(f))[1, 1, 1]
+        @test v(m2.land.temperature) ≈ v(m1.land.temperature)
+        @test v(m2.land.water_storage) ≈ v(m1.land.water_storage)
+        @test v(m2.interfaces.atmosphere_land_interface.fluxes.latent_heat) ≈
+              v(m1.interfaces.atmosphere_land_interface.fluxes.latent_heat)
+        @test v(m2.interfaces.atmosphere_land_interface.fluxes.sensible_heat) ≈
+              v(m1.interfaces.atmosphere_land_interface.fluxes.sensible_heat)
+    end
+end
+
 @testset "Atmosphere-Land turbulent fluxes (analytic neutral)" begin
     for arch in test_architectures
         grid = LatitudeLongitudeGrid(arch, Float64;


### PR DESCRIPTION
A coupled model restored from `prognostic_state`/`restore_prognostic_state!` was not step-for-step identical to the uninterrupted run: `land.fluxes` — the forcing fields the coupler writes at the end of each step and `time_step!(land, Δt)` consumes at the start of the next — was not checkpointed, so the first restored step integrated the slab with stale forcing. (The interface's own fields are recomputed inside `update_state!` before anything consumes them, so they need no checkpointing.)

- `SlabLand`'s `prognostic_state` gains a `fluxes` entry; restore is tolerant of older checkpoints without one.
- Coupled round-trip test: spin up, checkpoint, restore into a fresh model, continue both — land state and interface fluxes identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)