### PR TITLE
Cache the seasonal gap fill beside its lattice

### DIFF
--- a/src/DataWrangling/gap_filling.jl
+++ b/src/DataWrangling/gap_filling.jl
@@ -227,6 +227,58 @@ end
 @inline clamp_to_range(value, ::Nothing) = value
 @inline clamp_to_range(value, range) = clamp(value, first(range), last(range))
 
+#####
+##### Caching a filled series
+#####
+##### The chain is expensive over a continental lattice and deterministic in its inputs and
+##### its parameters, while the target grids that read its result are no part of it: every
+##### resolution built on the same native series wants the same fill.
+#####
+
+# An argument reduced to something storable beside the result: a scalar stands for itself,
+# an array for its shape and the sum of its finite entries, which no change of region,
+# window, or product leaves alone.
+fill_signature(parameter) = parameter
+fill_signature(parameter::AbstractArray) =
+    (size(parameter), sum(value -> isfinite(value) ? Float64(value) : 0.0, parameter; init = 0.0))
+fill_signature(fts::FieldTimeSeries) = fill_signature(Array(interior(fts)))
+
+seasonal_fill_key(; parameters...) = map(fill_signature, NamedTuple(parameters))
+
+cached_seasonal_fill(::Nothing, key, 𝒜) = nothing
+
+function cached_seasonal_fill(cache, key, 𝒜)
+    isfile(cache) || return nothing
+
+    try
+        return jldopen(cache, "r") do file
+            haskey(file, "key") && file["key"] == key || return nothing
+            copyto!(𝒜, file["series"])
+            (provenance = file["provenance"], reach = file["reach"])
+        end
+    catch err
+        @warn "Could not read the cached seasonal fill at $cache; filling again..." exception=err
+        rm(cache, force = true)
+        return nothing
+    end
+end
+
+cache_seasonal_fill!(::Nothing, key, 𝒜, provenance, reach) = nothing
+
+function cache_seasonal_fill!(cache, key, 𝒜, provenance, reach)
+    @root begin
+        write_atomically(cache) do staging_path
+            jldopen(staging_path, "w") do file
+                file["key"] = key
+                file["series"] = 𝒜
+                file["provenance"] = provenance
+                file["reach"] = reach
+            end
+        end
+    end
+    return nothing
+end
+
 """
     fill_seasonal_gaps!(series, land_cover; kw...)
 
@@ -266,6 +318,11 @@ Keyword arguments
                     ([`period_index`](@ref) computes it from a date). Default: cyclic reuse,
                     which assumes the series opens the anchor's cycle and covers whole
                     cycles, and is an error otherwise.
+- `cache`: path of a JLD2 file holding the filled series with its provenance and reach, so
+           the chain runs once for a native lattice however many model grids read it. The
+           file is written when the fill completes and read back when the inputs and the
+           parameters below still match what produced it; otherwise it is rewritten.
+           Default: `nothing`, no cache.
 - `cyclic`: `true` to wrap stage 1's interpolation across the ends of the time axis, as one
             period of a periodic signal. Default: `true` without an `anchor` (a seasonal
             climatology wraps), `false` with one (a date window does not).
@@ -293,6 +350,7 @@ Keyword arguments
 function fill_seasonal_gaps!(data::AbstractArray, land_cover;
                              anchor = nothing,
                              anchor_periods = nothing,
+                             cache = nothing,
                              cyclic = isnothing(anchor),
                              max_gap = 6,
                              block_size = 32,
@@ -319,6 +377,13 @@ function fill_seasonal_gaps!(data::AbstractArray, land_cover;
                             "which is worse than an error because the result still looks " *
                             "like a map."))
 
+    key = seasonal_fill_key(; series = 𝒜, land_cover = codes, anchor, anchor_periods, cyclic,
+                            max_gap, block_size, initial_radius, minimum_donors, maximum_radius,
+                            minimum_anchor_periods, scaling, valid_range, unfilled_classes, stages)
+
+    cached = cached_seasonal_fill(cache, key, 𝒜)
+    isnothing(cached) || return (; series = data, cached.provenance, cached.reach)
+
     class_index, classes_present = class_indices(codes)
     fillable = [!isfinite(code) || !(round(Int, code) in unfilled_classes) for code in codes]
 
@@ -342,7 +407,11 @@ function fill_seasonal_gaps!(data::AbstractArray, land_cover;
 
     scale_donors = :scaled in stages
     mean_donors  = :class_mean in stages
-    (scale_donors || mean_donors) || return (; series = data, provenance, reach)
+
+    if !(scale_donors || mean_donors)
+        cache_seasonal_fill!(cache, key, 𝒜, provenance, reach)
+        return (; series = data, provenance, reach)
+    end
 
     # Built after the temporal stage, so a neighbor's short bridged gap is available as a donor.
     pool = isnothing(anchor) ?
@@ -380,6 +449,8 @@ function fill_seasonal_gaps!(data::AbstractArray, land_cover;
 
         filled && (reach[i, j] = radius)
     end
+
+    cache_seasonal_fill!(cache, key, 𝒜, provenance, reach)
 
     return (; series = data, provenance, reach)
 end

--- a/src/DataWrangling/gap_filling.jl
+++ b/src/DataWrangling/gap_filling.jl
@@ -245,15 +245,15 @@ fill_signature(fts::FieldTimeSeries) = fill_signature(Array(interior(fts)))
 
 seasonal_fill_key(; parameters...) = map(fill_signature, NamedTuple(parameters))
 
-cached_seasonal_fill(::Nothing, key, 𝒜) = nothing
+cached_seasonal_fill(::Nothing, key, series) = nothing
 
-function cached_seasonal_fill(cache, key, 𝒜)
+function cached_seasonal_fill(cache, key, series)
     isfile(cache) || return nothing
 
     try
         return jldopen(cache, "r") do file
             haskey(file, "key") && file["key"] == key || return nothing
-            copyto!(𝒜, file["series"])
+            copyto!(series, file["series"])
             (provenance = file["provenance"], reach = file["reach"])
         end
     catch err
@@ -263,14 +263,14 @@ function cached_seasonal_fill(cache, key, 𝒜)
     end
 end
 
-cache_seasonal_fill!(::Nothing, key, 𝒜, provenance, reach) = nothing
+cache_seasonal_fill!(::Nothing, key, series, provenance, reach) = nothing
 
-function cache_seasonal_fill!(cache, key, 𝒜, provenance, reach)
+function cache_seasonal_fill!(cache, key, series, provenance, reach)
     @root begin
         write_atomically(cache) do staging_path
             jldopen(staging_path, "w") do file
                 file["key"] = key
-                file["series"] = 𝒜
+                file["series"] = series
                 file["provenance"] = provenance
                 file["reach"] = reach
             end

--- a/test/test_seasonal_gap_fill.jl
+++ b/test/test_seasonal_gap_fill.jl
@@ -5,6 +5,7 @@ using NumericalEarth.DataWrangling: fill_gaps!, fill_seasonal_gaps!, gap_fill_pr
 using Oceananigans.Grids: halo_size
 using Oceananigans.OutputReaders: Cyclical, InMemory
 using Dates: DateTime, Day, Month, Year
+using JLD2: jldopen
 using Statistics: mean
 
 # A seasonal shape both the donor and the target share, so a fill that preserves shape is
@@ -66,6 +67,58 @@ end
     @test 𝒜[1, 1, :] == shape
     @test all(t -> t == 5 || 𝒜[3, 3, t] == 2 * shape[t], 1:Nt)
     @test all(==(gap_fill_provenance.observed), filled.provenance[1, 1, :])
+end
+
+# Overwrite the cached values, keeping the key that names the inputs they came from.
+function overwrite_cached_series!(cache, series)
+    key, provenance, reach = jldopen(cache, "r") do file
+        file["key"], file["provenance"], file["reach"]
+    end
+
+    jldopen(cache, "w") do file
+        file["key"] = key
+        file["series"] = series
+        file["provenance"] = provenance
+        file["reach"] = reach
+    end
+
+    return nothing
+end
+
+@testset "Seasonal fill: a cached fill is read back" begin
+    Nt = 12
+    shape = seasonal_shape(Nt)
+    𝒜 = uniform_series(shape, 8, 8)
+    𝒜[3, 3, :] .= 2 .* shape
+    𝒜[3, 3, 5] = NaN32
+    classes = fill(Float32(2), 8, 8)
+
+    cache = joinpath(mktempdir(), "seasonal_fill.jld2")
+    parameters = (; cyclic = true, max_gap = 0, block_size = 4, minimum_donors = 4)
+
+    expected = fill_seasonal_gaps!(copy(𝒜), classes; parameters...)
+    filled = fill_seasonal_gaps!(copy(𝒜), classes; cache, parameters...)
+
+    @test isfile(cache)
+    @test filled.series == expected.series
+    @test filled.provenance == expected.provenance
+    @test filled.reach == expected.reach
+
+    # A value no fill would produce: a call that returns it read the file rather than
+    # filling again.
+    marker = fill(7f0, size(𝒜))
+    overwrite_cached_series!(cache, marker)
+    @test fill_seasonal_gaps!(copy(𝒜), classes; cache, parameters...).series == marker
+
+    # A parameter the fill depends on, and the series itself, are both part of what the
+    # cache is keyed on, so neither reads the marker back.
+    strict = merge(parameters, (; max_gap = 3))
+    @test fill_seasonal_gaps!(copy(𝒜), classes; cache, strict...).series != marker
+
+    overwrite_cached_series!(cache, marker)
+    ℬ = copy(𝒜)
+    ℬ[4, 4, 2] = NaN32
+    @test fill_seasonal_gaps!(ℬ, classes; cache, parameters...).series != marker
 end
 
 @testset "Seasonal fill: the estimator's guards" begin


### PR DESCRIPTION
`fill_seasonal_gaps!` runs for minutes over a continental native lattice, and the model grid that reads its result is no part of the fill: a 12 km, a 6 km and a 3 km configuration built on the same series each repeat the identical work.

- New `cache` keyword: the path of a JLD2 file holding the filled series with its provenance and reach.
- The file is read back when the series, the class map, and the fill parameters still match what produced it; anything else refills and rewrites.

```julia
fill_seasonal_gaps!(leaf_area_index_series, land_cover;
                    cache = joinpath(dir, "leaf_area_index_filled.jld2"))
```

Based on #424.
