### PR TITLE
Convert numeric roughness slots to the closure's float type

### DIFF
--- a/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
@@ -185,13 +185,11 @@ function SimilarityTheoryFluxes(FT::DataType = Oceananigans.defaults.FloatType;
                                 solver_tolerance = 1e-8,
                                 solver_maxiter = 100)
 
-    roughness_lengths = SimilarityScales(momentum_roughness_length,
-                                         temperature_roughness_length,
-                                         water_vapor_roughness_length)
+    roughness_lengths = SimilarityScales(convert_if_number(FT, momentum_roughness_length),
+                                         convert_if_number(FT, temperature_roughness_length),
+                                         convert_if_number(FT, water_vapor_roughness_length))
 
-    if zero_plane_displacement isa Number
-        zero_plane_displacement = convert(FT, zero_plane_displacement)
-    end
+    zero_plane_displacement = convert_if_number(FT, zero_plane_displacement)
 
     if isnothing(solver_stop_criteria)
         solver_tolerance = convert(FT, solver_tolerance)

--- a/test/test_subgrid_velocity_corrections.jl
+++ b/test/test_subgrid_velocity_corrections.jl
@@ -97,6 +97,21 @@ end
     # The correction survives an `adapt` roundtrip (GPU struct integrity)
     adapted = adapt(Array, fluxes)
     @test adapted.subgrid_velocities === fluxes.subgrid_velocities
+
+    # Numeric roughness and displacement slots join the closure's float type
+    slots = SimilarityTheoryFluxes(Float32; momentum_roughness_length = 0.1,
+                                            temperature_roughness_length = 1,
+                                            water_vapor_roughness_length = 0.01,
+                                            zero_plane_displacement = 4)
+
+    @test slots.roughness_lengths.momentum === 0.1f0
+    @test slots.roughness_lengths.temperature === 1f0
+    @test slots.roughness_lengths.water_vapor === 0.01f0
+    @test slots.zero_plane_displacement === 4f0
+
+    # Formulations are already built with FT and pass through untouched
+    ℓᵐ = MomentumRoughnessLength(Float32)
+    @test SimilarityTheoryFluxes(Float32; momentum_roughness_length = ℓᵐ).roughness_lengths.momentum === ℓᵐ
 end
 
 @testset "Coupled single-column: mesoscale velocity increases calm-wind u★" begin

--- a/test/test_subgrid_velocity_corrections.jl
+++ b/test/test_subgrid_velocity_corrections.jl
@@ -110,8 +110,8 @@ end
     @test slots.zero_plane_displacement === 4f0
 
     # Formulations are already built with FT and pass through untouched
-    ℓᵐ = MomentumRoughnessLength(Float32)
-    @test SimilarityTheoryFluxes(Float32; momentum_roughness_length = ℓᵐ).roughness_lengths.momentum === ℓᵐ
+    formulation = MomentumRoughnessLength(Float32)
+    @test SimilarityTheoryFluxes(Float32; momentum_roughness_length = formulation).roughness_lengths.momentum === formulation
 end
 
 @testset "Coupled single-column: mesoscale velocity increases calm-wind u★" begin


### PR DESCRIPTION
`SimilarityTheoryFluxes` converted `zero_plane_displacement` to `FT` but left the three roughness-length slots alone, so `SimilarityTheoryFluxes(Float32; momentum_roughness_length = 0.1)` stored a `Float64` and promoted the whole Monin–Obukhov chain to `Float64` inside a `Float32` kernel. An integer slot hit `convert` per cell inside the solve.

All four slots now convert through `convert_if_number`, already used for the transfer coefficients in the same module. Formulations pass through untouched.

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)