### PR TITLE
Say "ten days" instead of "dekad" for the CGLS albedo cadence

### DIFF
--- a/docs/src/Metadata/metadata_overview.md
+++ b/docs/src/Metadata/metadata_overview.md
@@ -211,7 +211,7 @@ NumericalEarth currently ships connectors for the following data products:
 | `ERA5MonthlyLand`  | [Supported variables](@ref dataset-era5monthlyland-vars)  | [ERA5-Land monthly overview](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means?tab=overview) |
 | `SoilGrids 2.0`     | Global profiles of soil texture, bulk density, and organic content in upper 2 meters  | [SoilGrids documentation](https://docs.isric.org/globaldata/soilgrids/)                                   |
 | `OpenLandMapSoilDB` | 30 m global soil texture (sand, silt, clay) and fine-earth bulk density over 0–100 cm | [OpenLandMap STAC](https://stac.openlandmap.org/) |
-| `CopernicusAlbedo` | `:albedo` — dekadal blue-sky broadband surface albedo on the global 1 km CGLS grid | [CGLS Surface Albedo](https://cds.climate.copernicus.eu/datasets/satellite-albedo) |
+| `CopernicusAlbedo` | `:albedo` — ten-day blue-sky broadband surface albedo on the global 1 km CGLS grid | [CGLS Surface Albedo](https://cds.climate.copernicus.eu/datasets/satellite-albedo) |
 | `CopernicusAlbedoClimatology` | `:albedo` — 12-month climatology of the CGLS blue-sky broadband albedo | [CGLS Surface Albedo](https://cds.climate.copernicus.eu/datasets/satellite-albedo) |
 | `GHSBuiltH`        | `:building_height` — mean net building height (ANBH, 100 m, epoch 2018) over a regional window; reprojected from GHSL World-Mollweide (needs `ArchGDAL`) | [GHSL GHS-BUILT-H](https://human-settlement.emergency.copernicus.eu) |
 | `GHSBuiltS`        | `:built_up_fraction` — plan-area built-up fraction (10 m or 100 m) over a regional window; reprojected from GHSL World-Mollweide (needs `ArchGDAL`) | [GHSL GHS-BUILT-S](https://human-settlement.emergency.copernicus.eu) |

--- a/examples/breeze_downscaling_era5.jl
+++ b/examples/breeze_downscaling_era5.jl
@@ -192,8 +192,8 @@ set!(land; M = 20)
 #
 # All-sky RRTMGP: interior heating on the evolving clouds, surface fluxes into the land
 # budget. The surface albedo is observed, not constant — passing the dataset materializes
-# the CGLS 1 km blue-sky albedo at the dekad nearest `epoch`, with water pixels (NaN in the
-# land product) defaulting to open water. Everything else is a Breeze default — per-column
+# the CGLS 1 km blue-sky albedo at the ten-day date nearest `epoch`, with water pixels
+# (NaN in the land product) defaulting to open water. Everything else is a Breeze default — per-column
 # sun angles from the grid, climatological ozone, emissivity, effective radii. No surface
 # temperature either: the coupled model below binds the atmosphere–land interface skin
 # temperature, re-read every solve. Hourly solves match the ERA5 cadence.

--- a/ext/NumericalEarthBreezeExt/breeze_surface_albedo.jl
+++ b/ext/NumericalEarthBreezeExt/breeze_surface_albedo.jl
@@ -3,8 +3,8 @@ using NumericalEarth.DataWrangling: DataWrangling, Metadatum
 using Oceananigans.Fields: interior
 
 # `surface_albedo = CopernicusAlbedo()` in a RadiativeTransferModel: CGLS blue-sky albedo
-# on the model grid at the dekad nearest the solar epoch; water/missing pixels (NaN in the
-# land product) become open-water albedo.
+# on the model grid at the ten-day date nearest the solar epoch; water/missing pixels
+# (NaN in the land product) become open-water albedo.
 
 albedo_epoch(solar_position::Breeze.ApparentSolarPosition) = solar_position.epoch
 albedo_epoch(solar_position) = nothing

--- a/ext/NumericalEarthCDSAPIExt/NumericalEarthCDSAPIExt.jl
+++ b/ext/NumericalEarthCDSAPIExt/NumericalEarthCDSAPIExt.jl
@@ -22,7 +22,7 @@ using NumericalEarth.DataWrangling.GloFAS: GloFASDataset, GloFASMetadata, GloFAS
                                            GloFAS_netcdf_variable_names
 using NumericalEarth.DataWrangling.CopernicusLandAlbedo: ALBEDO_CDS_PRODUCT,
                                                          CopernicusAlbedoDatasetMetadata,
-                                                         download_albedo_dekads!
+                                                         download_ten_day_albedo!
 
 include("cds_utils.jl")
 include("era5.jl")

--- a/ext/NumericalEarthCDSAPIExt/copernicus_land_albedo.jl
+++ b/ext/NumericalEarthCDSAPIExt/copernicus_land_albedo.jl
@@ -4,6 +4,6 @@
 #####
 
 Downloads.download(metadata::CopernicusAlbedoDatasetMetadata; kwargs...) =
-    download_albedo_dekads!(metadata; kwargs...) do request, path
+    download_ten_day_albedo!(metadata; kwargs...) do request, path
         retrieve_with_retries(ALBEDO_CDS_PRODUCT, request, path)
     end

--- a/ext/NumericalEarthCopernicusClimateDataStoreExt.jl
+++ b/ext/NumericalEarthCopernicusClimateDataStoreExt.jl
@@ -651,14 +651,14 @@ end
 
 using NumericalEarth.DataWrangling.CopernicusLandAlbedo: ALBEDO_CDS_PRODUCT,
                                                          CopernicusAlbedoDatasetMetadata,
-                                                         download_albedo_dekads!
+                                                         download_ten_day_albedo!
 
 function Downloads.download(metadata::CopernicusAlbedoDatasetMetadata; kwargs...)
     isdefined(CopernicusClimateDataStore, :retrieve) || throw(ArgumentError(
         "Downloading the Copernicus land albedo needs CopernicusClimateDataStore ≥ 0.2, " *
         "whose native CDS client provides `retrieve`."))
 
-    return download_albedo_dekads!(metadata; kwargs...) do request, path
+    return download_ten_day_albedo!(metadata; kwargs...) do request, path
         CopernicusClimateDataStore.retrieve(ALBEDO_CDS_PRODUCT, request, path)
     end
 end

--- a/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
+++ b/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
@@ -54,10 +54,10 @@ abstract type AbstractCopernicusAlbedo end
 """
     CopernicusAlbedo(; diffuse_fraction = 0.2)
 
-The Copernicus Global Land Service (CGLS) 1 km surface-albedo dataset, a dekadal
-(10-daily) time series derived from SPOT/VGT and PROBA-V observations. Provides
-`:albedo`, the broadband blue-sky albedo blended from the black-sky (`AL_DH_BB`)
-and white-sky (`AL_BH_BB`) broadband albedos with diffuse fraction `diffuse_fraction`.
+The Copernicus Global Land Service (CGLS) 1 km surface-albedo dataset, a ten-day time
+series derived from SPOT/VGT and PROBA-V observations. Provides `:albedo`, the broadband
+blue-sky albedo blended from the black-sky (`AL_DH_BB`) and white-sky (`AL_BH_BB`)
+broadband albedos with diffuse fraction `diffuse_fraction`.
 
 Files are global on a regular 1/112° latitude-longitude grid; build the `Metadata`
 with a lon/lat [`BoundingBox`](@ref) to window a region at read time. Downloads come
@@ -82,7 +82,7 @@ CopernicusAlbedo(; diffuse_fraction = 0.2) = CopernicusAlbedo(diffuse_fraction)
     CopernicusAlbedoClimatology(; diffuse_fraction = 0.2, years = 2019:2019)
 
 A 12-month climatology of the [`CopernicusAlbedo`](@ref) blue-sky broadband albedo,
-built by averaging all dekadal files of `years` month by month (NaN-aware, per pixel).
+built by averaging all ten-day files of `years` month by month (NaN-aware, per pixel).
 The monthly-mean files are generated on demand by [`build_monthly_climatology!`](@ref)
 (triggered automatically on download) and yield a 12-slot `FieldTimeSeries` with
 `Cyclical()` time indexing.
@@ -144,8 +144,8 @@ DataWrangling.latitude_interfaces(::CopernicusAlbedoMetadata)  = (-60 + 1/224, 8
 ##### Dates
 #####
 
-# CGLS dekads are stamped on day 10, day 20, and the last day of each month.
-function copernicus_albedo_dekadal_dates(start_date, end_date)
+# CGLS ten-day composites are stamped on day 10, day 20, and the last day of each month.
+function copernicus_albedo_ten_day_dates(start_date, end_date)
     dates = DateTime[]
     d = DateTime(year(start_date), month(start_date), 1)
     while d ≤ end_date
@@ -166,7 +166,7 @@ const last_albedo_date  = DateTime(2020, 6, 30)
 # SPOT ends May 2014; PROBA-V takes over from June 2014.
 albedo_satellite(date) = date < DateTime(2014, 6, 1) ? "spot" : "proba"
 
-DataWrangling.all_dates(::CopernicusAlbedo, variable) = copernicus_albedo_dekadal_dates(first_albedo_date, last_albedo_date)
+DataWrangling.all_dates(::CopernicusAlbedo, variable) = copernicus_albedo_ten_day_dates(first_albedo_date, last_albedo_date)
 
 # 12 climatological months; the year is arbitrary, only the month matters.
 DataWrangling.all_dates(::CopernicusAlbedoClimatology, variable) = [DateTime(2018, m, 1) for m in 1:12]
@@ -188,7 +188,7 @@ DataWrangling.metadata_filename(dataset::CopernicusAlbedoClimatology, name, date
 #####
 ##### Download
 #####
-##### The dekadal-file download lives in
+##### The ten-day-file download lives in
 ##### `ext/NumericalEarthCDSAPIExt/copernicus_land_albedo.jl` (needs `using CDSAPI`); it
 ##### fetches the source pair and calls `repack_albedo_pair` below.
 ##### Everything here is CDS-free: repacking, climatology download, and reading.
@@ -389,9 +389,9 @@ end
                                dir = default_download_directory(dataset),
                                latitude_chunk = 1120)
 
-For each calendar month in `months`, download every dekadal albedo file of
+For each calendar month in `months`, download every ten-day albedo file of
 `dataset.years` falling in that month, average the black-sky and white-sky
-broadband albedos pixel by pixel (NaN-aware: pixels missing in a dekad are
+broadband albedos pixel by pixel (NaN-aware: pixels missing in a ten-day file are
 excluded from its mean), and write one monthly-mean NetCDF to `dir` under the
 name computed by `metadata_filename`. Months whose file already exists are
 skipped. Returns the paths of the 12 (or `length(months)`) monthly files.
@@ -403,7 +403,7 @@ function build_monthly_climatology!(dataset::CopernicusAlbedoClimatology;
                                     latitude_chunk = 1120)
 
     raw_dataset = CopernicusAlbedo(diffuse_fraction = dataset.diffuse_fraction)
-    dekads = DataWrangling.all_dates(raw_dataset, name)
+    ten_day_dates = DataWrangling.all_dates(raw_dataset, name)
     variable_names = copernicus_albedo_variables[name]
     paths = String[]
 
@@ -412,14 +412,14 @@ function build_monthly_climatology!(dataset::CopernicusAlbedoClimatology;
         push!(paths, filepath)
         isfile(filepath) && continue
 
-        dates = [d for d in dekads if month(d) == m && year(d) in dataset.years]
-        isempty(dates) && error("No CGLS albedo dekads fall in month $m of years $(dataset.years).")
+        dates = [d for d in ten_day_dates if month(d) == m && year(d) in dataset.years]
+        isempty(dates) && error("No CGLS albedo ten-day dates fall in month $m of years $(dataset.years).")
 
         metadata = Metadata(name; dataset = raw_dataset, dates, dir)
         Downloads.download(metadata)
         source_paths = metadata_path(metadata)
 
-        @info "Averaging $(length(source_paths)) dekads into month $m of the CGLS albedo climatology..."
+        @info "Averaging $(length(source_paths)) ten-day files into month $m of the CGLS albedo climatology..."
         write_monthly_mean(filepath, source_paths, variable_names, latitude_chunk)
     end
 
@@ -467,7 +467,7 @@ end
 ##### Copernicus land surface albedo (C3S `satellite-albedo` catalog entry)
 #####
 ##### One CDS request per calendar month fetches the black-sky (`albb_dh`) and
-##### white-sky (`albb_bh`) products for all of that month's dekads; each dekad's
+##### white-sky (`albb_bh`) products for all of that month's ten-day dates; each date's
 ##### pair is repacked into one compact local file by the CopernicusLandAlbedo module.
 #####
 
@@ -481,7 +481,7 @@ $(TYPEDSIGNATURES)
 Construct the CDS request for the 1 km v2 albedo `source_variables` covering `dates`, which must
 share a `(year, month)` (CDS interprets `year`/`month`/`nominal_day` as a Cartesian product, and the
 valid nominal days differ by month). `source_variables` defaults to the full black-sky/white-sky pair,
-but [`download_albedo_dekads!`](@ref) requests one variable at a time — see the note there.
+but [`download_ten_day_albedo!`](@ref) requests one variable at a time — see the note there.
 """
 function build_albedo_request(name, dates, source_variables = albedo_cds_request_variables[name])
     dts = dates isa AbstractVector ? dates : [dates]
@@ -516,7 +516,7 @@ function extract_albedo_files(download_path, extraction_dir)
     return filter(p -> endswith(p, ".nc"), readdir(extraction_dir; join=true))
 end
 
-# The dekad a delivered file belongs to, from its time coordinate (authoritative)
+# The ten-day date a delivered file belongs to, from its time coordinate (authoritative)
 # or the timestamp in its filename.
 function albedo_file_date(path)
     date = NCDataset(path) do ds
@@ -546,7 +546,7 @@ function repack_albedo_batch(nc_files, batch, path_of, destination_names, expect
     for date in batch
         entry = get(members, date, nothing)
         if isnothing(entry) || !haskey(entry, :blacksky) || !haskey(entry, :whitesky)
-            # Distinguish "no file for this dekad" from "files arrived but one of the pair's
+            # Distinguish "no file for this date" from "files arrived but one of the pair's
             # variables was absent" — the latter means a delivery was dropped or renamed upstream,
             # and reporting only the dates makes it look like a date-matching failure.
             missing_skies = isnothing(entry) ? ["blacksky", "whitesky"] :
@@ -567,9 +567,9 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Download the dekadal black-sky and white-sky broadband albedo for every date of
+Download the ten-day black-sky and white-sky broadband albedo for every date of
 `metadata` through `retrieve(request, path)` (supplied by a CDS backend extension), and repack each
-dekad's pair into a single compact local NetCDF. Requires `~/.cdsapirc` credentials and acceptance of
+date's pair into a single compact local NetCDF. Requires `~/.cdsapirc` credentials and acceptance of
 the Copernicus Global Land product license on the CDS portal.
 
 Issues one request per source variable per calendar month, rather than one request for the pair: CDS
@@ -577,7 +577,7 @@ answers a multi-variable request with a ZIP of per-variable members, and a backe
 it to a single file — `CopernicusClimateDataStore` keeps only the first member — which silently drops
 half of the pair and fails the repack below.
 """
-function download_albedo_dekads!(retrieve, metadata::CopernicusAlbedoDatasetMetadata; skip_existing=true, cleanup=true)
+function download_ten_day_albedo!(retrieve, metadata::CopernicusAlbedoDatasetMetadata; skip_existing=true, cleanup=true)
     meta_filename = DataWrangling.metadata_filename
     dates = metadata.dates isa AbstractVector ? metadata.dates : [metadata.dates]
     dir = metadata.dir

--- a/src/DataWrangling/CopernicusLandAlbedo/README.md
+++ b/src/DataWrangling/CopernicusLandAlbedo/README.md
@@ -1,9 +1,9 @@
 # Copernicus Global Land Surface Albedo
 
 This module ingests the Copernicus Global Land Service (CGLS) 1 km surface-albedo
-collection (version 2): dekadal (10-daily) global NetCDF files on a regular 1/112°
-latitude-longitude grid spanning 80°N–60°S, derived from SPOT/VGT (1998–2014) and
-PROBA-V (2014–2020) observations.
+collection (version 2): ten-day global NetCDF files on a regular 1/112° latitude-longitude
+grid spanning 80°N–60°S, derived from SPOT/VGT (1998–2014) and PROBA-V (2014–2020)
+observations.
 
 The files are downloaded from the Copernicus Climate Data Store's
 [`satellite-albedo`](https://cds.climate.copernicus.eu/datasets/satellite-albedo)
@@ -22,7 +22,7 @@ Downloads go through the CDS API, the same setup as ERA5:
 
 ## What gets stored locally
 
-For each dekad, the extension downloads the black-sky (`albb_dh`,
+For each ten-day date, the extension downloads the black-sky (`albb_dh`,
 directional-hemispherical) and white-sky (`albb_bh`, bi-hemispherical) broadband
 products — one CDS request per calendar month — and repacks the pair into a single
 compact local NetCDF (variables `AL_DH_BB` and `AL_BH_BB`, packed integers with CF
@@ -38,7 +38,7 @@ using NumericalEarth
 using CDSAPI
 using Dates
 
-# Single dekad over a region
+# Single ten-day date over a region
 region = BoundingBox(longitude = (-114, -111), latitude = (35, 37))
 metadatum = Metadatum(:albedo; dataset = CopernicusAlbedo(), region, date = DateTime(2019, 7, 10))
 α = Field(metadatum)
@@ -49,7 +49,7 @@ albedo_climatology = FieldTimeSeries(metadata)
 ```
 
 `build_monthly_climatology!(dataset)` precomputes the monthly-mean files explicitly
-(useful to control when the dekadal downloads happen); months are cached and skipped
+(useful to control when the ten-day downloads happen); months are cached and skipped
 on rebuild.
 
 ## Notes

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -34,7 +34,7 @@ WorldOceanAtlasTools = "04f20302-f1b9-11e8-29d9-7d841cb0a64a"
 Zarr = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 
 [sources]
-NumericalEarth = {path = ".."}
+NumericalEarth = {path = "/private/tmp/claude-502/-Users-xklee-numericalearth-land/bded07f1-21e2-4bad-985d-922f504fae7b/scratchpad/ten-day"}
 
 [compat]
 ArchGDAL = "0.10"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -34,7 +34,7 @@ WorldOceanAtlasTools = "04f20302-f1b9-11e8-29d9-7d841cb0a64a"
 Zarr = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 
 [sources]
-NumericalEarth = {path = "/private/tmp/claude-502/-Users-xklee-numericalearth-land/bded07f1-21e2-4bad-985d-922f504fae7b/scratchpad/ten-day"}
+NumericalEarth = {path = ".."}
 
 [compat]
 ArchGDAL = "0.10"

--- a/test/test_copernicus_albedo.jl
+++ b/test/test_copernicus_albedo.jl
@@ -6,7 +6,7 @@ using NumericalEarth.DataWrangling: BoundingBox, Metadatum, native_grid,
     longitude_name, latitude_name, all_dates,
     longitude_interfaces, latitude_interfaces
 using NumericalEarth.DataWrangling.CopernicusLandAlbedo: bluesky_blend, copernicus_albedo_decode,
-    copernicus_albedo_dekadal_dates, albedo_satellite,
+    copernicus_albedo_ten_day_dates, albedo_satellite,
     albedo_cds_request_variables,
     albedo_read_window
 using Oceananigans.Grids: λnodes, φnodes
@@ -27,8 +27,8 @@ using Dates: DateTime, Day, day, month, daysinmonth
     @test isnan(bluesky_blend(copernicus_albedo_decode(missing), 0.5f0, 0.2f0))
 end
 
-@testset "Copernicus land albedo dekadal dates" begin
-    dates = copernicus_albedo_dekadal_dates(DateTime(2019, 1, 10), DateTime(2019, 12, 31))
+@testset "Copernicus land albedo ten-day dates" begin
+    dates = copernicus_albedo_ten_day_dates(DateTime(2019, 1, 10), DateTime(2019, 12, 31))
     @test length(dates) == 36
     @test issorted(dates)
     @test all(d -> day(d) in (10, 20, daysinmonth(d)), dates)


### PR DESCRIPTION
Terminology only, no behavior change. "Dekad" appeared throughout `CopernicusLandAlbedo` and its extensions, docs, README, example and tests; all of it now says "ten days"/"ten-day".

Two internal names were renamed with it:

- `copernicus_albedo_dekadal_dates` → `copernicus_albedo_ten_day_dates`
- `download_albedo_dekads!` → `download_ten_day_albedo!`

Neither is exported; the call sites in the CDSAPI and CopernicusClimateDataStore extensions were updated.

`test_copernicus_albedo.jl` passes (78/78).