### PR TITLE
Per-cell canopy optics via Field-valued CanopyAirSpace slots

### DIFF
--- a/src/EarthSystemModels/InterfaceComputations/atmosphere_land_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/atmosphere_land_fluxes.jl
@@ -24,6 +24,9 @@ the given turbulent-flux closure, interface-temperature model, atmosphere-relati
 velocity model, and specific-humidity formulation. Pass the result as
 `atmosphere_land_interface = ...` to `ComponentInterfaces` /
 `AtmosphereLandModel` to override the default.
+
+A [`CanopyAirSpace`](@ref) temperature formulation may carry per-cell `Field` optics; they
+are checked here by [`validate_canopy_optics`](@ref) and localized in the flux kernel.
 """
 function atmosphere_land_interface(grid, atmosphere, land;
                                    fluxes              = default_atmosphere_land_fluxes(land, eltype(grid)),
@@ -37,6 +40,8 @@ function atmosphere_land_interface(grid, atmosphere, land;
                             "moisture stress defined on the hydrology's own saturation " *
                             "(CriticalSaturation)."))
     end
+    validate_canopy_optics(temperature, grid)
+
     al_fluxes = AtmosphereSurfaceFluxes(grid)
     al_properties = InterfaceProperties(specific_humidity, temperature, velocity_difference)
     interface_temperature = build_interface_temperature(temperature, grid)
@@ -416,7 +421,13 @@ end
         qᵃᵗ = atmosphere_state.q[i, j, 1]
     end
 
-    q_formulation = interface_properties.specific_humidity_formulation
+    # `CanopyAirSpace` optics slots may be per-cell `Field`s; collapse them to this cell's
+    # values before the index-free solve.
+    temperature_formulation = local_interface_formulation(interface_properties.temperature_formulation, i, j)
+    q_formulation           = local_interface_formulation(interface_properties.specific_humidity_formulation, i, j)
+
+    local_interface_properties = InterfaceProperties(q_formulation, temperature_formulation,
+                                                     interface_properties.velocity_formulation)
 
     # Bulk land temperature serves as the initial skin-temperature guess.
     Tₛ = state2dindex(land_state.T, i, j)
@@ -449,7 +460,7 @@ end
     # prognostic formulations read their stored state back instead.
     u★ = convert(FT, 1e-4)
     qₛ = convert(FT, saturation_specific_humidity(ℂᵃᵗ, Tₛ, pᵃᵗ, interface_phase(q_formulation)))
-    Tₛ, qₛ = initial_interface_values(interface_properties.temperature_formulation,
+    Tₛ, qₛ = initial_interface_values(temperature_formulation,
                                       interface_temperature, i, j, Tₛ, qₛ, clock)
     initial_interface_state = AirLandInterfaceState(i, j, grid,
                                                     InterfaceFluxScales(u★, u★, u★),
@@ -463,7 +474,7 @@ end
                                               local_atmosphere_state,
                                               local_interior_state,
                                               radiation_state,
-                                              interface_properties,
+                                              local_interface_properties,
                                               atmosphere_properties,
                                               local_land_properties)
 
@@ -471,10 +482,10 @@ end
     # hand back the state whose scales the flux exports below use (step-mean values,
     # so the step energy/vapor ledger closes against the storage tendency).
     interface_state = advance_interface_state!(interface_temperature, i, j,
-                                               interface_properties.temperature_formulation,
+                                               temperature_formulation,
                                                interface_state, local_atmosphere_state,
                                                local_interior_state, radiation_state,
-                                               interface_properties, atmosphere_properties,
+                                               local_interface_properties, atmosphere_properties,
                                                clock)
 
     u★ = interface_state.fluxes.u★
@@ -483,7 +494,7 @@ end
 
     Ψₛ = interface_state
     Ψₐ = local_atmosphere_state
-    Δu, Δv = velocity_difference(interface_properties.velocity_formulation, Ψₐ, Ψₛ)
+    Δu, Δv = velocity_difference(local_interface_properties.velocity_formulation, Ψₐ, Ψₛ)
     ΔU = sqrt(Δu^2 + Δv^2)
 
     τˣ = ifelse(ΔU == 0, zero(grid), - u★^2 * Δu / ΔU)

--- a/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
+++ b/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
@@ -516,13 +516,13 @@ function CanopyAirSpace(FT=Oceananigans.defaults.FloatType;
                         phase                     = AtmosphericThermodynamics.Liquid(),
                         storage                   = DiagnosticCanopyAir())
 
-    # A `Field` optics slot carries its own eltype; a scalar converts to `FT` so the
-    # solve is not widened by a stray Float64 literal.
-    to_FT(x) = x isa Number ? convert(FT, x) : x
-
+    # Convert only a scalar optics slot; a `Field` passes through and is materialized
+    # per cell in the flux kernel.
     return CanopyAirSpace(soil, canopy, soil_skin_flux,
-                          to_FT(leaf_albedo), to_FT(ground_albedo),
-                          to_FT(canopy_emissivity_max), to_FT(ground_emissivity),
+                          convert_if_number(FT, leaf_albedo),
+                          convert_if_number(FT, ground_albedo),
+                          convert_if_number(FT, canopy_emissivity_max),
+                          convert_if_number(FT, ground_emissivity),
                           convert(FT, extinction), convert(FT, clumping),
                           convert(FT, leaf_boundary_conductance),
                           undercanopy_conductance_model(undercanopy_conductance, FT),
@@ -545,18 +545,15 @@ const PrognosticCanopyAirSpace = CanopyAirSpace{<:Any, <:Any, <:Any, <:Any, <:An
 #####
 
 # Collapse `Field`-valued optics slots to cell (i, j) before the index-free canopy solve;
-# `Number`s pass through `stateindex`'s fallback.
-@inline local_optical_property(x, i, j) = x
-@inline local_optical_property(x::AbstractArray, i, j) = state2dindex(x, i, j)
-
+# `state2dindex` returns a `Number` slot unchanged.
 @inline local_interface_formulation(formulation, i, j) = formulation
 
 @inline local_interface_formulation(c::CanopyAirSpace, i, j) =
     CanopyAirSpace(c.soil, c.canopy, c.soil_skin_flux,
-                   local_optical_property(c.leaf_albedo, i, j),
-                   local_optical_property(c.ground_albedo, i, j),
-                   local_optical_property(c.canopy_emissivity_max, i, j),
-                   local_optical_property(c.ground_emissivity, i, j),
+                   state2dindex(c.leaf_albedo, i, j),
+                   state2dindex(c.ground_albedo, i, j),
+                   state2dindex(c.canopy_emissivity_max, i, j),
+                   state2dindex(c.ground_emissivity, i, j),
                    c.extinction, c.clumping, c.leaf_boundary_conductance,
                    c.undercanopy_conductance, c.wet_soil_resistance, c.litter_resistance,
                    c.inner_iterations, c.relaxation, c.interception, c.phase, c.storage)

--- a/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
+++ b/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
@@ -1,3 +1,7 @@
+using DocStringExtensions: TYPEDSIGNATURES
+using Oceananigans.Architectures: architecture
+using Oceananigans.Fields: interior, location
+
 #####
 ##### `CanopyAirSpace` — a two-source canopy with a diagnostic canopy-air node.
 #####
@@ -413,8 +417,10 @@ Fields:
 - `soil`   : the soil vapor branch (a [`DryLayerHumidity`](@ref)).
 - `canopy` : the leaf vapor/photosynthesis branch (a [`CanopyConductanceHumidity`](@ref)).
 - `soil_skin_flux` : skin↔bulk conduction `Λᵍ = κᵀ/ℓᵀ` (a [`SoilConductiveFlux`](@ref)).
-- `leaf_albedo`, `ground_albedo` : broadband shortwave albedos.
-- `canopy_emissivity_max`, `ground_emissivity` : longwave emissivities (`εᵛ = εᵐᵃˣ(1 − e^{−LAI})`).
+- `leaf_albedo`, `ground_albedo` : broadband shortwave albedos. A `Number`, or a
+  `Field{Center, Center, Nothing}` of per-cell values (see [`atmosphere_land_interface`](@ref)).
+- `canopy_emissivity_max`, `ground_emissivity` : longwave emissivities (`εᵛ = εᵐᵃˣ(1 − e^{−LAI})`),
+  each a `Number` or a per-cell `Field`.
 - `extinction`, `clumping` : Beer–Lambert `K`, `Ω` for the shortwave split.
 - `leaf_boundary_conductance` : per-leaf boundary-layer conductance `gᵇ` (m s⁻¹) →
   sensible `gˡʰ = ρcₚ·LAI·gᵇ`, vapor `gʷ = ρ·LAI·gᵇ` (in series with the stomata
@@ -437,15 +443,46 @@ Fields:
 - `storage` : the canopy-air node storage — [`DiagnosticCanopyAir`](@ref) (the default,
   massless node) or [`PrognosticCanopyAir`](@ref) (the node carries the canopy-air
   heat and moisture capacity and is advanced with the model time step).
+
+The four optics slots accept a per-cell `Field{Center, Center, Nothing}` alongside a
+`Number`, so a satellite albedo product reaches the two-source radiation balance cell by
+cell. The land flux kernel localizes them before the canopy solve; the interface
+constructor checks them with [`validate_canopy_optics`](@ref).
+
+```jldoctest
+using NumericalEarth
+using Oceananigans
+using NumericalEarth.EarthSystemModels.InterfaceComputations: local_interface_formulation
+
+grid = LatitudeLongitudeGrid(size = (2, 1, 1), latitude = (10, 11), longitude = (10, 12),
+                             z = (-1, 0), topology = (Bounded, Bounded, Bounded))
+
+soil = DryLayerHumidity(Float64;
+                        dry_layer_depth = StorageBasedDryLayerDepth(Float64;
+                            maximum_dry_layer_depth = 0.015, dry_layer_onset_saturation = 0.5),
+                        vapor_exchange = DryLayerVaporPistonVelocity(Float64;
+                            minimum_dry_layer_depth = 1e-3, molecular_diffusivity = 2.4e-5),
+                        thermal_exchange_depth = 0.05, porosity = 0.4)
+
+leaf_albedo = Field{Center, Center, Nothing}(grid)
+set!(leaf_albedo, (λ, φ) -> ifelse(λ < 11, 0.12, 0.35))
+
+canopy = CanopyAirSpace(Float64; soil, leaf_albedo)
+
+local_interface_formulation(canopy, 2, 1).leaf_albedo
+
+# output
+0.35
+```
 """
-struct CanopyAirSpace{S, C, RF, FT, U, W, L, I, Φ, ST}
+struct CanopyAirSpace{S, C, RF, LA, GA, CE, GE, FT, U, W, L, I, Φ, ST}
     soil                      :: S
     canopy                    :: C
     soil_skin_flux             :: RF
-    leaf_albedo               :: FT
-    ground_albedo             :: FT
-    canopy_emissivity_max     :: FT
-    ground_emissivity         :: FT
+    leaf_albedo               :: LA
+    ground_albedo             :: GA
+    canopy_emissivity_max     :: CE
+    ground_emissivity         :: GE
     extinction                :: FT
     clumping                  :: FT
     leaf_boundary_conductance :: FT
@@ -479,9 +516,13 @@ function CanopyAirSpace(FT=Oceananigans.defaults.FloatType;
                         phase                     = AtmosphericThermodynamics.Liquid(),
                         storage                   = DiagnosticCanopyAir())
 
+    # A `Field` optics slot carries its own eltype; a scalar converts to `FT` so the
+    # solve is not widened by a stray Float64 literal.
+    to_FT(x) = x isa Number ? convert(FT, x) : x
+
     return CanopyAirSpace(soil, canopy, soil_skin_flux,
-                          convert(FT, leaf_albedo), convert(FT, ground_albedo),
-                          convert(FT, canopy_emissivity_max), convert(FT, ground_emissivity),
+                          to_FT(leaf_albedo), to_FT(ground_albedo),
+                          to_FT(canopy_emissivity_max), to_FT(ground_emissivity),
                           convert(FT, extinction), convert(FT, clumping),
                           convert(FT, leaf_boundary_conductance),
                           undercanopy_conductance_model(undercanopy_conductance, FT),
@@ -492,23 +533,125 @@ end
 
 # The storage type selects the node treatment inside `canopy_air_space_solve` and
 # the kernel data flow (frozen node + advance for the prognostic variant).
-const DiagnosticCanopyAirSpace = CanopyAirSpace{<:Any, <:Any, <:Any, <:Any, <:Any,
-                                                <:Any, <:Any, <:Any, <:Any, <:DiagnosticCanopyAir}
-const PrognosticCanopyAirSpace = CanopyAirSpace{<:Any, <:Any, <:Any, <:Any, <:Any,
-                                                <:Any, <:Any, <:Any, <:Any, <:PrognosticCanopyAir}
+const DiagnosticCanopyAirSpace = CanopyAirSpace{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any,
+                                                <:Any, <:Any, <:Any, <:Any, <:Any, <:Any,
+                                                <:DiagnosticCanopyAir}
+const PrognosticCanopyAirSpace = CanopyAirSpace{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any,
+                                                <:Any, <:Any, <:Any, <:Any, <:Any, <:Any,
+                                                <:PrognosticCanopyAir}
+
+#####
+##### Per-cell optics: localization (kernel) and validation (setup)
+#####
+
+# Collapse `Field`-valued optics slots to cell (i, j) before the index-free canopy solve;
+# `Number`s pass through `stateindex`'s fallback.
+@inline local_optical_property(x, i, j) = x
+@inline local_optical_property(x::AbstractArray, i, j) = state2dindex(x, i, j)
+
+@inline local_interface_formulation(formulation, i, j) = formulation
+
+@inline local_interface_formulation(c::CanopyAirSpace, i, j) =
+    CanopyAirSpace(c.soil, c.canopy, c.soil_skin_flux,
+                   local_optical_property(c.leaf_albedo, i, j),
+                   local_optical_property(c.ground_albedo, i, j),
+                   local_optical_property(c.canopy_emissivity_max, i, j),
+                   local_optical_property(c.ground_emissivity, i, j),
+                   c.extinction, c.clumping, c.leaf_boundary_conductance,
+                   c.undercanopy_conductance, c.wet_soil_resistance, c.litter_resistance,
+                   c.inner_iterations, c.relaxation, c.interception, c.phase, c.storage)
+
+@inline evaluable_albedo(α) = isfinite(α) & (α ≥ 0) & (α < 1)
+@inline evaluable_emissivity(ε) = isfinite(ε) & (ε > 0) & (ε ≤ 1)
+
+# The four slots that may carry per-cell values, each with the predicate its values must
+# satisfy and the requirement to quote when they do not.
+@inline canopy_optics_slots(c::CanopyAirSpace) =
+    (("leaf_albedo",           c.leaf_albedo,           evaluable_albedo,     "in [0, 1)"),
+     ("ground_albedo",         c.ground_albedo,         evaluable_albedo,     "in [0, 1)"),
+     ("canopy_emissivity_max", c.canopy_emissivity_max, evaluable_emissivity, "in (0, 1]"),
+     ("ground_emissivity",     c.ground_emissivity,     evaluable_emissivity, "in (0, 1]"))
+
+# Setup-time only, so the host copy is fine.
+optics_slot_values(slot::Number) = (slot,)
+optics_slot_values(slot::AbstractField) = Array(interior(slot))
+
+# `state2dindex` reads `slot[i, j, 1]`, so a slot must be a horizontally-reduced field on
+# *this* grid: a `(Center, Center, Center)` field would silently contribute its deepest
+# level, and a field from another grid would read the wrong cell — the kernel reads it
+# `@inbounds`.
+function validate_optics_slot_layout(slot::AbstractField, name, grid)
+    if location(slot) !== (Center, Center, Nothing)
+        LX, LY, LZ = location(slot)
+        throw(ArgumentError("$name must be a horizontally-reduced Field at " *
+                            "(Center, Center, Nothing), got ($LX, $LY, $LZ). " *
+                            "Build it with Field{Center, Center, Nothing}(grid)."))
+    end
+
+    # Grids compare with `==` (topology and nodes): two references to one grid are not
+    # guaranteed to be egal, so identity would reject a field built on the interface's grid.
+    if architecture(slot) !== architecture(grid) || slot.grid != grid
+        throw(ArgumentError("$name is built on a different grid than the interface " *
+                            "($(summary(slot.grid)) vs $(summary(grid))). Per-cell canopy " *
+                            "optics must be built on the grid the interface is constructed " *
+                            "with, or they index the wrong cell."))
+    end
+
+    return nothing
+end
+
+validate_optics_slot_layout(slot::Number, name, grid) = nothing
+
+# A bare array carries no location or grid, so nothing pins its rows and columns to the
+# exchange grid's cells; require a Field so the layout above can be checked. Anything else
+# has no per-cell values for `optics_slot_values` to read.
+validate_optics_slot_layout(slot, name, grid) =
+    throw(ArgumentError("$name must be a Number or a Field, got a $(summary(slot)). " *
+                        "Wrap per-cell values in a Field{Center, Center, Nothing}(grid)."))
+
+"""
+$(TYPEDSIGNATURES)
+
+Check that the optics slots of `formulation` can be localized on `grid` and evaluated by
+the canopy radiation balance, and throw an `ArgumentError` naming the offending slot
+otherwise.
+
+Kernels can neither throw nor report, so the conditions the two-source radiation balance
+depends on are checked here: a `Field` slot is horizontally reduced and sized to `grid`,
+every albedo lies in `[0, 1)` so the absorbed shortwave `(1 - α) SW` is a real fraction,
+and every emissivity lies in `(0, 1]` so the longwave balance stays invertible. A gap in
+a satellite albedo product would otherwise propagate `NaN` through the leaf and ground
+skin temperatures into the coupled state.
+"""
+function validate_canopy_optics(c::CanopyAirSpace, grid)
+    for (name, slot, evaluable, requirement) in canopy_optics_slots(c)
+        validate_optics_slot_layout(slot, name, grid)
+
+        values = optics_slot_values(slot)
+        all(evaluable, values) && continue
+
+        throw(ArgumentError("$name has $(count(!evaluable, values)) cells that are not " *
+                            "$requirement (minimum $(minimum(values)), maximum " *
+                            "$(maximum(values))). A bad cell propagates NaN through the " *
+                            "leaf and ground skin temperatures into the coupled state. " *
+                            "Gap-fill the field first."))
+    end
+
+    return nothing
+end
+
+validate_canopy_optics(formulation, grid) = nothing
 
 Base.summary(::CanopyAirSpace) = "CanopyAirSpace"
 Base.show(io::IO, c::CanopyAirSpace) =
     print(io, "CanopyAirSpace(soil=", summary(c.soil), ", canopy=", summary(c.canopy),
           ", storage=", summary(c.storage), ")")
 
-Adapt.adapt_structure(to, c::CanopyAirSpace) =
-    CanopyAirSpace(adapt(to, c.soil), adapt(to, c.canopy), c.soil_skin_flux,
-                   c.leaf_albedo, c.ground_albedo, c.canopy_emissivity_max, c.ground_emissivity,
-                   c.extinction, c.clumping, c.leaf_boundary_conductance,
-                   c.undercanopy_conductance, c.wet_soil_resistance, c.litter_resistance,
-                   c.inner_iterations, c.relaxation,
-                   c.interception, c.phase, adapt(to, c.storage))
+# `local_interface_formulation` rebuilds this struct positionally inside a kernel, where a
+# name-keyed rebuild would not be type-stable, so a reordered or inserted field would
+# silently mis-wire the closure rather than fail to compile. `test_canopy_air_space.jl`
+# pins the field order.
+Adapt.@adapt_structure CanopyAirSpace
 
 # Materialization / identity — delegate to the sub-models so the per-cell interface
 # state carries the soil saturation, bulk temperature, and LAI the branches read.
@@ -677,11 +820,13 @@ closes.
     σ   = Ψᵣ.σ
     SW  = Ψᵣ.ℐꜜˢʷ
     LWd = Ψᵣ.ℐꜜˡʷ
-    εᵛ = c.canopy_emissivity_max * (1 - exp(-LAI))
-    εᵍ = c.ground_emissivity
+    αˡᶠ = convert(FT, c.leaf_albedo)
+    αᵍ  = convert(FT, c.ground_albedo)
+    εᵛ = convert(FT, c.canopy_emissivity_max) * (1 - exp(-LAI))
+    εᵍ = convert(FT, c.ground_emissivity)
     ftrans    = exp(-c.extinction * LAI * c.clumping)
-    SWᵛ = (1 - c.leaf_albedo) * (1 - ftrans) * SW
-    SWᵍ = ftrans * (1 - c.ground_albedo) * SW
+    SWᵛ = (1 - αˡᶠ) * (1 - ftrans) * SW
+    SWᵍ = ftrans * (1 - αᵍ) * SW
 
     Tᵛ  = Tˡᵃ
     Tᵍ = Tˡᵃ

--- a/src/EarthSystemModels/InterfaceComputations/tiled_land_interface.jl
+++ b/src/EarthSystemModels/InterfaceComputations/tiled_land_interface.jl
@@ -71,7 +71,7 @@ vegetated value).
 function bare_canopy_air_space(c::CanopyAirSpace; undercanopy_conductance = c.undercanopy_conductance,
                                wet_soil_resistance = c.wet_soil_resistance,
                                litter_resistance = nothing)
-    FT = typeof(c.leaf_albedo)
+    FT = typeof(c.extinction)
     return CanopyAirSpace(c.soil, zero_leaf_area_index_canopy(c.canopy), c.soil_skin_flux,
                           c.leaf_albedo, c.ground_albedo, c.canopy_emissivity_max, c.ground_emissivity,
                           c.extinction, c.clumping, c.leaf_boundary_conductance,

--- a/test/test_canopy_air_space.jl
+++ b/test/test_canopy_air_space.jl
@@ -13,12 +13,13 @@ using NumericalEarth.EarthSystemModels.InterfaceComputations:
     ConstantUndercanopyConductance, AreaIndexUndercanopyConductance,
     FrictionVelocityUndercanopyConductance, undercanopy_conductance,
     SellersSoilResistance, LitterResistance, soil_surface_resistance, litter_resistance,
-    bare_canopy_air_space, CanopyAirSpaceDiagnostics, DiagnosticSkin
+    bare_canopy_air_space, CanopyAirSpaceDiagnostics, DiagnosticSkin,
+    default_atmosphere_land_fluxes, local_interface_formulation, validate_canopy_optics
 using NumericalEarth.Atmospheres: PrescribedAtmosphere, AtmosphereThermodynamicsParameters
 using NumericalEarth.Lands: SlabLand, SlabEnergy, BucketHydrology
 using NumericalEarth.Radiations: PrescribedRadiation, SurfaceRadiationProperties
 
-build_canopy_air_space(FT) = CanopyAirSpace(FT;
+build_canopy_air_space(FT; optics...) = CanopyAirSpace(FT;
     soil = DryLayerHumidity(FT;
         dry_layer_depth = StorageBasedDryLayerDepth(FT; maximum_dry_layer_depth = 0.015,
                                                     dry_layer_onset_saturation = 0.5, dry_layer_exponent = 2),
@@ -27,7 +28,7 @@ build_canopy_air_space(FT) = CanopyAirSpace(FT;
         thermal_exchange_depth = 0.05, porosity = 0.4),
     canopy = CanopyConductanceHumidity(FT; leaf_area_index = 4.0, moisture_stress = CriticalSaturation(0.5),
                                        absorbed_par = InteractiveAbsorbedPAR(FT)),
-    soil_skin_flux = SoilConductiveFlux(1.5, 0.05))
+    soil_skin_flux = SoilConductiveFlux(1.5, 0.05), optics...)
 
 # Coupled single-column model with the CanopyAirSpace in both interface slots.
 function canopy_air_space_model(arch, cas; shortwave = 600.0)
@@ -137,6 +138,144 @@ end
         Ψᵢ = (u = FT(0), v = FT(0), T = FT(298))
         Ψᵣ = AirLandRadiationState(FT(5.670374e-8), FT(0), FT(0), FT(600), FT(350))
         @inferred canopy_air_space_solve(cas, Ψₛ, Ψₐ, Ψᵢ, Ψᵣ, ℙₐ)
+    end
+end
+
+@testset "CanopyAirSpace field order and optics localization" begin
+    # `local_interface_formulation` rebuilds the closure positionally inside a kernel, and
+    # every optics slot is a free type parameter, so a reordered or inserted field would
+    # silently mis-wire it instead of failing to compile. Pin the order.
+    @test fieldnames(CanopyAirSpace) === (:soil,
+                                          :canopy,
+                                          :soil_skin_flux,
+                                          :leaf_albedo,
+                                          :ground_albedo,
+                                          :canopy_emissivity_max,
+                                          :ground_emissivity,
+                                          :extinction,
+                                          :clumping,
+                                          :leaf_boundary_conductance,
+                                          :undercanopy_conductance,
+                                          :wet_soil_resistance,
+                                          :litter_resistance,
+                                          :inner_iterations,
+                                          :relaxation,
+                                          :interception,
+                                          :phase,
+                                          :storage)
+
+    FT = Float64
+    grid = LatitudeLongitudeGrid(CPU(), FT; size = (2, 1, 1), latitude = (10, 11),
+                                 longitude = (10, 12), z = (-1, 0),
+                                 topology = (Bounded, Bounded, Bounded))
+
+    leaf_albedo = Field{Center, Center, Nothing}(grid)
+    set!(leaf_albedo, (λ, φ) -> ifelse(λ < 11, 0.12, 0.35))
+    cas = build_canopy_air_space(FT; leaf_albedo)
+
+    # A `Field` slot collapses per cell; the untouched scalar slots pass through.
+    @test local_interface_formulation(cas, 1, 1).leaf_albedo == 0.12
+    @test local_interface_formulation(cas, 2, 1).leaf_albedo == 0.35
+    @test local_interface_formulation(cas, 2, 1).ground_albedo == cas.ground_albedo
+    @test local_interface_formulation(cas, 2, 1).storage === cas.storage
+
+    # Localization is the identity for a closure with no per-cell slots, and for the
+    # non-canopy formulations that share the kernel path.
+    scalar_cas = build_canopy_air_space(FT)
+    @test local_interface_formulation(scalar_cas, 2, 1).leaf_albedo == scalar_cas.leaf_albedo
+    @test local_interface_formulation(BulkTemperature(), 2, 1) === BulkTemperature()
+
+    # A scalar slot keeps the closure's float type rather than widening the solve.
+    @test build_canopy_air_space(Float32).leaf_albedo isa Float32
+end
+
+@testset "Canopy optics validation" begin
+    FT = Float64
+    grid = LatitudeLongitudeGrid(CPU(), FT; size = (2, 1, 1), latitude = (10, 11),
+                                 longitude = (10, 12), z = (-1, 0),
+                                 topology = (Bounded, Bounded, Bounded))
+
+    @test validate_canopy_optics(build_canopy_air_space(FT), grid) === nothing
+    @test validate_canopy_optics(BulkTemperature(), grid) === nothing
+
+    # A gap or an out-of-range value would propagate NaN into the coupled state.
+    for bad in (NaN, -0.1, 1.0)
+        α = Field{Center, Center, Nothing}(grid)
+        set!(α, (λ, φ) -> ifelse(λ < 11, 0.15, bad))
+        @test_throws ArgumentError validate_canopy_optics(build_canopy_air_space(FT; leaf_albedo = α), grid)
+    end
+
+    for bad in (NaN, 0.0, 1.5)
+        ε = Field{Center, Center, Nothing}(grid)
+        set!(ε, (λ, φ) -> ifelse(λ < 11, 0.96, bad))
+        @test_throws ArgumentError validate_canopy_optics(build_canopy_air_space(FT; ground_emissivity = ε), grid)
+    end
+
+    # A slot `state2dindex` cannot read per cell is rejected by layout, not by value.
+    volume_field = Field{Center, Center, Center}(grid)
+    set!(volume_field, 0.15)
+    @test_throws ArgumentError validate_canopy_optics(build_canopy_air_space(FT; leaf_albedo = volume_field), grid)
+
+    @test_throws ArgumentError validate_canopy_optics(build_canopy_air_space(FT; leaf_albedo = [0.1, 0.2]), grid)
+
+    other_grid = LatitudeLongitudeGrid(CPU(), FT; size = (2, 1, 1), latitude = (40, 41),
+                                       longitude = (10, 12), z = (-1, 0),
+                                       topology = (Bounded, Bounded, Bounded))
+    stray = Field{Center, Center, Nothing}(other_grid)
+    set!(stray, 0.15)
+    @test_throws ArgumentError validate_canopy_optics(build_canopy_air_space(FT; leaf_albedo = stray), grid)
+end
+
+# Per-cell optics reach the coupled solve: two cells sharing a canopy closure but differing
+# in leaf albedo end up with different canopy temperatures, and a cell whose field matches
+# the scalar the closure would otherwise carry is unchanged.
+@testset "Coupled per-cell canopy optics" begin
+    for arch in test_architectures
+        FT = Float64
+        grid = LatitudeLongitudeGrid(arch, FT; size = (2, 1, 1), latitude = (10, 11),
+                                     longitude = (10, 12), z = (-1, 0),
+                                     topology = (Bounded, Bounded, Bounded))
+        atmosphere = PrescribedAtmosphere(grid; surface_layer_height = 10, boundary_layer_height = 512)
+        fill!(parent(atmosphere.temperature), 300.0)
+        fill!(parent(atmosphere.specific_humidity), 0.008)
+        fill!(parent(atmosphere.velocities.u), 3.0)
+        fill!(parent(atmosphere.pressure), 101325.0)
+        land = SlabLand(grid; hydrology = BucketHydrology(FT; maximum_water_storage = 150.0), energy = SlabEnergy(FT))
+        set!(land; T = 298.0)
+        fill!(parent(land.water_storage), 45.0)
+        radiation = PrescribedRadiation(grid; ocean_surface = nothing, sea_ice_surface = nothing,
+                                        land_surface = SurfaceRadiationProperties(0.2, 0.95))
+        fill!(parent(radiation.downwelling_shortwave), 600.0)
+        fill!(parent(radiation.downwelling_longwave), 350.0)
+        update_state!(radiation)
+
+        scalar_cas = build_canopy_air_space(FT)
+
+        # Cell 1 keeps the closure's own leaf albedo, cell 2 is a bright leaf.
+        leaf_albedo = Field{Center, Center, Nothing}(grid)
+        set!(leaf_albedo, (λ, φ) -> ifelse(λ < 11, scalar_cas.leaf_albedo, 0.6))
+
+        function canopy_model(cas)
+            interface = atmosphere_land_interface(grid, atmosphere, land;
+                                                  fluxes = default_atmosphere_land_fluxes(land, FT),
+                                                  temperature = cas, specific_humidity = cas)
+            model = AtmosphereLandModel(atmosphere, land; radiation,
+                                        atmosphere_land_interface = interface)
+            update_state!(model.land)
+            update_state!(model)
+            return model
+        end
+
+        model = canopy_model(build_canopy_air_space(FT; leaf_albedo))
+        Tᵛ = Array(interior(model.interfaces.atmosphere_land_interface.temperature.canopy))
+
+        # The bright leaf absorbs less shortwave and runs cooler.
+        @test Tᵛ[2, 1, 1] < Tᵛ[1, 1, 1]
+
+        # The cell carrying the closure's own albedo is bit-identical to the scalar run,
+        # so a configuration with no per-cell optics is unchanged.
+        Tᵛ_scalar = Array(interior(canopy_model(scalar_cas).interfaces.atmosphere_land_interface.temperature.canopy))
+        @test Tᵛ[1, 1, 1] == Tᵛ_scalar[1, 1, 1]
     end
 end
 


### PR DESCRIPTION
The four optics slots of `CanopyAirSpace` — `leaf_albedo`, `ground_albedo`,
`canopy_emissivity_max`, `ground_emissivity` — now accept per-cell `Field`s alongside the
existing `Number`, so a satellite albedo product reaches the two-source radiation balance
cell by cell. The land flux kernel collapses `Field` slots to each cell's values before the
index-free canopy solve.

```julia
leaf_albedo = Field{Center, Center, Nothing}(grid)   # e.g. CopernicusAlbedo

canopy = CanopyAirSpace(FT; soil, leaf_albedo)
interface = atmosphere_land_interface(grid, atmosphere, land; temperature = canopy,
                                      specific_humidity = canopy)
```

Slots are checked when the interface is built (`validate_canopy_optics`): a `Field` must be
horizontally reduced on the interface's own grid, albedos must lie in `[0, 1)` and
emissivities in `(0, 1]`. Kernels cannot throw, so a gap in an albedo product has to be
rejected here rather than propagate `NaN` through the leaf and ground skin temperatures.

Scalar slots are untouched, so a configuration passing no per-cell optics is bit-identical.
Each `TiledLandInterface` tile owns its own `CanopyAirSpace`, so per-tile optics need no
extra keyword.

Follows the per-cell slot pattern of #523: `Field`s live in the closure's own slots and are
localized in the kernel, rather than being supplied separately and fetched through a marker
type. `local_interface_formulation` rebuilds the closure positionally, so a test pins the
field order and `Adapt.@adapt_structure` replaces the hand-written `adapt_structure`.

The layout/value helpers here (`validate_optics_slot_layout`, `optics_slot_values`) mirror
#523's `validate_slot_layout` / `slot_values`, which are not on this branch. They should
collapse to one set when the two stacks meet.
