### PR TITLE
Optional texture-class retention curve for PlantAvailableWaterStress

### DIFF
--- a/src/EarthSystemModels/EarthSystemModels.jl
+++ b/src/EarthSystemModels/EarthSystemModels.jl
@@ -14,6 +14,7 @@ export
     FractionalHumidity,
     CriticalSaturation,
     PlantAvailableWaterStress,
+    van_genuchten_texture_parameters,
     DryLayerHumidity,
     StorageBasedDryLayerDepth,
     DryLayerVaporPistonVelocity,

--- a/src/EarthSystemModels/InterfaceComputations/InterfaceComputations.jl
+++ b/src/EarthSystemModels/InterfaceComputations/InterfaceComputations.jl
@@ -48,6 +48,7 @@ export
     FractionalHumidity,
     CriticalSaturation,
     PlantAvailableWaterStress,
+    van_genuchten_texture_parameters,
     DryLayerHumidity,
     StorageBasedDryLayerDepth,
     DryLayerVaporPistonVelocity,

--- a/src/EarthSystemModels/InterfaceComputations/atmosphere_land_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/atmosphere_land_fluxes.jl
@@ -33,9 +33,9 @@ function atmosphere_land_interface(grid, atmosphere, land;
     if requires_retention_curve(specific_humidity) && isnothing(surface_retention_curve(land))
         throw(ArgumentError("$(summary(specific_humidity)) measures plant-available water on " *
                             "the soil's retention curve, but this land's hydrology carries none. " *
-                            "Use a hydrology that owns one (VariablySaturatedHydrology), or a " *
-                            "moisture stress defined on the hydrology's own saturation " *
-                            "(CriticalSaturation)."))
+                            "Use a hydrology that owns one (VariablySaturatedHydrology), a " *
+                            "moisture stress carrying its own texture-class curve, or one defined " *
+                            "on the hydrology's own saturation (CriticalSaturation)."))
     end
     al_fluxes = AtmosphereSurfaceFluxes(grid)
     al_properties = InterfaceProperties(specific_humidity, temperature, velocity_difference)
@@ -361,15 +361,25 @@ end
     interface_hydrology_state(i, j, grid, q.efficiency, land_state)
 @inline requires_retention_curve(q::FractionalHumidity) = requires_retention_curve(q.efficiency)
 @inline interface_hydrology_state(i, j, grid, ::CriticalSaturation, land_state) = land_saturation(i, j, grid, land_state)
-# The stress endpoints live on the *land's* retention curve, whose parameters may vary
-# per cell; evaluate them here, once per cell, so the flux solve reads plain scalars.
+# The stress endpoints live on a retention curve — the closure's own texture-class curve
+# when it carries one, otherwise the *land's* curve, whose parameters may vary per cell;
+# evaluate them here, once per cell, so the flux solve reads plain scalars.
+@inline stress_endpoint_saturation(i, j, grid, ::HydrologyCurveWaterStress, land_state, ψ) =
+    effective_saturation(i, j, grid, land_state.retention_curve, ψ)
+
+@inline function stress_endpoint_saturation(i, j, grid, p::PlantAvailableWaterStress, land_state, ψ)
+    FT = typeof(ψ)
+    α = convert(FT, p.inverse_air_entry_head)
+    n = convert(FT, p.pore_size_uniformity)
+    return van_genuchten_saturation(α * ψ, n)
+end
+
 @inline function interface_hydrology_state(i, j, grid, p::PlantAvailableWaterStress, land_state)
     𝒮 = state2dindex(land_state.saturation, i, j)
     FT = typeof(𝒮)
-    r  = land_state.retention_curve
     return (saturation = 𝒮,
-            field_capacity_saturation = effective_saturation(i, j, grid, r, convert(FT, p.field_capacity_head)),
-            wilting_saturation        = effective_saturation(i, j, grid, r, convert(FT, p.wilting_point_head)))
+            field_capacity_saturation = stress_endpoint_saturation(i, j, grid, p, land_state, convert(FT, p.field_capacity_head)),
+            wilting_saturation        = stress_endpoint_saturation(i, j, grid, p, land_state, convert(FT, p.wilting_point_head)))
 end
 @inline interface_hydrology_state(i, j, grid, ::DryLayerHumidity, land_state) =
     land_saturation(i, j, grid, land_state)

--- a/src/EarthSystemModels/InterfaceComputations/moisture_stress.jl
+++ b/src/EarthSystemModels/InterfaceComputations/moisture_stress.jl
@@ -34,8 +34,59 @@ end
 # Constant efficiency — a uniformly sub-saturated surface; reads no land state.
 @inline evaporation_efficiency(β::Number, hydrology) = β
 
+# The van Genuchten (1980) shape relation and effective-saturation curve at
+# dimensionless suction αψ ≥ 0 — one home for the algebra `VariablySaturatedHydrology`'s
+# retention curve shares. Defined here (not in `Lands`) because the interface modules
+# load first; `Lands` imports these.
+@inline van_genuchten_m(n) = 1 - 1/n
+@inline van_genuchten_saturation(αψ, n) = (1 + αψ^n)^(-van_genuchten_m(n))
+
+const CARSEL_PARRISH_RETENTION = (
+    sand            = (inverse_air_entry_head = 14.5, pore_size_uniformity = 2.68),
+    loamy_sand      = (inverse_air_entry_head = 12.4, pore_size_uniformity = 2.28),
+    sandy_loam      = (inverse_air_entry_head = 7.5,  pore_size_uniformity = 1.89),
+    loam            = (inverse_air_entry_head = 3.6,  pore_size_uniformity = 1.56),
+    silt            = (inverse_air_entry_head = 1.6,  pore_size_uniformity = 1.37),
+    silt_loam       = (inverse_air_entry_head = 2.0,  pore_size_uniformity = 1.41),
+    sandy_clay_loam = (inverse_air_entry_head = 5.9,  pore_size_uniformity = 1.48),
+    clay_loam       = (inverse_air_entry_head = 1.9,  pore_size_uniformity = 1.31),
+    silty_clay_loam = (inverse_air_entry_head = 1.0,  pore_size_uniformity = 1.23),
+    sandy_clay      = (inverse_air_entry_head = 2.7,  pore_size_uniformity = 1.23),
+    silty_clay      = (inverse_air_entry_head = 0.5,  pore_size_uniformity = 1.09),
+    clay            = (inverse_air_entry_head = 0.8,  pore_size_uniformity = 1.09))
+
+"""
+    van_genuchten_texture_parameters(texture)
+
+The [Carsel and Parrish (1988)](@cite carsel1988) mean van Genuchten retention parameters
+`(; inverse_air_entry_head, pore_size_uniformity)` (`α` in m⁻¹ and `n`) for a USDA soil
+texture class — the parameter source a plant stress closure wants, as opposed to
+moisture-matched pedotransfer fits. `texture` is one of
+
+    :sand, :loamy_sand, :sandy_loam, :loam, :silt, :silt_loam,
+    :sandy_clay_loam, :clay_loam, :silty_clay_loam, :sandy_clay, :silty_clay, :clay
+
+```jldoctest
+using NumericalEarth
+
+van_genuchten_texture_parameters(:loam)
+
+# output
+(inverse_air_entry_head = 3.6, pore_size_uniformity = 1.56)
+```
+"""
+function van_genuchten_texture_parameters(texture::Symbol)
+    haskey(CARSEL_PARRISH_RETENTION, texture) ||
+        throw(ArgumentError("unknown soil texture class :$texture; expected one of " *
+                            join(string.(":", keys(CARSEL_PARRISH_RETENTION)), ", ")))
+    return CARSEL_PARRISH_RETENTION[texture]
+end
+
 """
     PlantAvailableWaterStress(FT = Oceananigans.defaults.FloatType;
+                              texture = nothing,
+                              inverse_air_entry_head = nothing,
+                              pore_size_uniformity = nothing,
                               field_capacity_head = 1,
                               wilting_point_head = 150)
 
@@ -46,17 +97,28 @@ the permanent wilting point to 1 at field capacity,
 β(𝒮) = \\mathrm{clamp}\\left(\\frac{𝒮 - 𝒮ʷᵖ}{𝒮ᶠᶜ - 𝒮ʷᵖ}, 0, 1\\right),
 ```
 
-where `𝒮ᶠᶜ` and `𝒮ʷᵖ` are the effective saturations at the two suction heads. The
-closure holds the heads, which are plant properties; the curve they are evaluated on
-comes from the land's own hydrology, per cell, so the stress and the soil cannot
-disagree. A hydrology carrying no retention curve (e.g. [`BucketHydrology`](@ref),
-whose `𝒮` is a fill fraction rather than a retention-curve saturation) is rejected when
-the interface is built.
+where `𝒮ᶠᶜ` and `𝒮ʷᵖ` are the effective saturations at the two suction heads. The default
+heads follow [Balsamo et al. (2009)](@cite balsamo2009): `ψᶠᶜ = 1` m and `ψʷᵖ = 150` m of
+suction.
 
-The default heads follow [Balsamo et al. (2009)](@cite balsamo2009): `ψᶠᶜ = 1` m and
-`ψʷᵖ = 150` m of suction.
+The retention curve the heads are evaluated on may come from two places:
 
-Because `β` is a ratio of effective saturations on one curve, the porosity and the
+  * **The closure's own curve** — pass a USDA `texture` class (`:loam`, `:silt_loam`, … —
+    resolved through [`van_genuchten_texture_parameters`](@ref)) or explicit
+    `inverse_air_entry_head` `α` (m⁻¹) and `pore_size_uniformity` `n`.
+  * **The land's own retention curve, per cell** (the default, when neither is given).
+    A hydrology carrying no retention curve (e.g. [`BucketHydrology`](@ref), whose `𝒮`
+    is a fill fraction rather than a retention-curve saturation) is rejected when the
+    interface is built.
+
+!!! warning "Pedotransfer curves over-stress the canopy"
+    Prefer texture-class retention parameters ([Carsel and Parrish (1988)](@cite carsel1988))
+    when the hydrology's curve comes from a pedotransfer reduction: fits matched through
+    the very field-capacity and wilting heads spanned here push `n` toward 1, and on such
+    a curve every moderate saturation maps deep into stress (`β ≈ 0.15` across a whole
+    domain is the typical symptom).
+
+Because the stress is a ratio of effective saturations on one curve, the porosity and the
 residual liquid fraction cancel; the closure needs neither.
 
 This is the moisture stress meant for a transpiring canopy
@@ -69,27 +131,49 @@ is physical: a wilted plant does not respond to a perturbation.
 ```jldoctest
 using NumericalEarth
 
-PlantAvailableWaterStress()
+PlantAvailableWaterStress(texture = :loam)
 
 # output
-PlantAvailableWaterStress(ψᶠᶜ=1.0, ψʷᵖ=150.0)
+PlantAvailableWaterStress(α=3.6, n=1.56, ψᶠᶜ=1.0, ψʷᵖ=150.0)
 ```
 """
-struct PlantAvailableWaterStress{FT}
-    field_capacity_head :: FT
-    wilting_point_head  :: FT
+struct PlantAvailableWaterStress{FT, R}
+    inverse_air_entry_head :: R
+    pore_size_uniformity   :: R
+    field_capacity_head    :: FT
+    wilting_point_head     :: FT
 end
 
 function PlantAvailableWaterStress(FT::Type = Oceananigans.defaults.FloatType;
+                                   texture = nothing,
+                                   inverse_air_entry_head = nothing,
+                                   pore_size_uniformity = nothing,
                                    field_capacity_head = 1,
                                    wilting_point_head = 150)
+    if !isnothing(texture)
+        (isnothing(inverse_air_entry_head) && isnothing(pore_size_uniformity)) ||
+            throw(ArgumentError("supply either a texture class or explicit retention " *
+                                "parameters, not both"))
+        (; inverse_air_entry_head, pore_size_uniformity) = van_genuchten_texture_parameters(texture)
+    elseif isnothing(inverse_air_entry_head) ≠ isnothing(pore_size_uniformity)
+        throw(ArgumentError("supply both inverse_air_entry_head and pore_size_uniformity " *
+                            "(or a texture class, or neither to use the land's own curve)"))
+    end
+    isnothing(pore_size_uniformity) || pore_size_uniformity > 1 ||
+        throw(ArgumentError("pore_size_uniformity must exceed 1"))
     0 < field_capacity_head < wilting_point_head ||
         throw(ArgumentError("heads must satisfy 0 < field_capacity_head < wilting_point_head"))
-    return PlantAvailableWaterStress(convert(FT, field_capacity_head),
+    α = isnothing(inverse_air_entry_head) ? nothing : convert(FT, inverse_air_entry_head)
+    n = isnothing(pore_size_uniformity)   ? nothing : convert(FT, pore_size_uniformity)
+    return PlantAvailableWaterStress(α, n,
+                                     convert(FT, field_capacity_head),
                                      convert(FT, wilting_point_head))
 end
 
-# The endpoints arrive precomputed on the land's own curve — see
+# A stress with no curve of its own reads the land's, per cell.
+const HydrologyCurveWaterStress = PlantAvailableWaterStress{<:Any, Nothing}
+
+# The endpoints arrive precomputed — on the land's own curve or the closure's — see
 # `interface_hydrology_state(i, j, grid, ::PlantAvailableWaterStress, land_state)`.
 @inline function evaporation_efficiency(::PlantAvailableWaterStress, hydrology)
     𝒮   = hydrology.saturation
@@ -99,9 +183,16 @@ end
     return clamp((𝒮 - 𝒮ʷᵖ) / (𝒮ᶠᶜ - 𝒮ʷᵖ), zero(FT), one(FT))
 end
 
-Base.summary(p::PlantAvailableWaterStress) =
+Base.summary(p::HydrologyCurveWaterStress) =
     string("PlantAvailableWaterStress",
            "(ψᶠᶜ=", prettysummary(p.field_capacity_head),
+           ", ψʷᵖ=", prettysummary(p.wilting_point_head), ")")
+
+Base.summary(p::PlantAvailableWaterStress) =
+    string("PlantAvailableWaterStress",
+           "(α=", prettysummary(p.inverse_air_entry_head),
+           ", n=", prettysummary(p.pore_size_uniformity),
+           ", ψᶠᶜ=", prettysummary(p.field_capacity_head),
            ", ψʷᵖ=", prettysummary(p.wilting_point_head), ")")
 
 Base.show(io::IO, p::PlantAvailableWaterStress) = print(io, summary(p))
@@ -114,4 +205,4 @@ Base.show(io::IO, p::PlantAvailableWaterStress) = print(io, summary(p))
 #####
 
 @inline requires_retention_curve(model) = false
-@inline requires_retention_curve(::PlantAvailableWaterStress) = true
+@inline requires_retention_curve(::HydrologyCurveWaterStress) = true

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -52,6 +52,7 @@ export
     FractionalHumidity,
     CriticalSaturation,
     PlantAvailableWaterStress,
+    van_genuchten_texture_parameters,
     DryLayerHumidity,
     StorageBasedDryLayerDepth,
     DryLayerVaporPistonVelocity,

--- a/test/test_plant_available_water_stress.jl
+++ b/test/test_plant_available_water_stress.jl
@@ -171,4 +171,43 @@ availability(model, 𝒮, curve) =
                                                               K_saturated = 1e-6, n = 1.56)))
         @test !isnothing(interface(soil))
     end
+
+    # A stress carrying its own texture-class curve computes its endpoints without the
+    # land's retention curve, so it pairs with a curve-less hydrology — and its β is set
+    # by the texture class, not by whatever curve the hydrology was fitted with.
+    let FT = Float64
+        loam = PlantAvailableWaterStress(FT; texture = :loam)
+        @test loam.inverse_air_entry_head == FT(3.6)
+        @test loam.pore_size_uniformity == FT(1.56)
+        @test !requires_retention_curve(loam)
+        @test_throws ArgumentError PlantAvailableWaterStress(FT; texture = :loam,
+                                                             inverse_air_entry_head = 1)
+        @test_throws ArgumentError PlantAvailableWaterStress(FT; texture = :peaty_gravel)
+        @test_throws ArgumentError PlantAvailableWaterStress(FT; inverse_air_entry_head = 1)
+
+        (; inverse_air_entry_head, pore_size_uniformity) = van_genuchten_texture_parameters(:clay)
+        @test inverse_air_entry_head == 0.8
+
+        # Endpoints from the closure's own curve: the land curve in the state is unused,
+        # so the availability matches the explicit-parameter evaluation on the loam curve.
+        explicit = PlantAvailableWaterStress(FT; inverse_air_entry_head = 3.6,
+                                             pore_size_uniformity = 1.56)
+        clay_curve = VanGenuchtenRetention(FT; α = 0.8, n = 1.09)
+        for 𝒮 in (FT(0.3), FT(0.6), FT(0.9))
+            @test availability(loam, 𝒮, clay_curve) == availability(explicit, 𝒮, clay_curve)
+            @test availability(loam, 𝒮, clay_curve) ==
+                  availability(PlantAvailableWaterStress(FT), 𝒮,
+                               VanGenuchtenRetention(FT; α = 3.6, n = 1.56))
+        end
+
+        # And it constructs against a hydrology with no retention curve at all.
+        transpiring = CanopyConductanceHumidity(FT; leaf_area_index = 2, moisture_stress = loam)
+        canopy = CanopyAirSpace(FT; soil = BulkHumidity(), canopy = transpiring)
+        grid = RectilinearGrid(FT; size = (), topology = (Flat, Flat, Flat))
+        atmosphere = PrescribedAtmosphere(grid, [0.0, 1.0]; surface_layer_height = 10)
+        bucket = SlabLand(grid; hydrology = BucketHydrology())
+        @test !isnothing(atmosphere_land_interface(grid, atmosphere, bucket;
+                                                   temperature = canopy,
+                                                   specific_humidity = canopy))
+    end
 end


### PR DESCRIPTION
Evaluating the stress endpoints on the land's own retention curve breaks down when that curve comes from a pedotransfer reduction: fits matched through the very field-capacity and wilting heads the stress spans push `n` toward 1, and every moderate saturation then maps deep into stress (β ≈ 0.15 domain-wide was the HI-SCALE symptom).

- `PlantAvailableWaterStress(FT; texture = :loam)` (or explicit `inverse_air_entry_head`/`pore_size_uniformity`) gives the closure its own Carsel–Parrish curve and drops the retention-curve requirement on the hydrology, so it also pairs with `BucketHydrology`
- passing neither keeps the current behavior: endpoints on the land's per-cell curve
- new export `van_genuchten_texture_parameters`; docstring carries the pedotransfer warning

```julia
canopy = CanopyConductanceHumidity(moisture_stress = PlantAvailableWaterStress(texture = :loam))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)