### PR TITLE
Reject a zero-plane displacement at or above the surface layer height

### DIFF
--- a/docs/src/appendix/notation.md
+++ b/docs/src/appendix/notation.md
@@ -223,6 +223,7 @@ Symbols introduced by [`VariablySaturatedHydrology`](@ref),
 | ``\psi`` | `ψ` | stability function | Integrated stability correction (–) |
 | ``\Psi`` | `Ψ` | interface state | Aggregate interface state (an `AbstractInterfaceState`) carried through the similarity-theory fixed-point solver `compute_interface_state` |
 | ``\zeta`` | `ζ` | stability parameter | ``z / L_\star`` (–) |
+| ``\Delta h^d`` | `Δhᵈ` | displaced profile height | Height ``\Delta h - d`` above the zero-plane displacement at which the similarity profiles are evaluated (m) |
 | ``\ell`` | `ℓ` | roughness length | Aerodynamic roughness length (m) |
 | ``\ell^\mathrm{m}`` | `ℓᵐ` | momentum roughness length | Aerodynamic momentum roughness length (m) |
 | ``\ell^\mathrm{s}`` | `ℓˢ` | scalar roughness length | Aerodynamic scalar roughness length (m) |

--- a/src/EarthSystemModels/InterfaceComputations/component_interfaces.jl
+++ b/src/EarthSystemModels/InterfaceComputations/component_interfaces.jl
@@ -480,8 +480,13 @@ function ComponentInterfaces(atmosphere, ocean, sea_ice=nothing;
     # atmospheres; a per-column 2-D field for grid-aware atmospheres (Breeze). The
     # boundary-layer height is *not* cached here: it evolves with the closure and is
     # refreshed every step in the flux builders.
-    properties = (; gravitational_acceleration,
-                    surface_layer_height = surface_layer_height(atmosphere, exchange_grid))
+    zᵃᵗ = surface_layer_height(atmosphere, exchange_grid)
+
+    for interface in (ao_interface, ai_interface, al_interface)
+        isnothing(interface) || validate_zero_plane_displacement(interface.flux_formulation, zᵃᵗ)
+    end
+
+    properties = (; gravitational_acceleration, surface_layer_height = zᵃᵗ)
 
     return ComponentInterfaces(ao_interface,
                                ai_interface,

--- a/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
@@ -1,4 +1,3 @@
-using DocStringExtensions: TYPEDSIGNATURES
 using Oceananigans.Utils: prettysummary
 using Thermodynamics: Thermodynamics as AtmosphericThermodynamics
 

--- a/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
@@ -302,15 +302,17 @@ end
     end
 end
 
-"""
-$(TYPEDSIGNATURES)
+# A zero-plane displacement at or above the surface layer height leaves no room
+# for the similarity profiles.
+validate_zero_plane_displacement(flux_formulation, zᵃᵗ) = nothing
 
-Height `Δh - d` at which the similarity profiles of a surface with zero-plane
-displacement `d` are evaluated, floored at twice the momentum roughness length `ℓ`
-so the profile stays above the roughness sublayer (and the transfer coefficients
-stay finite) when the displacement approaches the atmosphere surface layer height.
-"""
-@inline displaced_profile_height(Δh, d, ℓ) = max(Δh - d, 2ℓ)
+function validate_zero_plane_displacement(fluxes::SimilarityTheoryFluxes, zᵃᵗ)
+    d = fluxes.zero_plane_displacement
+    d isa Number || return nothing
+    zᵐⁱⁿ = minimum(zᵃᵗ)
+    d < zᵐⁱⁿ || throw(ArgumentError("zero_plane_displacement ($d m) must be below the surface layer height ($zᵐⁱⁿ m)"))
+    return nothing
+end
 
 function iterate_interface_fluxes(flux_formulation::SimilarityTheoryFluxes,
                                   Tₛ, qₛ, Δθ, Δq, Δh,
@@ -365,7 +367,7 @@ function iterate_interface_fluxes(flux_formulation::SimilarityTheoryFluxes,
     # Tall roughness elements displace the similarity profiles upward by `d`.
     d = local_zero_plane_displacement(flux_formulation.zero_plane_displacement,
                                       interior_properties)
-    Δh = displaced_profile_height(Δh, d, ℓu₀)
+    Δh = Δh - d
 
     # Transfer coefficients at height `h`
     ϰ = flux_formulation.von_karman_constant

--- a/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
@@ -367,16 +367,16 @@ function iterate_interface_fluxes(flux_formulation::SimilarityTheoryFluxes,
     # Tall roughness elements displace the similarity profiles upward by `d`.
     d = local_zero_plane_displacement(flux_formulation.zero_plane_displacement,
                                       interior_properties)
-    Δh = Δh - d
+    Δhᵈ = Δh - d
 
     # Transfer coefficients at height `h`
     ϰ = flux_formulation.von_karman_constant
     L★ = ifelse(b★ == 0, Inf, u★^2 / (ϰ * b★))
     form = flux_formulation.similarity_form
 
-    χu = ϰ / similarity_profile(form, ψu, Δh, ℓu₀, L★)
-    χθ = ϰ / similarity_profile(form, ψθ, Δh, ℓθ₀, L★)
-    χq = ϰ / similarity_profile(form, ψq, Δh, ℓq₀, L★)
+    χu = ϰ / similarity_profile(form, ψu, Δhᵈ, ℓu₀, L★)
+    χθ = ϰ / similarity_profile(form, ψθ, Δhᵈ, ℓθ₀, L★)
+    χq = ϰ / similarity_profile(form, ψq, Δhᵈ, ℓq₀, L★)
 
     # Recompute
     u★ = χu * U

--- a/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
@@ -306,11 +306,10 @@ end
 $(TYPEDSIGNATURES)
 
 Height `Δh - d` at which the similarity profiles of a surface with zero-plane
-displacement `d` are evaluated, floored at twice the momentum roughness length `ℓ`
-so the profile stays above the roughness sublayer (and the transfer coefficients
-stay finite) when the displacement approaches the atmosphere surface layer height.
+displacement `d` are evaluated, floored at twice the largest of the three roughness
+lengths `ℓᵐᵃˣ` so every profile stays above its own roughness sublayer.
 """
-@inline displaced_profile_height(Δh, d, ℓ) = max(Δh - d, 2ℓ)
+@inline displaced_profile_height(Δh, d, ℓᵐᵃˣ) = max(Δh - d, 2ℓᵐᵃˣ)
 
 function iterate_interface_fluxes(flux_formulation::SimilarityTheoryFluxes,
                                   Tₛ, qₛ, Δθ, Δq, Δh,
@@ -365,7 +364,7 @@ function iterate_interface_fluxes(flux_formulation::SimilarityTheoryFluxes,
     # Tall roughness elements displace the similarity profiles upward by `d`.
     d = local_zero_plane_displacement(flux_formulation.zero_plane_displacement,
                                       interior_properties)
-    Δh = displaced_profile_height(Δh, d, ℓu₀)
+    Δh = displaced_profile_height(Δh, d, max(ℓu₀, ℓθ₀, ℓq₀))
 
     # Transfer coefficients at height `h`
     ϰ = flux_formulation.von_karman_constant

--- a/test/test_slab_land.jl
+++ b/test/test_slab_land.jl
@@ -600,7 +600,6 @@ end
     @test per_cell == solved_friction_velocity(similarity_fluxes(4.0), (;))
     @test solved_friction_velocity(similarity_fluxes(LandZeroPlaneDisplacement()), (;)) ==
           solved_friction_velocity(similarity_fluxes(0.0), (;))
-
 end
 
 @testset "Atmosphere-Land flux stability and roughness response" begin

--- a/test/test_slab_land.jl
+++ b/test/test_slab_land.jl
@@ -557,8 +557,9 @@ end
         @test displaced_friction_velocity(6.0) > displaced_friction_velocity(3.0) > displaced_friction_velocity(0.0)
 
         # A displacement at or above the surface-layer height stays finite: the
-        # profile height is floored at twice the momentum roughness length.
+        # profile height is floored at twice the largest roughness length.
         @test displaced_friction_velocity(2h) ≈ ϰ / log(2) * uᵃᵗ
+
     end
 
     # Per-cell resolution: `LandZeroPlaneDisplacement` reads the displacement a land
@@ -600,6 +601,24 @@ end
     @test per_cell == solved_friction_velocity(similarity_fluxes(4.0), (;))
     @test solved_friction_velocity(similarity_fluxes(LandZeroPlaneDisplacement()), (;)) ==
           solved_friction_velocity(similarity_fluxes(0.0), (;))
+
+    # The floor is twice the largest of the three roughness lengths. Δh - d = 0.05
+    # clears 2ℓu = 0.02, so a floor on ℓu alone would not bind and the temperature
+    # profile would be evaluated below its own sublayer, where log(h / ℓθ) < 0 and the
+    # heat flux runs backwards.
+    crowded = SimilarityTheoryFluxes(; momentum_roughness_length    = 0.01,
+                                       temperature_roughness_length = 0.1,
+                                       water_vapor_roughness_length = 0.1,
+                                       zero_plane_displacement      = 9.95,
+                                       subgrid_velocities = nothing,
+                                       stability_functions = SimilarityScales(zero_ψ, zero_ψ, zero_ψ))
+
+    u★, θ★, q★ = iterate_interface_fluxes(crowded, 290.0, 0.01, -2.0, 0.001, Δh,
+                                          approximate_state, atmosphere_state,
+                                          interface_properties, atmosphere_properties, (;))
+
+    @test u★ > 0
+    @test θ★ < 0   # Δθ = -2 K, so heat flows toward the atmosphere
 end
 
 @testset "Atmosphere-Land flux stability and roughness response" begin

--- a/test/test_slab_land.jl
+++ b/test/test_slab_land.jl
@@ -556,9 +556,9 @@ end
         # Displacement thins the effective surface layer, raising the drag.
         @test displaced_friction_velocity(6.0) > displaced_friction_velocity(3.0) > displaced_friction_velocity(0.0)
 
-        # A displacement at or above the surface-layer height stays finite: the
-        # profile height is floored at twice the momentum roughness length.
-        @test displaced_friction_velocity(2h) ≈ ϰ / log(2) * uᵃᵗ
+        # A displacement at or above the surface layer height leaves no room for the
+        # similarity profiles and is rejected when the interface is built.
+        @test_throws ArgumentError displaced_friction_velocity(2h)
     end
 
     # Per-cell resolution: `LandZeroPlaneDisplacement` reads the displacement a land
@@ -600,6 +600,7 @@ end
     @test per_cell == solved_friction_velocity(similarity_fluxes(4.0), (;))
     @test solved_friction_velocity(similarity_fluxes(LandZeroPlaneDisplacement()), (;)) ==
           solved_friction_velocity(similarity_fluxes(0.0), (;))
+
 end
 
 @testset "Atmosphere-Land flux stability and roughness response" begin


### PR DESCRIPTION
A zero-plane displacement at or above the atmosphere surface layer height leaves no room for the similarity profiles; the `max(Δh - d, 2ℓu)` floor silently capped it instead, saturating the neutral transfer coefficient at `ϰ²/log²2 ≈ 0.33`.

- `ComponentInterfaces` now throws when a `Number` `zero_plane_displacement` on a `SimilarityTheoryFluxes` reaches `minimum(surface_layer_height)`.
- The runtime floor is removed: the profiles are evaluated at `Δh - d`. A per-cell displacement that violates the bound at runtime fails loudly (`DomainError` on CPU, `NaN` on GPU) instead of producing plausible capped fluxes.

Closes #582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)