### PR TITLE
Fix TiledLandInterface dispatch in the NaN checker and checkpoint paths

### DIFF
--- a/src/EarthSystemModels/InterfaceComputations/component_interfaces.jl
+++ b/src/EarthSystemModels/InterfaceComputations/component_interfaces.jl
@@ -233,7 +233,7 @@ EarthSystemModels.surface_temperature(interfaces::ComponentInterfaces) =
                                           interfaces.atmosphere_ocean_interface)
 
 EarthSystemModels.surface_temperature(land_interface::AtmosphereInterface, ocean_interface) =
-    land_interface.temperature
+    interface_node_temperature(land_interface.temperature)
 EarthSystemModels.surface_temperature(::Nothing, ocean_interface::AtmosphereInterface) =
     ocean_interface.temperature
 EarthSystemModels.surface_temperature(::Nothing, ::Nothing) = nothing

--- a/src/EarthSystemModels/InterfaceComputations/tiled_land_interface.jl
+++ b/src/EarthSystemModels/InterfaceComputations/tiled_land_interface.jl
@@ -137,6 +137,22 @@ Base.show(io::IO, ti::TiledLandInterface) =
 # The atmosphere-facing surface temperature is the blended canopy-air node (the same
 # NamedTuple signal a single CanopyAirSpace uses).
 EarthSystemModels.surface_temperature(ti::TiledLandInterface) = interface_node_temperature(ti.temperature)
+EarthSystemModels.surface_temperature(ti::TiledLandInterface, ::Nothing) =
+    EarthSystemModels.surface_temperature(ti)
+
+# Checkpointing: each tile is an ordinary `AtmosphereInterface`, so its prognostic
+# interface state (canopy-air node, prognostic skin) round-trips tile by tile.
+interface_prognostic_state(ti::TiledLandInterface) =
+    (; vegetated = interface_prognostic_state(ti.vegetated),
+       bare      = interface_prognostic_state(ti.bare))
+
+restore_interface_state!(ti::TiledLandInterface, ::Nothing) = nothing
+
+function restore_interface_state!(ti::TiledLandInterface, state)
+    restore_interface_state!(ti.vegetated, state.vegetated)
+    restore_interface_state!(ti.bare, state.bare)
+    return nothing
+end
 
 """
     leaf_area_index_cover_fraction(leaf_area_index; extinction=0.5, clumping=1)


### PR DESCRIPTION
`surface_temperature(interfaces)` and `prognostic_state(interfaces)` dispatch only on `AtmosphereInterface`, so a `TiledLandInterface` raises a `MethodError` from `Simulation`'s default NaN checker and from checkpointing; the two-argument `surface_temperature` also returns the raw `CanopyAirSpaceDiagnostics` instead of the node-temperature `Field` for a single `CanopyAirSpace`.

MWE:
```julia
using NumericalEarth, Oceananigans
grid = LatitudeLongitudeGrid(size = (4, 4), longitude = (0, 1), latitude = (0, 1),
                             topology = (Bounded, Bounded, Flat))
atmosphere = PrescribedAtmosphere(grid, [0.0, 3600.0])
land = SlabLand(grid)
cas = CanopyAirSpace(soil = DryLayerHumidity(porosity = 0.4))
interface = TiledLandInterface(grid, atmosphere, land; vegetated = cas, fraction = 0.5)
model = AtmosphereLandModel(atmosphere, land; atmosphere_land_interface = interface)
Simulation(model, Δt = 60, stop_time = 3600)   # MethodError: surface_temperature
```

- Blended node temperature returned for `(::TiledLandInterface, ::Nothing)` and unwrapped via `interface_node_temperature` in the two-argument method
- Per-tile `interface_prognostic_state` / `restore_interface_state!`, so the prognostic canopy-air node and skin round-trip through checkpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)