### PR TITLE
Cache MODIS granules beside the reprojected files

### DIFF
--- a/ext/NumericalEarthArchGDALExt/NumericalEarthArchGDALExt.jl
+++ b/ext/NumericalEarthArchGDALExt/NumericalEarthArchGDALExt.jl
@@ -12,7 +12,7 @@ using Oceananigans.Grids: λnodes, φnodes
 
 using NumericalEarth.DataWrangling: BoundingBox, native_grid, native_region_grid,
                                     dataset_variable_name, bounding_box_intersects,
-                                    cmr_granules, earthdata_download, earthdata_download_cached,
+                                    cmr_granules, earthdata_download_cached,
                                     figshare_article_url, write_atomically
 using NumericalEarth.DataWrangling.ASTERGED: asterged_short_name, asterged_version,
                                              asterged_decode_emissivity, asterged_decode_uncertainty,

--- a/ext/NumericalEarthArchGDALExt/modis_land.jl
+++ b/ext/NumericalEarthArchGDALExt/modis_land.jl
@@ -78,13 +78,18 @@ function MODISLand.modis_granules_to_netcdf(metadatum::MODISLand.MODISLandMetada
     lattice = regional_lattice(metadatum)
     urls = granule_urls(metadatum)
 
-    mktempdir() do tmp
-        @info string("Fetching ", length(urls), " MODIS granules for ", metadatum.dates, "...")
-        granule_paths = [earthdata_download(url, joinpath(tmp, basename(url))) for url in urls]
-        layers = Dict(layer => warp_modis_layer(granule_paths, layer, lattice)
-                      for layer in stored_granule_layers(metadatum.dataset))
-        write_modis_netcdf(nc_path, layers, lattice)
-    end
+    # A sinusoidal tile spans 10° and carries every layer of the product, so the same
+    # granules serve neighboring regions, sibling variables, and every year a climatology
+    # composites. Keeping them beside the warped files makes those warps a local operation.
+    granule_cache = mkpath(joinpath(dirname(nc_path), "granules"))
+    fetched = count(url -> !isfile(joinpath(granule_cache, basename(url))), urls)
+    fetched > 0 && @info string("Fetching ", fetched, " of ", length(urls),
+                                " MODIS granules for ", metadatum.dates, "...")
+
+    granule_paths = [earthdata_download_cached(url, granule_cache) for url in urls]
+    layers = Dict(layer => warp_modis_layer(granule_paths, layer, lattice)
+                  for layer in stored_granule_layers(metadatum.dataset))
+    write_modis_netcdf(nc_path, layers, lattice)
 
     return nothing
 end

--- a/src/DataWrangling/MODISLand/MODISLand.jl
+++ b/src/DataWrangling/MODISLand/MODISLand.jl
@@ -18,7 +18,7 @@ using Statistics: mean
 using ..DataWrangling: DataWrangling, Metadata, Metadatum, BoundingBox,
                        metadata_path, default_download_directory,
                        native_cell_range, native_convention_longitude,
-                       cmr_granules_url, download_with_retries, write_atomically
+                       cmr_granules, write_atomically
 
 import Oceananigans
 

--- a/src/DataWrangling/MODISLand/README.md
+++ b/src/DataWrangling/MODISLand/README.md
@@ -34,6 +34,9 @@ lattice — one NetCDF per date and region holding every layer as raw digital nu
 Decoding (fill rejection, scale factors, quality screening) happens at read time. A
 lon/lat `BoundingBox` region is required; a global read is rejected.
 
+The granules themselves are kept under `granules/` beside the reprojected files, keyed by
+granule name, so a new region or date over the same tiles warps from local files.
+
 ## Usage
 
 ```julia
@@ -68,8 +71,9 @@ compositing leaves behind — see their docstrings and `examples/modis_landcover
 - A longitude window straddling the ±180° seam is rejected; split it into two requests.
 - Whole tiles are downloaded (HDF4 defeats GDAL's windowed reads), and a climatology
   multiplies quickly: 46 periods × `length(years)` × tiles — a 1° box over five years is
-  ~230 granules and tens of minutes. Per-date files are cached and shared across periods
-  and variables; build only the periods you need with the `periods` keyword while iterating.
+  ~230 granules and tens of minutes. Per-date files and the granules behind them are cached
+  and shared across periods and variables; build only the periods you need with the
+  `periods` keyword while iterating.
 - The record has outage holes (2016-02-18 is one): a climatology skips them with a warning,
   a single-date read raises `MissingGranulesError`.
 - `years` defaults to 2003–2019, the span over which Terra and Aqua held their equatorial

--- a/src/DataWrangling/MODISLand/granules.jl
+++ b/src/DataWrangling/MODISLand/granules.jl
@@ -110,16 +110,8 @@ Requires network access, but no credentials.
 function granule_urls(metadatum::MODISLandMetadatum)
     dataset = metadatum.dataset
 
-    # One day of one product is a handful of sinusoidal tiles, so a single page always covers it.
-    url = cmr_granules_url(modis_short_name(dataset), modis_version(dataset), metadatum.region;
-                           date = metadatum.dates)
-
-    candidates = mktempdir() do tmp
-        json = joinpath(tmp, "cmr_granules.json")
-        download_with_retries(url, json; description = "CMR granule query")
-        text = read(json, String)
-        unique(m.match for m in eachmatch(r"https://[^\"]+\.hdf", text))
-    end
+    candidates = cmr_granules(modis_short_name(dataset), modis_version(dataset),
+                              metadatum.region; extension = "hdf", date = metadatum.dates)
 
     granules = select_granules(candidates, metadatum.dates)
     isempty(granules) &&

--- a/src/DataWrangling/earthdata.jl
+++ b/src/DataWrangling/earthdata.jl
@@ -57,11 +57,18 @@ end
 Download the granule at `url` into `cache_dir` unless it is already there, and return
 its path. Keyed on the granule name, so overlapping regions and sibling variables
 reuse a granule instead of re-downloading it.
+
+The download is staged and renamed into place, since a granule already in `cache_dir` is
+skipped on sight: an interrupted download must not leave a truncated file behind where a
+later call expects a complete one.
 """
 function earthdata_download_cached(url, cache_dir; attempts = 3)
     path = joinpath(cache_dir, basename(url))
     isfile(path) && return path
-    return earthdata_download(url, path; attempts)
+    write_atomically(path) do staging_path
+        earthdata_download(url, staging_path; attempts)
+    end
+    return path
 end
 
 """
@@ -99,15 +106,17 @@ cmr_temporal_query(date) =
 cmr_time(date) = string(Dates.format(DateTime(date), "yyyy-mm-ddTHH:MM:SS"), "Z")
 
 """
-    cmr_granules(short_name, version, bbox; extension = "h5", page_size = 2000, attempts = 3)
+    cmr_granules(short_name, version, bbox; extension = "h5", date = nothing,
+                 page_size = 2000, attempts = 3)
 
 Return the download URLs of the `short_name` / `version` granules whose footprints
 intersect `bbox`, querying NASA CMR page by page until a short page signals the last
 one. Only URLs ending in `extension` are collected, and one URL is kept per granule
-name (preferring a protected `data`-host endpoint).
+name (preferring a protected `data`-host endpoint). A `date` narrows the search to the
+day it opens, for a product whose granules are dated.
 """
 function cmr_granules(short_name, version, bbox::BoundingBox;
-                      extension = "h5", page_size = 2000, attempts = 3)
+                      extension = "h5", date = nothing, page_size = 2000, attempts = 3)
 
     granule_url_pattern = Regex(string("https://[^\"]+\\.", extension))
     by_granule = Dict{String, String}()
@@ -115,7 +124,7 @@ function cmr_granules(short_name, version, bbox::BoundingBox;
     mktempdir() do tmp
         page_num = 1
         while true
-            url = cmr_granules_url(short_name, version, bbox; page_size, page_num)
+            url = cmr_granules_url(short_name, version, bbox; date, page_size, page_num)
             json_path = joinpath(tmp, string("cmr_granules_", page_num, ".json"))
             download_with_retries(url, json_path; attempts, description = "CMR granule query")
             text = read(json_path, String)

--- a/test/test_earthdata.jl
+++ b/test/test_earthdata.jl
@@ -1,6 +1,6 @@
 include("runtests_setup.jl")
 
-using NumericalEarth.DataWrangling: BoundingBox, cmr_granules_url
+using NumericalEarth.DataWrangling: BoundingBox, cmr_granules_url, earthdata_download_cached
 using Dates: DateTime
 
 # The granule query itself needs network access; the URL it is built from does not.
@@ -22,4 +22,17 @@ using Dates: DateTime
     @test occursin("temporal=2020-07-03T00:00:00Z,2020-07-04T00:00:00Z", dated)
 
     @test_throws ArgumentError cmr_granules_url("AG100", "003", BoundingBox())
+end
+
+@testset "Cached Earthdata granules" begin
+    cache = mktempdir()
+    url = "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/" *
+          "MCD15A2H.061/MCD15A2H.A2020185.h10v05.061.2020340132006.hdf"
+    path = joinpath(cache, basename(url))
+    write(path, "granule")
+
+    # A granule already in the cache is returned as it stands, so a repeated ingestion
+    # needs neither the network nor credentials.
+    @test earthdata_download_cached(url, cache) == path
+    @test read(path, String) == "granule"
 end

--- a/test/test_modis_land_downloading.jl
+++ b/test/test_modis_land_downloading.jl
@@ -89,6 +89,26 @@ end
     @test all(f -> 0 ≤ f ≤ 1, fpar)
 end
 
+@testset "Warping a second region from cached granules" begin
+    granule_cache = joinpath(modis_download_directory, "granules")
+    granules = sort!(readdir(granule_cache))
+    @test !isempty(granules)
+    @test all(endswith(".hdf"), granules)
+
+    stamps = [mtime(joinpath(granule_cache, granule)) for granule in granules]
+
+    # A window inside the one just warped is served by the same granules, so the second
+    # warp is local: the cache neither grows nor is rewritten.
+    inner = BoundingBox(longitude = (-92.45, -92.35), latitude = (36.55, 36.65))
+    metadatum = Metadatum(:leaf_area_index; dataset = MCD15A2H(), region = inner,
+                          date = modis_composite_date, dir = modis_download_directory)
+    download(metadatum)
+    @test isfile(metadata_path(metadatum))
+
+    @test sort!(readdir(granule_cache)) == granules
+    @test [mtime(joinpath(granule_cache, granule)) for granule in granules] == stamps
+end
+
 @testset "Downloading a MCD12Q1 land-cover map" begin
     dataset = MCD12Q1()
     metadatum = Metadatum(:landcover_class; dataset, region = modis_region,


### PR DESCRIPTION
MODIS granules were downloaded into a temporary directory and discarded after each warp, so a new region or date over the same sinusoidal tiles refetched granules it already had (~200 MB per composite).

- Granules are kept under `granules/` beside the reprojected NetCDFs and skipped when already there, the way the ASTER GED tiles already are.
- `granule_urls` goes through `cmr_granules`, which pages the CMR query rather than assuming one page of 2000 holds every granule; `cmr_granules` takes a `date` for products whose granules are dated.
- `earthdata_download_cached` stages its download, so an interrupted fetch cannot leave a truncated file where the next call expects a complete one.

Based on #424.
