### PR TITLE
Post a reviewer checklist on each pull request and report it as a status

### DIFF
--- a/.github/review-checklist.md
+++ b/.github/review-checklist.md
@@ -1,0 +1,8 @@
+**Reviewer checklist**, please tick these before approving:
+
+- [ ] I read the diff top to bottom once and can say what the change does
+- [ ] It doesn't reintroduce something the codebase already has, or add a name that only forwards
+- [ ] The diff is the feature, not mostly validation, fallbacks, or scaffolding
+- [ ] Comments, docstrings, and error messages earn their lines
+
+These are judgement calls CI can't make. The rules behind them are in `AGENTS.md`.

--- a/.github/workflows/review-checklist.yml
+++ b/.github/workflows/review-checklist.yml
@@ -1,0 +1,60 @@
+name: Review checklist
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, review_requested, synchronize]
+  # TODO: remove before merging. Lets the workflow run on its own pull request,
+  # which `pull_request_target` cannot do until it reaches the default branch.
+  pull_request:
+    types: [opened, ready_for_review, review_requested, synchronize]
+  issue_comment:
+    types: [edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  checklist:
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request &&
+       github.event.comment.user.login == 'github-actions[bot]' &&
+       startsWith(github.event.comment.body, '<!-- review-checklist -->'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const MARKER = '<!-- review-checklist -->'
+            const {owner, repo} = context.repo
+            const number = context.payload.pull_request?.number ?? context.payload.issue.number
+
+            const {data: pull_request} = await github.rest.pulls.get({owner, repo, pull_number: number})
+            if (pull_request.draft) return
+
+            const comments = await github.paginate(github.rest.issues.listComments,
+                                                   {owner, repo, issue_number: number, per_page: 100})
+            let checklist = comments.find(comment => comment.body.startsWith(MARKER))
+
+            if (!checklist) {
+              const body = MARKER + '\n' + require('fs').readFileSync('.github/review-checklist.md', 'utf8')
+              checklist = (await github.rest.issues.createComment({owner, repo, issue_number: number, body})).data
+            }
+
+            const boxes = checklist.body.match(/^\s*[-*]\s*\[[ xX]\]/gm) ?? []
+            const ticked = boxes.filter(box => /\[[xX]\]/.test(box)).length
+
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha: pull_request.head.sha,
+              state: boxes.length > 0 && ticked === boxes.length ? 'success' : 'failure',
+              context: 'review-checklist',
+              description: boxes.length === 0 ? 'checklist comment has no items' : `${ticked} of ${boxes.length} items ticked`,
+              target_url: checklist.html_url,
+            })


### PR DESCRIPTION
Once a pull request leaves draft, a workflow posts `.github/review-checklist.md` as a comment and reports a `review-checklist` commit status counting the ticked boxes. Reviewers click the boxes and type nothing; the author's description is untouched. Comes out of the discussion in #576.

### Intended behavior

1. A pull request leaves draft, or someone is added as a reviewer. The bot posts the checklist and the status reads `0 of 4 items ticked`, red.
2. A reviewer ticks a box. The status updates, turning green at `4 of 4`.
3. New commits are pushed. The status is re-posted on the new commit from the same comment, so ticks are not lost.

Editing any other comment does nothing, and approving fires nothing: the ruleset already requires one approval, and would separately require this status to be green.

Nothing is blocked until someone with admin adds `review-checklist` to the `main` ruleset as a required status check.

TODO: remove the `pull_request` trigger before merging.