### PR TITLE
Surface `GLO30`/`GLO90` and correct CopernicusDEM's file traits

### DIFF
--- a/src/DataWrangling/CopernicusDEM/CopernicusDEM.jl
+++ b/src/DataWrangling/CopernicusDEM/CopernicusDEM.jl
@@ -85,6 +85,13 @@ const CopernicusDEMMetadatum = Metadatum{<:CopernicusDEMDataset}
 DataWrangling.dataset_variable_name(data::CopernicusDEMMetadatum) =
     CopernicusDEM_bathymetry_variable_names[data.name]
 
+# The downloaded window names its axes "lon"/"lat".
+DataWrangling.longitude_name(::CopernicusDEMMetadatum) = "lon"
+DataWrangling.latitude_name(::CopernicusDEMMetadatum)  = "lat"
+
+# The DEM covers every cell of its window, with ocean set to 0, so there is nothing to fill.
+DataWrangling.default_inpainting(::CopernicusDEMMetadatum) = nothing
+
 DataWrangling.metadata_filename(dataset::CopernicusDEMDataset, name, date, region) =
     string(dataset_prefix(dataset), "_", bounding_box_suffix(region), ".nc")
 

--- a/src/DataWrangling/CopernicusDEM/CopernicusDEM.jl
+++ b/src/DataWrangling/CopernicusDEM/CopernicusDEM.jl
@@ -89,7 +89,6 @@ DataWrangling.dataset_variable_name(data::CopernicusDEMMetadatum) =
 DataWrangling.longitude_name(::CopernicusDEMMetadatum) = "lon"
 DataWrangling.latitude_name(::CopernicusDEMMetadatum)  = "lat"
 
-# The DEM covers every cell of its window, with ocean set to 0, so there is nothing to fill.
 DataWrangling.default_inpainting(::CopernicusDEMMetadatum) = nothing
 
 DataWrangling.metadata_filename(dataset::CopernicusDEMDataset, name, date, region) =

--- a/src/DataWrangling/CopernicusDEM/CopernicusDEM.jl
+++ b/src/DataWrangling/CopernicusDEM/CopernicusDEM.jl
@@ -85,7 +85,6 @@ const CopernicusDEMMetadatum = Metadatum{<:CopernicusDEMDataset}
 DataWrangling.dataset_variable_name(data::CopernicusDEMMetadatum) =
     CopernicusDEM_bathymetry_variable_names[data.name]
 
-# The downloaded window names its axes "lon"/"lat".
 DataWrangling.longitude_name(::CopernicusDEMMetadatum) = "lon"
 DataWrangling.latitude_name(::CopernicusDEMMetadatum)  = "lat"
 

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -114,6 +114,7 @@ export
     ECCOMetadatum,
     EN4Metadatum,
     ETOPO2022,
+    GLO30, GLO90,
     ECCO2Daily, ECCO2Monthly, ECCO4Monthly,
     ECCO2DarwinMonthly, ECCO4DarwinMonthly,
     EN4Monthly,
@@ -281,6 +282,7 @@ using .DataWrangling.GloFAS
 using .DataWrangling.ERA5
 using .DataWrangling.SoilGrids
 using .DataWrangling.ASTERGED
+using .DataWrangling.CopernicusDEM
 using .DataWrangling.CopernicusLandAlbedo
 using .DataWrangling.OpenLandMap
 using .DataWrangling.GloBFP3D


### PR DESCRIPTION
`GLO30` and `GLO90` were never brought into scope at the top level, so `using NumericalEarth`
could not see them, and three of CopernicusDEM's traits did not match the file its downloader
writes.

- `using .DataWrangling.CopernicusDEM`, plus `GLO30, GLO90` in the export list. Every other
  dataset module is already surfaced this way.
- `longitude_name` and `latitude_name` return `"lon"` and `"lat"`, the names the Zarr downloader
  writes. The defaults, `"longitude"` and `"latitude"`, are not variables in the file.
- `default_inpainting` returns `nothing`. The generic default is `NearestNeighborInpainting(5)`,
  meant for ocean datasets whose land cells are missing; the DEM covers every cell of its window,
  with ocean set to 0.

```julia
using NumericalEarth

GLO30()
```

`Field(metadatum, grid)` on a `GLO30` metadatum still fails further in, on a disk-read indexing
error for the DEM's two-dimensional `z` variable. This makes the traits correct; it does not
finish `Field` support.
