### PR TITLE
New rules to make the generated code more sustainable

### DIFF
--- a/.claude/rules/restraint-rules.md
+++ b/.claude/rules/restraint-rules.md
@@ -18,6 +18,11 @@ effect**, and they outrank any instinct toward completeness.
 > **The test behind every rule below:** could a reviewer who knows the physics read this hunk once, in order,
 > and say yes?
 
+**They apply to existing code too.** Every rule below is also a license to delete: when you are already editing
+a file and a rule catches something that is *already there*, removing it is in scope, not scope creep. What is
+out of scope is going looking — do not open unrelated files to hunt for violations, and keep a cleanup that
+grows past the change it started from to its own PR.
+
 ## Rule 1 — The feature is the diff; everything else is scope creep
 
 Before opening a PR, ask what the smallest diff is that delivers the stated change. That diff is the PR.
@@ -66,7 +71,10 @@ A **loud failure is better than a silent fallback.** A `NaN` that reaches the co
 first output; a roughness silently floored at `1e-5` produces plausible wrong fluxes forever.
 
 - If a guard's own docstring has to say *"this is a guard, not a physical parameter"* — delete the guard.
-- Never grow a struct, a keyword argument, or a `show` line to hold a value that is not physics.
+- A keyword argument must express **physics or numerics** — a rate, a length, a tolerance, an iteration
+  cap, a search radius. What it must not express is a defense: a floor, a clamp, or a fallback whose
+  only job is to keep malformed input from reaching the solver. Never grow a struct or a `show` line
+  for one either.
 
 ❌ `minimum_roughness_length` — a new public keyword, struct field, `FT` conversion and `show` row, existing
    only so a field mutated after validation cannot produce `NaN`.
@@ -228,6 +236,7 @@ Any **yes** means cut before presenting.
 9. Is any error message longer than one sentence?
 10. Does any test pin an internal helper, a field order, or a fallback value?
 11. Does any identifier carry an invented sub/superscript, or mix math with English?
-12. Is there a new public keyword argument that the docs describe as non-physical?
+12. Is there a new public keyword argument that is neither physics nor numerics — a floor, clamp, or
+    fallback guarding against malformed input?
 13. Does the diff contain anything a reader would not expect from the title — including another
     branch merged into the head?

--- a/.claude/rules/restraint-rules.md
+++ b/.claude/rules/restraint-rules.md
@@ -216,7 +216,7 @@ The protocol:
    *"Self-review: cut the `minimum_roughness_length` guard (Q3) and two forwarding methods (Q5); 41 lines
    removed."* If it caught nothing, say *"Self-review: clean."* Never claim clean without having read the diff.
 5. **Never delete a rule to pass the checklist.** If a rule seems wrong for the case at hand, say so to the PR author
-   and let him decide. Editing `restraint-rules.md` to accommodate your own diff is the one forbidden move.
+   and let them decide. Editing `restraint-rules.md` to accommodate your own diff is the one forbidden move.
 
 For a three-line edit this takes seconds. For a large one it is the difference between review and no review.
 

--- a/.claude/rules/restraint-rules.md
+++ b/.claude/rules/restraint-rules.md
@@ -215,7 +215,7 @@ The protocol:
 4. **Report the result in one line.** State that the checklist ran and what it caught, e.g.
    *"Self-review: cut the `minimum_roughness_length` guard (Q3) and two forwarding methods (Q5); 41 lines
    removed."* If it caught nothing, say *"Self-review: clean."* Never claim clean without having read the diff.
-5. **Never delete a rule to pass the checklist.** If a rule seems wrong for the case at hand, say so to Simone
+5. **Never delete a rule to pass the checklist.** If a rule seems wrong for the case at hand, say so to the PR author
    and let him decide. Editing `restraint-rules.md` to accommodate your own diff is the one forbidden move.
 
 For a three-line edit this takes seconds. For a large one it is the difference between review and no review.

--- a/.claude/rules/restraint-rules.md
+++ b/.claude/rules/restraint-rules.md
@@ -215,6 +215,23 @@ number.
    `interface.flux_formulation.zero_plane_displacement[2, 1, 1] == 4.0`
 ✅ A doctest that shows the object, via `show`/`summary`, or nothing at all.
 
+## Rule 13 — Search before you write; do not reinvent what exists
+
+Before adding a function, search Oceananigans and NumericalEarth for one that already does the job. Reuse it,
+extend it, or dispatch on it. A second implementation of an existing capability is the most expensive kind of
+scope creep: the duplicate is correct on the day it lands and diverges from the original forever after.
+
+- If an existing function is close but not exact, **widen it** — a new method, a keyword argument, a relaxed
+  type annotation. A near-copy under a new name is never the answer.
+- If you cannot find it, say where you looked. "I searched `Oceananigans/src/Fields` and `DataWrangling` for a
+  masked fill and found none" is a reviewable claim; silence is not.
+- The same holds for patterns, not just functions: grid construction, the `launch!` idiom, `Adapt` rules,
+  `show` methods, dataset hooks — follow the way the codebase already does it.
+
+❌ A new `fill_gaps!` writing a fresh flood-fill kernel while `inpaint_mask!` sits in `DataWrangling`.
+❌ A hand-rolled bilinear interpolation in an example, next to `Oceananigans.Fields.interpolate`.
+✅ `NumericalEarth.DataWrangling.inpaint_mask!(field, mask)`, or a new method on it.
+
 ## Mandatory self-review
 
 **Claude: run the checklist below over every change you make, before you present it.** Not at PR time — at
@@ -224,7 +241,7 @@ The protocol:
 
 1. **Read your own diff.** `git diff` (or `git diff --stat` first if it is large). Review what you actually
    wrote, not what you remember intending. The checklist is answered from the diff, never from memory.
-2. **Answer all thirteen questions.** Every **yes** is a defect you introduced. There is no "yes, but it is
+2. **Answer all fourteen questions.** Every **yes** is a defect you introduced. There is no "yes, but it is
    justified here" — that judgment is exactly the one that produced the drift.
 3. **Cut before presenting.** Removing your own scaffolding is the default action and needs no permission.
    Do not ask "should I remove the validation?" — remove it, and say that you did.
@@ -256,3 +273,5 @@ Any **yes** means cut before presenting.
     fallback guarding against malformed input?
 13. Does the diff contain anything a reader would not expect from the title — including another
     branch merged into the head?
+14. Does the diff reimplement something that already exists in Oceananigans or NumericalEarth, or add a
+    new name where a new method on an existing function would do?

--- a/.claude/rules/restraint-rules.md
+++ b/.claude/rules/restraint-rules.md
@@ -30,6 +30,15 @@ and belongs in a separate PR, or nowhere.
 - Adding lines to `src/` is a cost paid forever. The bar is not "is this useful?" but "is the codebase better
   off carrying this than not?"
 
+**A PR must show only its own change.** Reviewability is a property of the diff GitHub renders, not of the
+commits you know are yours. Never open a PR whose head has merged another feature branch into it: base the PR
+on that branch instead, so the diff shows your commits alone. If the base has to be a feature branch, keep it
+one level deep and rebase — never merge sideways.
+
+❌ #570: a 5-line forwarding method and an 11-line test, presented as **+6186 / −1926 across 119 files**,
+   because the head merged `xk/slab-canopy` (50 commits of unrelated canopy work) into itself.
+✅ Base the PR on `xk/slab-canopy` directly. Diff renders 16 lines. Review takes one minute.
+
 ❌ Feature lands in commit 1 (+142/−143); commits 4 and 7 add +680 lines of validation nobody asked for.
 ✅ Feature lands in commit 1. PR ends. Validation, if genuinely needed, is proposed separately on its merits.
 
@@ -73,14 +82,26 @@ constraint.
    two kernels and a 20-line docstring, to undo it — while noting `inpaint_mask!` already exists.
 ✅ `urban_roughness` does not emit values its only consumer rejects, or the consumer tolerates them.
 
-## Rule 5 — Dispatch is for polymorphism, not for `if`
+## Rule 5 — Minimize the number of methods; dispatch is for polymorphism, not for `if`
 
-Do not write families of one-line methods whose only purpose is to select a branch. Dispatch is the right tool
-when the *behavior* differs by type; it is the wrong tool when a single `ifelse` says it plainly. A reader must
-not have to collect four scattered methods to learn that a value is clamped when it comes from a `Field`.
+**Every method is a maintenance cost.** It has to be named, found, kept consistent with its siblings, kept
+correct under refactoring, and understood by anyone reading any of its callers. If one method does the job,
+do not define two or three. Prefer widening an existing method to introducing a new one, and prefer no new
+name at all to a new name that only forwards.
+
+- Adding a method is justified by **behavior that genuinely differs by type**, not by a value that differs.
+  A value that differs is an argument.
+- A method whose body is a single call to another method, with arguments reordered or a default filled in,
+  should not exist — give the callee the default instead.
+- Do not write families of one-line methods whose only purpose is to select a branch: a reader must not have
+  to collect four scattered definitions to learn that a value is clamped when it comes from a `Field`.
+- If a helper has exactly one call site and no name a physicist would recognize, inline it.
+- Count the methods a hunk adds before pushing. Nine new names for one clamp is not thoroughness.
 
 ❌ `clearance_roughness_length` (3 methods) + `guard_local_roughness_length` (3 methods) +
    `guard_local_zero_plane_displacement` (3 methods) — nine one-liners implementing one clamp.
+❌ `local_flux_formulation(f, i, j) = local_flux_formulation(f, i, j, nothing)` — a forwarding method for a
+   default; give `zᵃᵗ` the default in the one real method.
 ✅ One `@inline` with an `ifelse`, or the clamp written where the value is used.
 
 ## Rule 6 — No table-driven generalization of a small fixed set
@@ -170,15 +191,37 @@ number.
    `interface.flux_formulation.zero_plane_displacement[2, 1, 1] == 4.0`
 ✅ A doctest that shows the object, via `show`/`summary`, or nothing at all.
 
-## Reviewer's checklist
+## Mandatory self-review
 
-Run this over your own diff before asking for review. Any **yes** means cut before pushing.
+**Claude: run the checklist below over every change you make, before you present it.** Not at PR time — at
+the end of every edit, every time. This is not optional and it is not proportional to how confident you feel.
+
+The protocol:
+
+1. **Read your own diff.** `git diff` (or `git diff --stat` first if it is large). Review what you actually
+   wrote, not what you remember intending. The checklist is answered from the diff, never from memory.
+2. **Answer all thirteen questions.** Every **yes** is a defect you introduced. There is no "yes, but it is
+   justified here" — that judgment is exactly the one that produced the drift.
+3. **Cut before presenting.** Removing your own scaffolding is the default action and needs no permission.
+   Do not ask "should I remove the validation?" — remove it, and say that you did.
+4. **Report the result in one line.** State that the checklist ran and what it caught, e.g.
+   *"Self-review: cut the `minimum_roughness_length` guard (Q3) and two forwarding methods (Q5); 41 lines
+   removed."* If it caught nothing, say *"Self-review: clean."* Never claim clean without having read the diff.
+5. **Never delete a rule to pass the checklist.** If a rule seems wrong for the case at hand, say so to Simone
+   and let him decide. Editing `restraint-rules.md` to accommodate your own diff is the one forbidden move.
+
+For a three-line edit this takes seconds. For a large one it is the difference between review and no review.
+
+## The checklist
+
+Any **yes** means cut before presenting.
 
 1. Is the diff more than ~2× the size of the change actually described in the title?
 2. Does any invariant get enforced in more than one place?
 3. Does any new code defend against a state unreachable through the public API?
 4. Does the PR add an API to repair damage the PR itself caused?
-5. Are there ≥3 one-line methods that together implement a single `ifelse`?
+5. How many methods does this diff add, and could any of them be one method, an argument, or nothing?
+   (≥3 one-liners implementing a single `ifelse`, or a method that only forwards to another, is a no.)
 6. Is there a table, registry, or predicate list covering fewer than ~12 fixed entries?
 7. Does any comment mention a function, module, kernel, or test other than the one it sits in?
 8. Does any docstring argue for the function's existence or carry `@ref`s to siblings to be understood?
@@ -186,3 +229,5 @@ Run this over your own diff before asking for review. Any **yes** means cut befo
 10. Does any test pin an internal helper, a field order, or a fallback value?
 11. Does any identifier carry an invented sub/superscript, or mix math with English?
 12. Is there a new public keyword argument that the docs describe as non-physical?
+13. Does the diff contain anything a reader would not expect from the title — including another
+    branch merged into the head?

--- a/.claude/rules/restraint-rules.md
+++ b/.claude/rules/restraint-rules.md
@@ -18,6 +18,10 @@ effect**, and they outrank any instinct toward completeness.
 > **The test behind every rule below:** could a reviewer who knows the physics read this hunk once, in order,
 > and say yes?
 
+**If you carry away only four, carry these:** the diff is the feature and nothing else (Rule 1); an invariant is
+enforced in one place (Rule 2); a comment describes the code that is there (Rule 7); an error message is one
+sentence (Rule 9). The rest are corollaries of those four, and the checklist at the end is how they are applied.
+
 **They apply to existing code too.** Every rule below is also a license to delete: when you are already editing
 a file and a rule catches something that is *already there*, removing it is in scope, not scope creep. What is
 out of scope is going looking — do not open unrelated files to hunt for violations, and keep a cleanup that
@@ -51,7 +55,7 @@ one level deep and rebase — never merge sideways.
 
 An invariant is enforced in exactly one place. Enforcing it at setup *and* in the kernel *and* through a
 fallback *and* in a gap-filler does not make it four times as safe — it makes it impossible to tell which
-mechanism is load-bearing, and guarantees the four drift apart.
+mechanism actually does the work, and guarantees the four drift apart.
 
 Before adding a check, find where the invariant is already enforced. If a runtime floor already exists,
 setup-time validation is redundant; if setup-time validation is added, the runtime floor should be deleted.
@@ -63,9 +67,13 @@ setup-time validation is redundant; if setup-time validation is added, the runti
 
 ## Rule 3 — No guards for states the code cannot reach
 
-Never add machinery to defend against a state that is unreachable through the public API. "A user might mutate
-this field after construction" and "a downstream package might pass a wrong type" are hypotheticals, not
-requirements. Code written against hypotheticals is permanent; the hypothetical usually never arrives.
+The shape to watch for: an inner function that checks for input its only caller cannot produce, or a branch
+that repeats a rejection the public constructor already performed. The check is technically correct, and it
+never runs.
+
+"A user might mutate this field after construction" and "a downstream package might pass a wrong type" are
+hypotheticals, not requirements. The guard written against one outlives the hypothetical, which usually never
+arrives — and because such a guard is bloat rather than a bug, nothing ever forces it out again.
 
 A **loud failure is better than a silent fallback.** A `NaN` that reaches the coupled state is visible in the
 first output; a roughness silently floored at `1e-5` produces plausible wrong fluxes forever.
@@ -134,12 +142,20 @@ Reinforces the comment rules in `style-rules.md`, which this codebase violates m
 - teach the language (`==` vs `===`, how `@inbounds` works, why `Adapt` needs field order);
 - carry a multi-line design memo or `TODO` about a different module's construction order.
 
+History belongs in the commit message, which has both the code before and the code after the change in view. A
+comment has only the code that is there now, so a comment about what the code used to do — or what it does not
+do — cannot be read: the reader has no access to the thing being contrasted, and the contrast ages into a lie
+the first time either side moves. Avoid "no longer", "previously", "used to", "instead of", and "now" in the
+sense of "now does X". A docstring reading `Returns (Q, Tᵦ, Sᵦ)` is complete; adding "the melt rate is no
+longer returned" only leaves the reader hunting for a melt rate.
+
 If the reasoning genuinely cannot be dropped, it belongs in the PR description — which reviewers read once and
 which does not age in the source tree.
 
 ❌ Five lines above `Adapt.@adapt_structure SimilarityTheoryFluxes` explaining that a positional rebuild
    elsewhere would mis-wire the struct and that a test pins the field order.
 ❌ `# Grids are compared with `==` … rather than `===`: two references to one grid are not guaranteed to be egal`
+❌ `# the melt rate is no longer returned; callers derive it from the mass change instead`
 ✅ `# ifelse, not ?:, so the kernel stays branch-free on GPU`
 
 ## Rule 8 — Docstrings describe, they do not argue
@@ -169,7 +185,7 @@ six lines each is fifty lines of string literal in `src/`.
 ## Rule 10 — Test behavior, not scaffolding
 
 Tests pin the physics and the public contract. A test that asserts an internal helper's return type, a struct's
-field order, or the exact value a fallback produces makes the scaffolding **load-bearing**: it can no longer be
+field order, or the exact value a fallback produces makes that scaffolding **permanent**: it can no longer be
 deleted without "breaking tests", which is precisely how machine-written scaffolding becomes permanent.
 
 - Never write a test whose only purpose is to lock in a guard added by the same PR.

--- a/.claude/rules/restraint-rules.md
+++ b/.claude/rules/restraint-rules.md
@@ -1,0 +1,188 @@
+---
+paths:
+  - src/**/*.jl
+  - test/**/*.jl
+  - validation/**/*.jl
+  - examples/**/*.jl
+---
+
+# Restraint Rules
+
+Machine-written code fails in a characteristic way: it is **correct and unreadable**. Every branch is handled,
+every failure anticipated, every invariant checked at three layers — and no human can hold the result in their
+head. A reviewer facing 700 lines cannot tell which 40 are the feature.
+
+These rules exist to keep the diff small, the mechanisms singular, and the prose scarce. They are **always in
+effect**, and they outrank any instinct toward completeness.
+
+> **The test behind every rule below:** could a reviewer who knows the physics read this hunk once, in order,
+> and say yes?
+
+## Rule 1 — The feature is the diff; everything else is scope creep
+
+Before opening a PR, ask what the smallest diff is that delivers the stated change. That diff is the PR.
+Anything that is not the feature — validation, fallbacks, gap-fillers, helper APIs — is a **separate concern**
+and belongs in a separate PR, or nowhere.
+
+- A generalization that **deletes** an abstraction is the best possible change. A change that ends net-negative
+  needs no justification; celebrate it and stop there.
+- If the feature commit is net-zero and the PR is +700, the PR is 95 % scaffolding. Drop the scaffolding.
+- Adding lines to `src/` is a cost paid forever. The bar is not "is this useful?" but "is the codebase better
+  off carrying this than not?"
+
+❌ Feature lands in commit 1 (+142/−143); commits 4 and 7 add +680 lines of validation nobody asked for.
+✅ Feature lands in commit 1. PR ends. Validation, if genuinely needed, is proposed separately on its merits.
+
+## Rule 2 — One invariant, one mechanism
+
+An invariant is enforced in exactly one place. Enforcing it at setup *and* in the kernel *and* through a
+fallback *and* in a gap-filler does not make it four times as safe — it makes it impossible to tell which
+mechanism is load-bearing, and guarantees the four drift apart.
+
+Before adding a check, find where the invariant is already enforced. If a runtime floor already exists,
+setup-time validation is redundant; if setup-time validation is added, the runtime floor should be deleted.
+
+❌ `evaluable_roughness_length` checked in `validate_flux_formulation`, again in `local_roughness_length`,
+   again in `guard_local_roughness_length`, again in `fill_aerodynamic_roughness_gaps!` — while
+   `displaced_profile_height`'s `max(Δh - d, 2ℓ)` already floored it before the PR.
+✅ One check, at the layer that owns the contract. State in one line where that is.
+
+## Rule 3 — No guards for states the code cannot reach
+
+Never add machinery to defend against a state that is unreachable through the public API. "A user might mutate
+this field after construction" and "a downstream package might pass a wrong type" are hypotheticals, not
+requirements. Code written against hypotheticals is permanent; the hypothetical usually never arrives.
+
+A **loud failure is better than a silent fallback.** A `NaN` that reaches the coupled state is visible in the
+first output; a roughness silently floored at `1e-5` produces plausible wrong fluxes forever.
+
+- If a guard's own docstring has to say *"this is a guard, not a physical parameter"* — delete the guard.
+- Never grow a struct, a keyword argument, or a `show` line to hold a value that is not physics.
+
+❌ `minimum_roughness_length` — a new public keyword, struct field, `FT` conversion and `show` row, existing
+   only so a field mutated after validation cannot produce `NaN`.
+✅ Validate at construction, or let it fail loudly. No new API.
+
+## Rule 4 — Don't invent an API to solve a problem the same PR created
+
+If a change makes previously valid data invalid, and the PR then ships a new exported helper to repair that
+data, the PR has manufactured its own problem. Fix the producer, reuse what exists, or loosen the new
+constraint.
+
+❌ New validation rejects `urban_roughness`'s `NaN` cells → same PR adds `fill_aerodynamic_roughness_gaps!`,
+   two kernels and a 20-line docstring, to undo it — while noting `inpaint_mask!` already exists.
+✅ `urban_roughness` does not emit values its only consumer rejects, or the consumer tolerates them.
+
+## Rule 5 — Dispatch is for polymorphism, not for `if`
+
+Do not write families of one-line methods whose only purpose is to select a branch. Dispatch is the right tool
+when the *behavior* differs by type; it is the wrong tool when a single `ifelse` says it plainly. A reader must
+not have to collect four scattered methods to learn that a value is clamped when it comes from a `Field`.
+
+❌ `clearance_roughness_length` (3 methods) + `guard_local_roughness_length` (3 methods) +
+   `guard_local_zero_plane_displacement` (3 methods) — nine one-liners implementing one clamp.
+✅ One `@inline` with an `ifelse`, or the clamp written where the value is used.
+
+## Rule 6 — No table-driven generalization of a small fixed set
+
+Four things are not a collection. Do not build a registry of `(name, slot, predicate, message)` tuples and loop
+over it to save writing four explicit checks — the table costs more to read, hides the control flow, and its
+promised "adding one is a single edit" is usually false the moment anything unpacks it positionally.
+
+Reach for a table at roughly a dozen homogeneous entries, when they genuinely vary at runtime — not before.
+
+❌ `flux_formulation_slots` returning 4 tuples of name/value/predicate/prose, walked by two functions, then
+   destructured positionally as `ℓuᵛ, ℓθᵛ, ℓqᵛ, dᵛ = values` right afterward.
+✅ Four explicit one-line checks, in order, readable top to bottom.
+
+## Rule 7 — Comments describe this code, now — nothing else
+
+Reinforces the comment rules in `style-rules.md`, which this codebase violates most often. A comment must not:
+
+- explain what **another** function does, or what a **caller** or **kernel elsewhere** would do;
+- justify a design decision, compare it to a rejected alternative, or narrate history;
+- describe code that **is not there** ("the ocean kernel would fail with…", "a bare `MethodError` on CPU…");
+- teach the language (`==` vs `===`, how `@inbounds` works, why `Adapt` needs field order);
+- carry a multi-line design memo or `TODO` about a different module's construction order.
+
+If the reasoning genuinely cannot be dropped, it belongs in the PR description — which reviewers read once and
+which does not age in the source tree.
+
+❌ Five lines above `Adapt.@adapt_structure SimilarityTheoryFluxes` explaining that a positional rebuild
+   elsewhere would mis-wire the struct and that a test pins the field order.
+❌ `# Grids are compared with `==` … rather than `===`: two references to one grid are not guaranteed to be egal`
+✅ `# ifelse, not ?:, so the kernel stays branch-free on GPU`
+
+## Rule 8 — Docstrings describe, they do not argue
+
+A docstring says what the function does, its arguments, and its units. It does not defend the function's
+existence, quantify what would go wrong without it, or send the reader to three other functions to understand
+it. A cluster of `@ref`s pointing at siblings means the abstraction is wrong, not that the docs are thorough.
+
+- No "this is a backstop, not a supported regime" framing. No bulleted rationale lists.
+- No tuning advice for a parameter the same docstring calls non-physical.
+- Keep the argument list; drop the essay.
+
+❌ 18 lines documenting `minimum_roughness_length`, of which 2 describe it and 16 argue about when it binds.
+✅ `` `minimum_roughness_length`: Floor [m] on the roughness length used in the similarity profile. Default: 1e-5. ``
+
+## Rule 9 — Error messages are one sentence
+
+Name the offending object, say what was required, stop. An `ArgumentError` is not a tutorial: it should not
+explain the physics, list downstream consequences, quote numbers, or recommend a helper function. Six errors of
+six lines each is fifty lines of string literal in `src/`.
+
+❌ `"$name has $(count(...)) cells that are not $requirement (minimum $(minimum(values))). A bad cell either
+   propagates NaN through u★, θ★ and q★ into the coupled state or silently zeroes every turbulent flux there.
+   Fill the gaps first, e.g. with fill_aerodynamic_roughness_gaps!."`
+✅ `"momentum_roughness_length must be finite and positive, found $(minimum(values))"`
+
+## Rule 10 — Test behavior, not scaffolding
+
+Tests pin the physics and the public contract. A test that asserts an internal helper's return type, a struct's
+field order, or the exact value a fallback produces makes the scaffolding **load-bearing**: it can no longer be
+deleted without "breaking tests", which is precisely how machine-written scaffolding becomes permanent.
+
+- Never write a test whose only purpose is to lock in a guard added by the same PR.
+- No tautological assertions (`@test !isnothing(constructor(...))`) — a constructor returning `nothing` is a bug
+  in itself, not something to assert.
+- One clear analytical check (`u★ = ϰ ΔU / log((h − d) / ℓᵐ)`, cell by cell) beats twenty defensive ones.
+
+## Rule 11 — Notation is from `notation.md`, or it is English
+
+No inventing decorations. A superscript must mean what it means in the physics, not encode a code-level
+distinction like "host-side copy" or "clearance contribution". If a value needs that kind of qualifier, it
+needs a verbose English name.
+
+Reread `style-rules.md` Rules 1–3 before naming anything: identifiers are **fully math or fully English**.
+
+❌ `ℓᵛ`, `zᵛ`, `dᵛ`, `ℓᵐᵃˣᵛ`, `ℓuᶜ` (invented `ᵛ` = "values array", `ᶜ` = "clearance")
+❌ `ℓmin` (math + truncated English in one identifier), `to_FT` (ad-hoc local closure)
+✅ `roughness_length_values`, `ℓᵐᵃˣ` (in `notation.md`), `minimum_roughness_length`
+
+## Rule 12 — Use constructors as designed
+
+Already pitfall 6 in `AGENTS.md`; it is broken most often in new doctests and examples. Never reach into a
+constructor's result to prove it worked, and never write a doctest whose assertion is that `set!` assigned a
+number.
+
+❌ ```jldoctest``` that builds a full coupled interface to check
+   `interface.flux_formulation.zero_plane_displacement[2, 1, 1] == 4.0`
+✅ A doctest that shows the object, via `show`/`summary`, or nothing at all.
+
+## Reviewer's checklist
+
+Run this over your own diff before asking for review. Any **yes** means cut before pushing.
+
+1. Is the diff more than ~2× the size of the change actually described in the title?
+2. Does any invariant get enforced in more than one place?
+3. Does any new code defend against a state unreachable through the public API?
+4. Does the PR add an API to repair damage the PR itself caused?
+5. Are there ≥3 one-line methods that together implement a single `ifelse`?
+6. Is there a table, registry, or predicate list covering fewer than ~12 fixed entries?
+7. Does any comment mention a function, module, kernel, or test other than the one it sits in?
+8. Does any docstring argue for the function's existence or carry `@ref`s to siblings to be understood?
+9. Is any error message longer than one sentence?
+10. Does any test pin an internal helper, a field order, or a fallback value?
+11. Does any identifier carry an invented sub/superscript, or mix math with English?
+12. Is there a new public keyword argument that the docs describe as non-physical?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,8 @@ remove trailing whitespace, remove trailing blank lines, ensure file ends with e
 
 ## Agent Behavior
 
+- **Before presenting any change, run the checklist in `.claude/rules/restraint-rules.md` over your own
+  `git diff` and cut what it catches.** Report the result in one line. This is mandatory for every edit.
 - Prioritize type stability and GPU compatibility
 - Follow established patterns in existing code
 - Add tests for new functionality; update exports when adding public API

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,8 @@ Rules in `.claude/rules/` load automatically when you touch matching files:
 - `testing-rules.md` — test writing and running (test/)
 - `docs-rules.md` — documentation building and style (docs/)
 - `examples-rules.md` — Literate.jl example conventions (examples/)
+- `restraint-rules.md` — **keeping the code human-written**: diff size, one invariant one mechanism,
+  no guards for unreachable states, comments that describe only this code (src/, test/, examples/)
 
 ### Skills (slash commands)
 


### PR DESCRIPTION
Recently claude coding has become quite the standard for NumericalEarth. This is not a negative, it allows to accelerate writing code and NumericalEarth has grown quite quickly thanks to it. What I am afraid of, however, is the sustainability of the codebase. I feel like generated code it quite obscure to a human reviewer because of several reasons: (1) the excess of prose which, counterintuitively hampers readability, (2) comments that refer to different part of the codebase, very useful for a machine, not so much for a human reader, (3) the insane amount of bespoke features that a machine introduces rather than finding a more general design or a lower-impact change in the code that would result in the same feature implementation, (4) the thousands of lines of code written for implementing rather simple changes (maybe same as number 3), (5) the excessive input validation which now makes up most of the codebase.

To be practical and quantitative, the codebase grew from 10k lines in January to 26k lines now with the share of comments increasing from ~8.5% to ~13%.

For this reason, I tried to synthesize this in a "restriction" rule that tries to make the code more sustainable and human-readable.