### PR TITLE
Absorb PAR on the canopy's own transmittance

### DIFF
--- a/src/EarthSystemModels/InterfaceComputations/absorbed_par.jl
+++ b/src/EarthSystemModels/InterfaceComputations/absorbed_par.jl
@@ -52,8 +52,9 @@ Fields:
 - `par_fraction`     : PAR/shortwave by energy (≈ 0.45).
 - `photon_per_joule` : mol photons per J in the PAR band (≈ 4.57e-6).
 - `leaf_albedo_par`  : leaf albedo in the PAR band.
-- `extinction`       : canopy extinction coefficient `K`.
-- `clumping`         : foliage clumping index `Ω`.
+- `extinction`       : canopy extinction coefficient `K`. Overridden by the canopy's own
+                       value inside a [`CanopyAirSpace`](@ref), which owns the geometry.
+- `clumping`         : foliage clumping index `Ω`. Overridden as `extinction` is.
 - `lai_min`          : floor on `LAI` in the per-leaf division.
 """
 struct InteractiveAbsorbedPAR{FT} <: AbstractAbsorbedPAR
@@ -74,6 +75,17 @@ InteractiveAbsorbedPAR(FT=Oceananigans.defaults.FloatType;
                        lai_min          = 0.1) =
     InteractiveAbsorbedPAR{FT}(par_fraction, photon_per_joule, leaf_albedo_par,
                                extinction, clumping, lai_min)
+
+# Canopy geometry is waveband-independent, so inside a `CanopyAirSpace` the PAR closure takes
+# the canopy's `extinction` and `clumping` rather than keeping a second copy that can disagree
+# with the shortwave split driving the energy balance. `par_fraction` and `leaf_albedo_par` are
+# band properties and stay.
+inherit_canopy_geometry(par, extinction, clumping) = par
+
+function inherit_canopy_geometry(par::InteractiveAbsorbedPAR{FT}, extinction, clumping) where FT
+    return InteractiveAbsorbedPAR{FT}(par.par_fraction, par.photon_per_joule, par.leaf_albedo_par,
+                                      convert(FT, extinction), convert(FT, clumping), par.lai_min)
+end
 
 Base.summary(::InteractiveAbsorbedPAR{FT}) where FT = "InteractiveAbsorbedPAR{$FT}"
 Base.show(io::IO, p::InteractiveAbsorbedPAR) = print(io, summary(p),

--- a/src/EarthSystemModels/InterfaceComputations/absorbed_par.jl
+++ b/src/EarthSystemModels/InterfaceComputations/absorbed_par.jl
@@ -7,15 +7,14 @@
 #####
 
 """
-    beer_lambert_absorbed_fraction(leaf_area_index, leaf_albedo, extinction, clumping)
+    beer_lambert_absorbed_fraction(leaf_albedo, canopy_transmittance)
 
-Fraction of incident shortwave a bulk canopy absorbs, `fᵃᵇˢ = (1 − α)(1 − e^{−K·LAI·Ω})`
-(ClimaLand Eq D11). Multiply an incident PAR photon flux by this to get `absorbed_par`.
+Fraction of incident shortwave a bulk canopy absorbs, `fᵃᵇˢ = (1 − α)(1 − ftrans)`
+(ClimaLand Eq D11). `canopy_transmittance` is the Beer–Lambert `e^{−K·LAI·Ω}` of whatever
+owns the canopy geometry, so a band absorbs on the same structure the shortwave split uses.
 """
-@inline function beer_lambert_absorbed_fraction(leaf_area_index, leaf_albedo, extinction, clumping)
-    transmitted = exp(-extinction * leaf_area_index * clumping)
-    return (1 - leaf_albedo) * (1 - transmitted)
-end
+@inline beer_lambert_absorbed_fraction(leaf_albedo, canopy_transmittance) =
+    (1 - leaf_albedo) * (1 - canopy_transmittance)
 
 abstract type AbstractAbsorbedPAR end
 
@@ -34,17 +33,19 @@ Base.show(io::IO, p::PrescribedAbsorbedPAR) = print(io, summary(p))
 
 """
     InteractiveAbsorbedPAR(FT = Float64; par_fraction, photon_per_joule,
-                           leaf_albedo_par, extinction, clumping, lai_min)
+                           leaf_albedo_par, lai_min)
 
 Per-leaf absorbed PAR recomputed each step from the downwelling shortwave `ℐꜜˢʷ`
 (W m⁻²) in the radiation state,
 
-    APAR = fᵃᵇˢ(LAI) · (fᵖᵃʳ · ℐꜜˢʷ · Qᴶ) / max(LAI, LAIᵐⁱⁿ) ,
+    APAR = fᵃᵇˢ · (fᵖᵃʳ · ℐꜜˢʷ · Qᴶ) / max(LAI, LAIᵐⁱⁿ) ,
 
 where `fᵖᵃʳ` (`par_fraction`) is the PAR energy fraction of shortwave, `Qᴶ`
 (`photon_per_joule`) converts PAR energy to a photon flux, and `fᵃᵇˢ` is the
-Beer–Lambert canopy-absorbed fraction ([`beer_lambert_absorbed_fraction`](@ref)).
-Dividing by `LAI` returns a per-leaf value (see the convention note above). With
+absorbed fraction ([`beer_lambert_absorbed_fraction`](@ref)) on the canopy
+transmittance the caller supplies — a [`CanopyAirSpace`](@ref) passes the one its
+own shortwave split uses, so the two cannot diverge. Dividing by `LAI` returns a
+per-leaf value (see the convention note above). With
 the shortwave following the sun, the canopy conductance then follows the diurnal
 light cycle — the dominant daytime driver of transpiration.
 
@@ -52,17 +53,12 @@ Fields:
 - `par_fraction`     : PAR/shortwave by energy (≈ 0.45).
 - `photon_per_joule` : mol photons per J in the PAR band (≈ 4.57e-6).
 - `leaf_albedo_par`  : leaf albedo in the PAR band.
-- `extinction`       : canopy extinction coefficient `K`. Overridden by the canopy's own
-                       value inside a [`CanopyAirSpace`](@ref), which owns the geometry.
-- `clumping`         : foliage clumping index `Ω`. Overridden as `extinction` is.
 - `lai_min`          : floor on `LAI` in the per-leaf division.
 """
 struct InteractiveAbsorbedPAR{FT} <: AbstractAbsorbedPAR
     par_fraction     :: FT
     photon_per_joule :: FT
     leaf_albedo_par  :: FT
-    extinction       :: FT
-    clumping         :: FT
     lai_min          :: FT
 end
 
@@ -70,22 +66,8 @@ InteractiveAbsorbedPAR(FT=Oceananigans.defaults.FloatType;
                        par_fraction     = 0.45,
                        photon_per_joule = 4.57e-6,
                        leaf_albedo_par  = 0.1,
-                       extinction       = 0.5,
-                       clumping         = 1,
                        lai_min          = 0.1) =
-    InteractiveAbsorbedPAR{FT}(par_fraction, photon_per_joule, leaf_albedo_par,
-                               extinction, clumping, lai_min)
-
-# Canopy geometry is waveband-independent, so inside a `CanopyAirSpace` the PAR closure takes
-# the canopy's `extinction` and `clumping` rather than keeping a second copy that can disagree
-# with the shortwave split driving the energy balance. `par_fraction` and `leaf_albedo_par` are
-# band properties and stay.
-inherit_canopy_geometry(par, extinction, clumping) = par
-
-function inherit_canopy_geometry(par::InteractiveAbsorbedPAR{FT}, extinction, clumping) where FT
-    return InteractiveAbsorbedPAR{FT}(par.par_fraction, par.photon_per_joule, par.leaf_albedo_par,
-                                      convert(FT, extinction), convert(FT, clumping), par.lai_min)
-end
+    InteractiveAbsorbedPAR{FT}(par_fraction, photon_per_joule, leaf_albedo_par, lai_min)
 
 Base.summary(::InteractiveAbsorbedPAR{FT}) where FT = "InteractiveAbsorbedPAR{$FT}"
 Base.show(io::IO, p::InteractiveAbsorbedPAR) = print(io, summary(p),
@@ -95,11 +77,11 @@ Base.show(io::IO, p::InteractiveAbsorbedPAR) = print(io, summary(p),
 @inline absorbed_par_spec(x::AbstractAbsorbedPAR, FT) = x
 @inline absorbed_par_spec(x::Number, FT) = PrescribedAbsorbedPAR(convert(FT, x))
 
-@inline absorbed_par_value(p::PrescribedAbsorbedPAR, radiation, leaf_area_index) = p.value
+@inline absorbed_par_value(p::PrescribedAbsorbedPAR, radiation, leaf_area_index, canopy_transmittance) = p.value
 
-@inline function absorbed_par_value(p::InteractiveAbsorbedPAR, radiation, leaf_area_index)
+@inline function absorbed_par_value(p::InteractiveAbsorbedPAR, radiation, leaf_area_index, canopy_transmittance)
     SW   = radiation.ℐꜜˢʷ                                      # downwelling shortwave (W m⁻²)
     parQ = p.par_fraction * SW * p.photon_per_joule            # canopy-incident PAR photon flux
-    fᵃᵇˢ = beer_lambert_absorbed_fraction(leaf_area_index, p.leaf_albedo_par, p.extinction, p.clumping)
+    fᵃᵇˢ = beer_lambert_absorbed_fraction(p.leaf_albedo_par, canopy_transmittance)
     return fᵃᵇˢ * parQ / max(leaf_area_index, p.lai_min)       # per-leaf
 end

--- a/src/EarthSystemModels/InterfaceComputations/absorbed_par.jl
+++ b/src/EarthSystemModels/InterfaceComputations/absorbed_par.jl
@@ -33,7 +33,7 @@ Base.show(io::IO, p::PrescribedAbsorbedPAR) = print(io, summary(p))
 
 """
     InteractiveAbsorbedPAR(FT = Float64; par_fraction, photon_per_joule,
-                           leaf_albedo_par, lai_min)
+                           leaf_albedo_par, extinction, clumping, lai_min)
 
 Per-leaf absorbed PAR recomputed each step from the downwelling shortwave `ℐꜜˢʷ`
 (W m⁻²) in the radiation state,
@@ -53,12 +53,17 @@ Fields:
 - `par_fraction`     : PAR/shortwave by energy (≈ 0.45).
 - `photon_per_joule` : mol photons per J in the PAR band (≈ 4.57e-6).
 - `leaf_albedo_par`  : leaf albedo in the PAR band.
+- `extinction`       : canopy extinction coefficient `K`, used only when no canopy supplies a
+                       transmittance. A [`CanopyAirSpace`](@ref) always does.
+- `clumping`         : foliage clumping index `Ω`, used as `extinction` is.
 - `lai_min`          : floor on `LAI` in the per-leaf division.
 """
 struct InteractiveAbsorbedPAR{FT} <: AbstractAbsorbedPAR
     par_fraction     :: FT
     photon_per_joule :: FT
     leaf_albedo_par  :: FT
+    extinction       :: FT
+    clumping         :: FT
     lai_min          :: FT
 end
 
@@ -66,8 +71,11 @@ InteractiveAbsorbedPAR(FT=Oceananigans.defaults.FloatType;
                        par_fraction     = 0.45,
                        photon_per_joule = 4.57e-6,
                        leaf_albedo_par  = 0.1,
+                       extinction       = 0.5,
+                       clumping         = 1,
                        lai_min          = 0.1) =
-    InteractiveAbsorbedPAR{FT}(par_fraction, photon_per_joule, leaf_albedo_par, lai_min)
+    InteractiveAbsorbedPAR{FT}(par_fraction, photon_per_joule, leaf_albedo_par,
+                               extinction, clumping, lai_min)
 
 Base.summary(::InteractiveAbsorbedPAR{FT}) where FT = "InteractiveAbsorbedPAR{$FT}"
 Base.show(io::IO, p::InteractiveAbsorbedPAR) = print(io, summary(p),
@@ -77,11 +85,19 @@ Base.show(io::IO, p::InteractiveAbsorbedPAR) = print(io, summary(p),
 @inline absorbed_par_spec(x::AbstractAbsorbedPAR, FT) = x
 @inline absorbed_par_spec(x::Number, FT) = PrescribedAbsorbedPAR(convert(FT, x))
 
-@inline absorbed_par_value(p::PrescribedAbsorbedPAR, radiation, leaf_area_index, canopy_transmittance) = p.value
+# A canopy hands down the transmittance its own shortwave split used, so PAR absorbs on that
+# structure rather than rebuilding it. `nothing` means no canopy supplied one — the closure's own
+# `extinction` and `clumping` are the fallback, and are read in no other case.
+@inline canopy_transmittance(p::InteractiveAbsorbedPAR, leaf_area_index, ::Nothing) =
+    exp(-p.extinction * leaf_area_index * p.clumping)
+@inline canopy_transmittance(p::InteractiveAbsorbedPAR, leaf_area_index, ftrans) = ftrans
 
-@inline function absorbed_par_value(p::InteractiveAbsorbedPAR, radiation, leaf_area_index, canopy_transmittance)
+@inline absorbed_par_value(p::PrescribedAbsorbedPAR, radiation, leaf_area_index, ftrans) = p.value
+
+@inline function absorbed_par_value(p::InteractiveAbsorbedPAR, radiation, leaf_area_index, ftrans)
     SW   = radiation.ℐꜜˢʷ                                      # downwelling shortwave (W m⁻²)
     parQ = p.par_fraction * SW * p.photon_per_joule            # canopy-incident PAR photon flux
-    fᵃᵇˢ = beer_lambert_absorbed_fraction(p.leaf_albedo_par, canopy_transmittance)
+    fᵃᵇˢ = beer_lambert_absorbed_fraction(p.leaf_albedo_par,
+                                          canopy_transmittance(p, leaf_area_index, ftrans))
     return fᵃᵇˢ * parQ / max(leaf_area_index, p.lai_min)       # per-leaf
 end

--- a/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
+++ b/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
@@ -518,7 +518,7 @@ function CanopyAirSpace(FT=Oceananigans.defaults.FloatType;
 
     # Convert only a scalar optics slot; a `Field` passes through and is materialized
     # per cell in the flux kernel.
-    return CanopyAirSpace(soil, canopy, soil_skin_flux,
+    return CanopyAirSpace(soil, inherit_canopy_geometry(canopy, extinction, clumping), soil_skin_flux,
                           convert_if_number(FT, leaf_albedo),
                           convert_if_number(FT, ground_albedo),
                           convert_if_number(FT, max_canopy_emissivity),

--- a/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
+++ b/src/EarthSystemModels/InterfaceComputations/canopy_air_space.jl
@@ -518,7 +518,7 @@ function CanopyAirSpace(FT=Oceananigans.defaults.FloatType;
 
     # Convert only a scalar optics slot; a `Field` passes through and is materialized
     # per cell in the flux kernel.
-    return CanopyAirSpace(soil, inherit_canopy_geometry(canopy, extinction, clumping), soil_skin_flux,
+    return CanopyAirSpace(soil, canopy, soil_skin_flux,
                           convert_if_number(FT, leaf_albedo),
                           convert_if_number(FT, ground_albedo),
                           convert_if_number(FT, max_canopy_emissivity),
@@ -683,8 +683,8 @@ Adapt.@adapt_structure CanopyAirSpace
 end
 
 # Leaf vapor conductance `gˡʷ` and leaf-saturated humidity `qᵛ` at the leaf temperature `Tᵛ`.
-@inline function leaf_vapor_terms(canopy, Tᵛ, gʷ, fʷ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
-    gᶜ, qᵛ = canopy_conductance_terms(canopy, Tᵛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
+@inline function leaf_vapor_terms(canopy, Tᵛ, gʷ, fʷ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, ftrans)
+    gᶜ, qᵛ = canopy_conductance_terms(canopy, Tᵛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, ftrans)
     return leaf_vapor_conductance(gᶜ, gʷ, fʷ), qᵛ
 end
 
@@ -835,7 +835,7 @@ closes.
     tiny = eps(FT)
 
     for _ in 1:c.inner_iterations
-        gˡʷ, qᵛ = leaf_vapor_terms(c.canopy, Tᵛ, gʷ, fʷ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
+        gˡʷ, qᵛ = leaf_vapor_terms(c.canopy, Tᵛ, gʷ, fʷ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, ftrans)
         Gᵉ, qᵉ  = soil_vapor_terms(c.soil, Tᵍ, gᵍʷ, gᵖ, Ψₛ, Ψₐ, ℙₐ)
 
         Tᵃᶜ = node_value(c.storage, gᵍʰ, Tᵍ, gˡʰ, Tᵛ, gᵃʰ, θᵃᵗ, Tᵃᶜ)
@@ -864,7 +864,7 @@ closes.
     # The diagnostic node is re-solved against the final skins: inside the loop it
     # updates ahead of them, so the loop exits one iterate stale and the shares below
     # would miss closure. The prognostic node stays frozen.
-    gˡʷ, qᵛ = leaf_vapor_terms(c.canopy, Tᵛ, gʷ, fʷ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
+    gˡʷ, qᵛ = leaf_vapor_terms(c.canopy, Tᵛ, gʷ, fʷ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, ftrans)
     Gᵉ, qᵉ  = soil_vapor_terms(c.soil, Tᵍ, gᵍʷ, gᵖ, Ψₛ, Ψₐ, ℙₐ)
     Tᵃᶜ = node_value(c.storage, gᵍʰ, Tᵍ, gˡʰ, Tᵛ, gᵃʰ, θᵃᵗ, Tᵃᶜ)
     qᵃᶜ = node_value(c.storage, Gᵉ, qᵉ, gˡʷ, qᵛ, gᵃʷ, qᵃᵗ, qᵃᶜ)

--- a/src/EarthSystemModels/InterfaceComputations/canopy_conductance.jl
+++ b/src/EarthSystemModels/InterfaceComputations/canopy_conductance.jl
@@ -114,11 +114,6 @@ Adapt.adapt_structure(to, q::CanopyConductanceHumidity) =
                               q.photosynthesis, q.conductance, q.moisture_stress,
                               q.absorbed_par, q.atmospheric_co2, q.phase)
 
-inherit_canopy_geometry(q::CanopyConductanceHumidity, extinction, clumping) =
-    CanopyConductanceHumidity(q.leaf_area_index, q.photosynthesis, q.conductance, q.moisture_stress,
-                              inherit_canopy_geometry(q.absorbed_par, extinction, clumping),
-                              q.atmospheric_co2, q.phase)
-
 Base.summary(::CanopyConductanceHumidity{L, P, C, S, A, Q, Φ}) where {L, P, C, S, A, Q, Φ} =
     string("CanopyConductanceHumidity{", Φ === AtmosphericThermodynamics.Liquid ? "Liquid" : "Ice", "}")
 Base.show(io::IO, q::CanopyConductanceHumidity) = print(io, summary(q))
@@ -139,13 +134,19 @@ Base.show(io::IO, q::CanopyConductanceHumidity) = print(io, summary(q))
 @inline interface_vegetation_state(i, j, grid, ::CanopyConductanceHumidity, vegetation, time_interpolator) =
     (leaf_area_index = convert(eltype(grid), surface_field_value(vegetation, i, j, time_interpolator)),)
 
+# A formulation with no vertical canopy structure is one leaf layer: nothing passes it, so the
+# absorbed fraction is the band's `1 - α`. A `CanopyAirSpace` passes its own Beer-Lambert
+# transmittance instead, so PAR absorbs on the structure its shortwave split already used.
+@inline big_leaf_transmittance(Ψₛ) = zero(eltype(Ψₛ))
+
 # Canopy flux terms, split off so the standalone formulation and the composite
 # (soil + canopy) share them. Returns the bulk canopy (stomatal) mass conductance
 # `gᶜ = LAI · gₛ · Mᵈ` (kg m⁻² s⁻¹) and the leaf saturation source `qᵛ⁺(Tₗ)`.
 # The canopy (leaf) reservoir is saturated at the leaf temperature (= skin
 # temperature Tₛ, single-source). `Ψᵣ` is the interface radiation state (drives
 # `InteractiveAbsorbedPAR`).
-@inline function canopy_conductance_terms(q::CanopyConductanceHumidity, Tₗ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
+@inline function canopy_conductance_terms(q::CanopyConductanceHumidity, Tₗ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ,
+                                          canopy_transmittance)
     ℂᵃᵗ = ℙₐ.thermodynamics_parameters
     pᵃᵗ = Ψₐ.p
     qᵃᵗ = Ψₐ.q
@@ -155,7 +156,7 @@ Base.show(io::IO, q::CanopyConductanceHumidity) = print(io, summary(q))
     qᵛ⁺  = saturation_specific_humidity(ℂᵃᵗ, Tₗ, pᵃᵗ, q.phase)
     VPD  = vapor_pressure_deficit(ℂᵃᵗ, Tₗ, Tᵃᵗ, pᵃᵗ, qᵃᵗ, q.phase)
     β    = evaporation_efficiency(q.moisture_stress, Ψₛ.hydrology)
-    APAR = absorbed_par_value(q.absorbed_par, Ψᵣ, LAI)
+    APAR = absorbed_par_value(q.absorbed_par, Ψᵣ, LAI, canopy_transmittance)
 
     gs, _, _ = stomatal_conductance(q.conductance, q.photosynthesis,
                                     APAR, VPD, Tₗ, q.atmospheric_co2, pᵃᵗ, β)
@@ -168,7 +169,7 @@ end
 
 @inline function compute_interface_humidity(q::CanopyConductanceHumidity, Tₛ, Ψₛ, Ψₐ, Ψᵢ, Ψᵣ, ℙₐ)
     FT = eltype(Ψₛ)
-    gᶜ, qᵛ⁺ = canopy_conductance_terms(q, Tₛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)   # leaf temperature = skin temperature Tₛ
+    gᶜ, qᵛ⁺ = canopy_conductance_terms(q, Tₛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, big_leaf_transmittance(Ψₛ))
 
     qˢ⁻ = Ψₛ.specific_humidity
     qᵃᵗ = Ψₐ.q

--- a/src/EarthSystemModels/InterfaceComputations/canopy_conductance.jl
+++ b/src/EarthSystemModels/InterfaceComputations/canopy_conductance.jl
@@ -134,11 +134,6 @@ Base.show(io::IO, q::CanopyConductanceHumidity) = print(io, summary(q))
 @inline interface_vegetation_state(i, j, grid, ::CanopyConductanceHumidity, vegetation, time_interpolator) =
     (leaf_area_index = convert(eltype(grid), surface_field_value(vegetation, i, j, time_interpolator)),)
 
-# A formulation with no vertical canopy structure is one leaf layer: nothing passes it, so the
-# absorbed fraction is the band's `1 - α`. A `CanopyAirSpace` passes its own Beer-Lambert
-# transmittance instead, so PAR absorbs on the structure its shortwave split already used.
-@inline big_leaf_transmittance(Ψₛ) = zero(eltype(Ψₛ))
-
 # Canopy flux terms, split off so the standalone formulation and the composite
 # (soil + canopy) share them. Returns the bulk canopy (stomatal) mass conductance
 # `gᶜ = LAI · gₛ · Mᵈ` (kg m⁻² s⁻¹) and the leaf saturation source `qᵛ⁺(Tₗ)`.
@@ -169,7 +164,7 @@ end
 
 @inline function compute_interface_humidity(q::CanopyConductanceHumidity, Tₛ, Ψₛ, Ψₐ, Ψᵢ, Ψᵣ, ℙₐ)
     FT = eltype(Ψₛ)
-    gᶜ, qᵛ⁺ = canopy_conductance_terms(q, Tₛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, big_leaf_transmittance(Ψₛ))
+    gᶜ, qᵛ⁺ = canopy_conductance_terms(q, Tₛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, nothing)
 
     qˢ⁻ = Ψₛ.specific_humidity
     qᵃᵗ = Ψₐ.q

--- a/src/EarthSystemModels/InterfaceComputations/canopy_conductance.jl
+++ b/src/EarthSystemModels/InterfaceComputations/canopy_conductance.jl
@@ -114,6 +114,11 @@ Adapt.adapt_structure(to, q::CanopyConductanceHumidity) =
                               q.photosynthesis, q.conductance, q.moisture_stress,
                               q.absorbed_par, q.atmospheric_co2, q.phase)
 
+inherit_canopy_geometry(q::CanopyConductanceHumidity, extinction, clumping) =
+    CanopyConductanceHumidity(q.leaf_area_index, q.photosynthesis, q.conductance, q.moisture_stress,
+                              inherit_canopy_geometry(q.absorbed_par, extinction, clumping),
+                              q.atmospheric_co2, q.phase)
+
 Base.summary(::CanopyConductanceHumidity{L, P, C, S, A, Q, Φ}) where {L, P, C, S, A, Q, Φ} =
     string("CanopyConductanceHumidity{", Φ === AtmosphericThermodynamics.Liquid ? "Liquid" : "Ice", "}")
 Base.show(io::IO, q::CanopyConductanceHumidity) = print(io, summary(q))

--- a/src/EarthSystemModels/InterfaceComputations/composite_surface_humidity.jl
+++ b/src/EarthSystemModels/InterfaceComputations/composite_surface_humidity.jl
@@ -89,7 +89,7 @@ Base.show(io::IO, q::CompositeSurfaceHumidity) = print(io, summary(q))
     FT = eltype(Ψₛ)
 
     Gᵉ, qᵉ, σ, qᵍ⁺ = dry_layer_terms(q.soil, Tₛ, Ψₛ, Ψₐ, ℙₐ)          # soil branch (+ wet-blend)
-    gᶜ, qᵛ⁺      = canopy_conductance_terms(q.canopy, Tₛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, big_leaf_transmittance(Ψₛ))  # canopy branch
+    gᶜ, qᵛ⁺      = canopy_conductance_terms(q.canopy, Tₛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, nothing)  # canopy branch
 
     qˢ⁻ = Ψₛ.specific_humidity
     qᵃᵗ = Ψₐ.q
@@ -120,7 +120,7 @@ dry (`σ = 1`). Returns `(; soil_evaporation, transpiration)`.
 """
 @inline function evaporation_partition(q::CompositeSurfaceHumidity, qˢ, Tₛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
     Gᵉ, qᵉ, σ, qᵍ⁺ = dry_layer_terms(q.soil, Tₛ, Ψₛ, Ψₐ, ℙₐ)
-    gᶜ, qᵛ⁺      = canopy_conductance_terms(q.canopy, Tₛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, big_leaf_transmittance(Ψₛ))
+    gᶜ, qᵛ⁺      = canopy_conductance_terms(q.canopy, Tₛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, nothing)
     soil_evaporation = Gᵉ * (qᵉ - qˢ)
     transpiration    = gᶜ * (qᵛ⁺ - qˢ)
     return (; soil_evaporation, transpiration)

--- a/src/EarthSystemModels/InterfaceComputations/composite_surface_humidity.jl
+++ b/src/EarthSystemModels/InterfaceComputations/composite_surface_humidity.jl
@@ -89,7 +89,7 @@ Base.show(io::IO, q::CompositeSurfaceHumidity) = print(io, summary(q))
     FT = eltype(Ψₛ)
 
     Gᵉ, qᵉ, σ, qᵍ⁺ = dry_layer_terms(q.soil, Tₛ, Ψₛ, Ψₐ, ℙₐ)          # soil branch (+ wet-blend)
-    gᶜ, qᵛ⁺      = canopy_conductance_terms(q.canopy, Tₛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)  # canopy branch
+    gᶜ, qᵛ⁺      = canopy_conductance_terms(q.canopy, Tₛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, big_leaf_transmittance(Ψₛ))  # canopy branch
 
     qˢ⁻ = Ψₛ.specific_humidity
     qᵃᵗ = Ψₐ.q
@@ -120,7 +120,7 @@ dry (`σ = 1`). Returns `(; soil_evaporation, transpiration)`.
 """
 @inline function evaporation_partition(q::CompositeSurfaceHumidity, qˢ, Tₛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
     Gᵉ, qᵉ, σ, qᵍ⁺ = dry_layer_terms(q.soil, Tₛ, Ψₛ, Ψₐ, ℙₐ)
-    gᶜ, qᵛ⁺      = canopy_conductance_terms(q.canopy, Tₛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
+    gᶜ, qᵛ⁺      = canopy_conductance_terms(q.canopy, Tₛ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, big_leaf_transmittance(Ψₛ))
     soil_evaporation = Gᵉ * (qᵉ - qˢ)
     transpiration    = gᶜ * (qᵛ⁺ - qˢ)
     return (; soil_evaporation, transpiration)

--- a/test/test_canopy_air_space.jl
+++ b/test/test_canopy_air_space.jl
@@ -6,7 +6,7 @@ using Oceananigans.TimeSteppers: update_state!
 using NumericalEarth.EarthSystemModels.InterfaceComputations:
     CanopyAirSpace, CanopyConductanceHumidity, CanopyInterception, DryLayerHumidity, StorageBasedDryLayerDepth,
     DryLayerVaporPistonVelocity, ConstantTortuosity, PowerLawTortuosity, CriticalSaturation, InteractiveAbsorbedPAR,
-    PrescribedAbsorbedPAR,
+    PrescribedAbsorbedPAR, absorbed_par_value,
     SoilConductiveFlux, SoilSkinTemperature, canopy_air_space_solve, dry_layer_terms,
     compute_interface_temperature, compute_interface_humidity, interface_temperature_and_humidity,
     saturation_specific_humidity, default_dry_air_molar_mass, AtmosphericThermodynamics,
@@ -190,34 +190,42 @@ end
     @test build_canopy_air_space(Float32).leaf_albedo isa Float32
 end
 
-@testset "Absorbed PAR inherits the canopy's geometry" begin
+@testset "Absorbed PAR absorbs on the canopy's own structure" begin
     FT = Float64
-    soil = DryLayerHumidity(FT;
-        dry_layer_depth = StorageBasedDryLayerDepth(FT; maximum_dry_layer_depth = 0.015,
-                                                    dry_layer_onset_saturation = 0.5, dry_layer_exponent = 2),
-        vapor_exchange  = DryLayerVaporPistonVelocity(FT; minimum_dry_layer_depth = 1e-3,
-                                                      molecular_diffusivity = 2.4e-5,
-                                                      tortuosity = ConstantTortuosity()),
-        thermal_exchange_depth = 0.05, porosity = 0.4)
+    par = InteractiveAbsorbedPAR(FT; leaf_albedo_par = 0.08)
 
-    # A PAR closure built with geometry that disagrees with the canopy's.
-    par = InteractiveAbsorbedPAR(FT; extinction = 0.9, clumping = 0.4, leaf_albedo_par = 0.08)
-    canopy = CanopyConductanceHumidity(FT; leaf_area_index = 3.0, absorbed_par = par)
-    cas = CanopyAirSpace(FT; soil, canopy, extinction = 0.55, clumping = 0.75)
+    # The closure carries band properties only: geometry is the canopy's to supply.
+    @test !hasfield(typeof(par), :extinction)
+    @test !hasfield(typeof(par), :clumping)
 
-    inherited = cas.canopy.absorbed_par
-    @test inherited.extinction == cas.extinction
-    @test inherited.clumping == cas.clumping
+    Ψᵣ = AirLandRadiationState(FT(5.67e-8), FT(0.2), FT(0.95), FT(800), FT(350))
+    LAI = FT(3)
 
-    # Band properties are the closure's own and survive.
-    @test inherited.leaf_albedo_par == par.leaf_albedo_par
-    @test inherited.par_fraction == par.par_fraction
-    @test inherited.lai_min == par.lai_min
+    # Absorbed PAR follows the transmittance it is handed, and is the band's `1 - α` of the
+    # incident PAR when nothing is transmitted past the leaves.
+    dense = absorbed_par_value(par, Ψᵣ, LAI, FT(0))
+    sparse = absorbed_par_value(par, Ψᵣ, LAI, FT(0.6))
+    @test dense > sparse
+    @test dense ≈ (1 - par.leaf_albedo_par) * par.par_fraction * Ψᵣ.ℐꜜˢʷ * par.photon_per_joule / LAI
 
-    # A prescribed closure carries no geometry and passes through untouched.
-    prescribed = PrescribedAbsorbedPAR(FT(5e-4))
-    canopy_p = CanopyConductanceHumidity(FT; leaf_area_index = 3.0, absorbed_par = prescribed)
-    @test CanopyAirSpace(FT; soil, canopy = canopy_p).canopy.absorbed_par === prescribed
+    # A canopy hands down `exp(-K Ω LAI)`, so PAR and the shortwave split share one geometry.
+    cas = CanopyAirSpace(FT; soil = DryLayerHumidity(FT;
+                             dry_layer_depth = StorageBasedDryLayerDepth(FT; maximum_dry_layer_depth = 0.015,
+                                                                         dry_layer_onset_saturation = 0.5,
+                                                                         dry_layer_exponent = 2),
+                             vapor_exchange  = DryLayerVaporPistonVelocity(FT; minimum_dry_layer_depth = 1e-3,
+                                                                           molecular_diffusivity = 2.4e-5,
+                                                                           tortuosity = ConstantTortuosity()),
+                             thermal_exchange_depth = 0.05, porosity = 0.4),
+                         canopy = CanopyConductanceHumidity(FT; leaf_area_index = LAI, absorbed_par = par),
+                         extinction = 0.55, clumping = 0.75)
+
+    ftrans = exp(-cas.extinction * LAI * cas.clumping)
+    @test absorbed_par_value(cas.canopy.absorbed_par, Ψᵣ, LAI, ftrans) ≈
+          (1 - par.leaf_albedo_par) * (1 - ftrans) * par.par_fraction * Ψᵣ.ℐꜜˢʷ * par.photon_per_joule / LAI
+
+    # A prescribed closure ignores the geometry entirely.
+    @test absorbed_par_value(PrescribedAbsorbedPAR(FT(5e-4)), Ψᵣ, LAI, FT(0.3)) == FT(5e-4)
 end
 
 @testset "Canopy optics validation" begin

--- a/test/test_canopy_air_space.jl
+++ b/test/test_canopy_air_space.jl
@@ -6,6 +6,7 @@ using Oceananigans.TimeSteppers: update_state!
 using NumericalEarth.EarthSystemModels.InterfaceComputations:
     CanopyAirSpace, CanopyConductanceHumidity, CanopyInterception, DryLayerHumidity, StorageBasedDryLayerDepth,
     DryLayerVaporPistonVelocity, ConstantTortuosity, PowerLawTortuosity, CriticalSaturation, InteractiveAbsorbedPAR,
+    PrescribedAbsorbedPAR,
     SoilConductiveFlux, SoilSkinTemperature, canopy_air_space_solve, dry_layer_terms,
     compute_interface_temperature, compute_interface_humidity, interface_temperature_and_humidity,
     saturation_specific_humidity, default_dry_air_molar_mass, AtmosphericThermodynamics,
@@ -187,6 +188,36 @@ end
 
     # A scalar slot keeps the closure's float type rather than widening the solve.
     @test build_canopy_air_space(Float32).leaf_albedo isa Float32
+end
+
+@testset "Absorbed PAR inherits the canopy's geometry" begin
+    FT = Float64
+    soil = DryLayerHumidity(FT;
+        dry_layer_depth = StorageBasedDryLayerDepth(FT; maximum_dry_layer_depth = 0.015,
+                                                    dry_layer_onset_saturation = 0.5, dry_layer_exponent = 2),
+        vapor_exchange  = DryLayerVaporPistonVelocity(FT; minimum_dry_layer_depth = 1e-3,
+                                                      molecular_diffusivity = 2.4e-5,
+                                                      tortuosity = ConstantTortuosity()),
+        thermal_exchange_depth = 0.05, porosity = 0.4)
+
+    # A PAR closure built with geometry that disagrees with the canopy's.
+    par = InteractiveAbsorbedPAR(FT; extinction = 0.9, clumping = 0.4, leaf_albedo_par = 0.08)
+    canopy = CanopyConductanceHumidity(FT; leaf_area_index = 3.0, absorbed_par = par)
+    cas = CanopyAirSpace(FT; soil, canopy, extinction = 0.55, clumping = 0.75)
+
+    inherited = cas.canopy.absorbed_par
+    @test inherited.extinction == cas.extinction
+    @test inherited.clumping == cas.clumping
+
+    # Band properties are the closure's own and survive.
+    @test inherited.leaf_albedo_par == par.leaf_albedo_par
+    @test inherited.par_fraction == par.par_fraction
+    @test inherited.lai_min == par.lai_min
+
+    # A prescribed closure carries no geometry and passes through untouched.
+    prescribed = PrescribedAbsorbedPAR(FT(5e-4))
+    canopy_p = CanopyConductanceHumidity(FT; leaf_area_index = 3.0, absorbed_par = prescribed)
+    @test CanopyAirSpace(FT; soil, canopy = canopy_p).canopy.absorbed_par === prescribed
 end
 
 @testset "Canopy optics validation" begin

--- a/test/test_canopy_air_space.jl
+++ b/test/test_canopy_air_space.jl
@@ -192,23 +192,29 @@ end
 
 @testset "Absorbed PAR absorbs on the canopy's own structure" begin
     FT = Float64
-    par = InteractiveAbsorbedPAR(FT; leaf_albedo_par = 0.08)
-
-    # The closure carries band properties only: geometry is the canopy's to supply.
-    @test !hasfield(typeof(par), :extinction)
-    @test !hasfield(typeof(par), :clumping)
-
+    par = InteractiveAbsorbedPAR(FT; leaf_albedo_par = 0.08, extinction = 0.5, clumping = 1)
     Ψᵣ = AirLandRadiationState(FT(5.67e-8), FT(0.2), FT(0.95), FT(800), FT(350))
     LAI = FT(3)
+    incident = par.par_fraction * Ψᵣ.ℐꜜˢʷ * par.photon_per_joule
 
-    # Absorbed PAR follows the transmittance it is handed, and is the band's `1 - α` of the
-    # incident PAR when nothing is transmitted past the leaves.
-    dense = absorbed_par_value(par, Ψᵣ, LAI, FT(0))
-    sparse = absorbed_par_value(par, Ψᵣ, LAI, FT(0.6))
-    @test dense > sparse
-    @test dense ≈ (1 - par.leaf_albedo_par) * par.par_fraction * Ψᵣ.ℐꜜˢʷ * par.photon_per_joule / LAI
+    # With no canopy to supply one, the closure builds the transmittance from its own geometry.
+    own = exp(-par.extinction * LAI * par.clumping)
+    @test absorbed_par_value(par, Ψᵣ, LAI, nothing) ≈
+          (1 - par.leaf_albedo_par) * (1 - own) * incident / LAI
 
-    # A canopy hands down `exp(-K Ω LAI)`, so PAR and the shortwave split share one geometry.
+    # A sparse canopy intercepts little, so the vanishing absorbed fraction cancels the per-leaf
+    # division and a leaf never receives more than the flux falling on it.
+    @test absorbed_par_value(par, Ψᵣ, par.lai_min, nothing) < incident
+    @test absorbed_par_value(par, Ψᵣ, FT(1e-3), nothing) < incident
+
+    # A supplied transmittance wins, and the closure's own geometry is not consulted.
+    ftrans = FT(0.4)
+    supplied = absorbed_par_value(par, Ψᵣ, LAI, ftrans)
+    @test supplied ≈ (1 - par.leaf_albedo_par) * (1 - ftrans) * incident / LAI
+    @test absorbed_par_value(InteractiveAbsorbedPAR(FT; leaf_albedo_par = 0.08, extinction = 0.9),
+                             Ψᵣ, LAI, ftrans) ≈ supplied
+
+    # A canopy hands down the transmittance its own shortwave split uses.
     cas = CanopyAirSpace(FT; soil = DryLayerHumidity(FT;
                              dry_layer_depth = StorageBasedDryLayerDepth(FT; maximum_dry_layer_depth = 0.015,
                                                                          dry_layer_onset_saturation = 0.5,
@@ -219,12 +225,8 @@ end
                              thermal_exchange_depth = 0.05, porosity = 0.4),
                          canopy = CanopyConductanceHumidity(FT; leaf_area_index = LAI, absorbed_par = par),
                          extinction = 0.55, clumping = 0.75)
+    @test exp(-cas.extinction * LAI * cas.clumping) != own
 
-    ftrans = exp(-cas.extinction * LAI * cas.clumping)
-    @test absorbed_par_value(cas.canopy.absorbed_par, Ψᵣ, LAI, ftrans) ≈
-          (1 - par.leaf_albedo_par) * (1 - ftrans) * par.par_fraction * Ψᵣ.ℐꜜˢʷ * par.photon_per_joule / LAI
-
-    # A prescribed closure ignores the geometry entirely.
     @test absorbed_par_value(PrescribedAbsorbedPAR(FT(5e-4)), Ψᵣ, LAI, FT(0.3)) == FT(5e-4)
 end
 

--- a/test/test_canopy_conductance.jl
+++ b/test/test_canopy_conductance.jl
@@ -170,23 +170,23 @@ end
 
         # Prescribed reproduces its value, ignoring the radiation state.
         pre = PrescribedAbsorbedPAR(FT(4e-4))
-        @test absorbed_par_value(pre, nothing, LAI) == FT(4e-4)
+        @test absorbed_par_value(pre, nothing, LAI, 0) == FT(4e-4)
 
         inter = InteractiveAbsorbedPAR(FT)
         rad(SW) = (; ℐꜜˢʷ = FT(SW))
 
         # Night: no shortwave ⇒ no absorbed PAR.
-        @test absorbed_par_value(inter, rad(0), LAI) == 0
+        @test absorbed_par_value(inter, rad(0), LAI, 0) == 0
 
         # APAR is linear in the downwelling shortwave, and per-leaf O(1e-4) at a
         # representative midday flux — same order as the prescribed default (4e-4).
-        apar_noon = absorbed_par_value(inter, rad(500), LAI)
+        apar_noon = absorbed_par_value(inter, rad(500), LAI, 0)
         @test apar_noon > 0
         @test 1e-4 < apar_noon < 1e-3
-        @test absorbed_par_value(inter, rad(1000), LAI) ≈ 2 * apar_noon
+        @test absorbed_par_value(inter, rad(1000), LAI, 0) ≈ 2 * apar_noon
 
-        @test eltype(absorbed_par_value(inter, rad(500), LAI)) == FT
-        @inferred absorbed_par_value(inter, rad(500), LAI)
+        @test eltype(absorbed_par_value(inter, rad(500), LAI, 0)) == FT
+        @inferred absorbed_par_value(inter, rad(500), LAI, 0)
     end
 end
 

--- a/test/test_canopy_conductance.jl
+++ b/test/test_canopy_conductance.jl
@@ -170,23 +170,23 @@ end
 
         # Prescribed reproduces its value, ignoring the radiation state.
         pre = PrescribedAbsorbedPAR(FT(4e-4))
-        @test absorbed_par_value(pre, nothing, LAI, 0) == FT(4e-4)
+        @test absorbed_par_value(pre, nothing, LAI, nothing) == FT(4e-4)
 
         inter = InteractiveAbsorbedPAR(FT)
         rad(SW) = (; ℐꜜˢʷ = FT(SW))
 
         # Night: no shortwave ⇒ no absorbed PAR.
-        @test absorbed_par_value(inter, rad(0), LAI, 0) == 0
+        @test absorbed_par_value(inter, rad(0), LAI, nothing) == 0
 
         # APAR is linear in the downwelling shortwave, and per-leaf O(1e-4) at a
         # representative midday flux — same order as the prescribed default (4e-4).
-        apar_noon = absorbed_par_value(inter, rad(500), LAI, 0)
+        apar_noon = absorbed_par_value(inter, rad(500), LAI, nothing)
         @test apar_noon > 0
         @test 1e-4 < apar_noon < 1e-3
-        @test absorbed_par_value(inter, rad(1000), LAI, 0) ≈ 2 * apar_noon
+        @test absorbed_par_value(inter, rad(1000), LAI, nothing) ≈ 2 * apar_noon
 
-        @test eltype(absorbed_par_value(inter, rad(500), LAI, 0)) == FT
-        @inferred absorbed_par_value(inter, rad(500), LAI, 0)
+        @test eltype(absorbed_par_value(inter, rad(500), LAI, nothing)) == FT
+        @inferred absorbed_par_value(inter, rad(500), LAI, nothing)
     end
 end
 

--- a/test/test_composite_surface_humidity.jl
+++ b/test/test_composite_surface_humidity.jl
@@ -61,7 +61,7 @@ end
     comp = CompositeSurfaceHumidity(soil, canopy)
     _, Ψₛ, Ψₐ, Ψᵢ, Ψᵣ, ℙₐ = _make_call_args(; 𝒮=0.05, st...)   # 𝒮 ≪ 𝒮ᶜ ⇒ σ = 1
     Gᵉ, qᵉ, σ, qᵍ⁺ = dry_layer_terms(comp.soil, st.Tᵍ, Ψₛ, Ψₐ, ℙₐ)
-    gᶜ, qᵛ⁺ = canopy_conductance_terms(comp.canopy, st.Tᵍ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, 0)
+    gᶜ, qᵛ⁺ = canopy_conductance_terms(comp.canopy, st.Tᵍ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, nothing)
     Gᵃ = aerodynamic_vapor_conductance(Ψₛ, Ψₐ, ℙₐ.thermodynamics_parameters)
     qˢ = (Gᵉ * qᵉ + gᶜ * qᵛ⁺ + Gᵃ * st.qᵃᵗ) / (Gᵉ + gᶜ + Gᵃ)
     @test σ ≈ 1

--- a/test/test_composite_surface_humidity.jl
+++ b/test/test_composite_surface_humidity.jl
@@ -61,7 +61,7 @@ end
     comp = CompositeSurfaceHumidity(soil, canopy)
     _, Ψₛ, Ψₐ, Ψᵢ, Ψᵣ, ℙₐ = _make_call_args(; 𝒮=0.05, st...)   # 𝒮 ≪ 𝒮ᶜ ⇒ σ = 1
     Gᵉ, qᵉ, σ, qᵍ⁺ = dry_layer_terms(comp.soil, st.Tᵍ, Ψₛ, Ψₐ, ℙₐ)
-    gᶜ, qᵛ⁺ = canopy_conductance_terms(comp.canopy, st.Tᵍ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ)
+    gᶜ, qᵛ⁺ = canopy_conductance_terms(comp.canopy, st.Tᵍ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, 0)
     Gᵃ = aerodynamic_vapor_conductance(Ψₛ, Ψₐ, ℙₐ.thermodynamics_parameters)
     qˢ = (Gᵉ * qᵉ + gᶜ * qᵛ⁺ + Gᵃ * st.qᵃᵗ) / (Gᵉ + gᶜ + Gᵃ)
     @test σ ≈ 1


### PR DESCRIPTION
The two closures each carried an `extinction` and a `clumping`, so the light driving photosynthesis could be computed on a different canopy geometry than the shortwave split driving the energy balance.

The duplication was structural: `InteractiveAbsorbedPAR` recomputed the canopy's leaf split term for term.

```julia
beer_lambert_absorbed_fraction = (1 - α)   * (1 - exp(-K * LAI * Ω))   # absorbed_par.jl
SWᵛ                           = (1 - αˡᶠ) * (1 - ftrans) * SW         # canopy_air_space.jl
```

Same expression; only the leaf albedo legitimately differs, since it is band-dependent. Geometry is identical by construction, so the second copy could never be right when it disagreed.

Canopy transmittance is now passed in rather than rebuilt. A `CanopyAirSpace` hands down the `ftrans` its own shortwave split used, and the closure reads its own `extinction`/`clumping` only when nothing supplies one — the canopy-free case, where no other object holds canopy structure.

```julia
absorbed_par_value(par, Ψᵣ, LAI, ftrans)          # `nothing` ⇒ use the closure's own geometry
canopy_conductance_terms(canopy, Tₗ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, canopy_transmittance)
leaf_vapor_terms(canopy, Tᵛ, gʷ, fʷ, Ψₛ, Ψₐ, Ψᵣ, ℙₐ, ftrans)
```

Inside a `CanopyAirSpace` the two geometries cannot diverge, because only one is read. Values are unchanged wherever they already agreed, which is every default configuration, and the canopy-free path is unchanged outright.

Superseded in part by #574: a per-band two-stream would make absorbed PAR an output of the same radiative transfer, and the band albedo would go with it.

Found while auditing the canopy radiation budget in #565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
