### PR TITLE
Convert prognostic interface flux scales to the state float type

### DIFF
--- a/src/EarthSystemModels/InterfaceComputations/atmosphere_land_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/atmosphere_land_fluxes.jl
@@ -149,14 +149,16 @@ end
 
     # Exported scales at the step-mean node (the same floored transfer coefficients
     # the node balance uses), so −ρ cᵖ u★ θ★ = gᵃʰ (T̄ − θᵃᵗ) and the vapor analog.
-    θᵃᵗ = surface_atmosphere_temperature(Ψₐ, ℙₐ)
+    # `InterfaceFluxScales` fields share one type: convert, since the thermodynamic
+    # constants (and hence θᵃᵗ) may carry a wider float type than the state.
+    θᵃᵗ = convert(FT, surface_atmosphere_temperature(Ψₐ, ℙₐ))
     χθ⁺ = max(zero(FT), Ψₛ.fluxes.χθ)
     χq⁺ = max(zero(FT), Ψₛ.fluxes.χq)
     fluxes = InterfaceFluxScales(Ψₛ.fluxes.u★,
-                                 χθ⁺ * (θᵃᵗ - T̄),
-                                 χq⁺ * (Ψₐ.q - q̄),
+                                 convert(FT, χθ⁺ * (θᵃᵗ - T̄)),
+                                 convert(FT, χq⁺ * (Ψₐ.q - q̄)),
                                  Ψₛ.fluxes.χθ, Ψₛ.fluxes.χq)
-    return rebuild_interface_state(Ψₛ, fluxes, T⁺, q⁺)
+    return rebuild_interface_state(Ψₛ, fluxes, convert(FT, T⁺), convert(FT, q⁺))
 end
 
 # A prognostic energy-balance skin reads its stored temperature back from the
@@ -202,9 +204,9 @@ end
     u★  = Ψₛ.fluxes.u★
     χθ⁺ = max(zero(FT), Ψₛ.fluxes.χθ)
     χq⁺ = max(zero(FT), Ψₛ.fluxes.χq)
-    Tᵃᵗ = surface_atmosphere_temperature(Ψₐ, ℙₐ)
+    Tᵃᵗ = convert(FT, surface_atmosphere_temperature(Ψₐ, ℙₐ))
     q⁺  = compute_interface_humidity(ℙₛ.specific_humidity_formulation, T⁺, Ψₛ, Ψₐ, Ψᵢ, Ψᵣ, ℙₐ)
-    fluxes = InterfaceFluxScales(u★, χθ⁺ * (Tᵃᵗ - T⁺), χq⁺ * (Ψₐ.q - q⁺),
+    fluxes = InterfaceFluxScales(u★, convert(FT, χθ⁺ * (Tᵃᵗ - T⁺)), convert(FT, χq⁺ * (Ψₐ.q - q⁺)),
                                  Ψₛ.fluxes.χθ, Ψₛ.fluxes.χq)
     return rebuild_interface_state(Ψₛ, fluxes, convert(FT, T⁺), convert(FT, q⁺))
 end


### PR DESCRIPTION
The prognostic canopy-air and skin advances build `InterfaceFluxScales` — whose five fields share one type — from products involving `surface_atmosphere_temperature`, which inherits the thermodynamic constants' float type. With `Float64` constants over a `Float32` interface state (what the Breeze coupling adapter supplies) the constructor call has no matching method; on the GPU this surfaces as an `InvalidIRError` when compiling `_compute_atmosphere_land_interface_state!` with `storage = PrognosticCanopyAir(...)` or a `PrognosticSkin`, and on the CPU it would throw at the first coupled step.

`convert(FT, ...)` on the temperature and the two flux-scale products, mirroring the convention the diagnostic paths already follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)