### PR TITLE
Fill urban roughness gaps with the closure's bare-soil endpoint

### DIFF
--- a/src/Lands/Lands.jl
+++ b/src/Lands/Lands.jl
@@ -23,6 +23,7 @@ export AbstractLand,
        IsotropicFrontalArea, EmpiricalFrontalArea,
        UniformHeight, VariableHeight,
        urban_roughness, compute_aerodynamic_roughness!, aerodynamic_parameters,
+       fill_aerodynamic_roughness_gaps!,
        # Atmosphere-facing accessors
        surface_temperature, surface_saturation
 

--- a/src/Lands/roughness/urban_roughness_field.jl
+++ b/src/Lands/roughness/urban_roughness_field.jl
@@ -65,9 +65,12 @@ endpoint `aerodynamic_parameters(closure, 0, 0)`, in place. The roughness length
 zero-plane displacement `d` are filled together, so a gap in either becomes unbuilt
 surface in both.
 
-Where the morphometry that produced `ℓᵐ` and `d` is still to hand, inpainting `λᵖ` and `h`
-with `DataWrangling.inpaint_mask!` before evaluating the closure fills from horizontal
-neighbors instead, and a hole in a city stays a city.
+Gaps arise where a region reaches past a dataset's published coverage — GHSL omits its
+all-ocean Mollweide tiles, so a coastal window can straddle one. The bare-soil endpoint is
+what those cells would have carried had the tile been published, since open water reads as
+unbuilt. For a dataset whose gaps fall inside built-up land, inpaint `λᵖ` and `h` with
+`DataWrangling.inpaint_mask!` before evaluating the closure instead, so the fill comes from
+horizontal neighbors.
 """
 function fill_aerodynamic_roughness_gaps!(ℓᵐ, d, closure::AbstractUrbanRoughness)
     grid = ℓᵐ.grid

--- a/src/Lands/roughness/urban_roughness_field.jl
+++ b/src/Lands/roughness/urban_roughness_field.jl
@@ -65,12 +65,12 @@ endpoint `aerodynamic_parameters(closure, 0, 0)`, in place. The roughness length
 zero-plane displacement `d` are filled together, so a gap in either becomes unbuilt
 surface in both.
 
-Gaps arise where a region reaches past a dataset's published coverage — GHSL omits its
-all-ocean Mollweide tiles, so a coastal window can straddle one. The bare-soil endpoint is
-what those cells would have carried had the tile been published, since open water reads as
-unbuilt. For a dataset whose gaps fall inside built-up land, inpaint `λᵖ` and `h` with
-`DataWrangling.inpaint_mask!` before evaluating the closure instead, so the fill comes from
-horizontal neighbors.
+Gaps are the open ocean of a domain that extends offshore: GHSL omits its all-ocean
+Mollweide tiles and marks open water no-data inside the tiles it does publish, so a
+coastal window can be half gaps. Those cells carry no land, and the bare-soil endpoint
+keeps them evaluable. For gaps that fall inside built-up land, inpaint `λᵖ` and `h` with
+`DataWrangling.inpaint_mask!` before evaluating the closure instead, so the fill comes
+from horizontal neighbors.
 """
 function fill_aerodynamic_roughness_gaps!(ℓᵐ, d, closure::AbstractUrbanRoughness)
     grid = ℓᵐ.grid

--- a/src/Lands/roughness/urban_roughness_field.jl
+++ b/src/Lands/roughness/urban_roughness_field.jl
@@ -46,38 +46,54 @@ function urban_roughness(h, λᵖ; closure = MorphometricRoughness(eltype(h.grid
     return ℓᵐ, d
 end
 
-@kernel function _fill_aerodynamic_roughness_gaps!(ℓᵐ, d, ℓˢᵒⁱˡ, dˢᵒⁱˡ)
+#####
+##### Gap filling
+#####
+
+# A similarity profile needs a finite, positive roughness length.
+@inline roughness_gap(ℓᵐ, d) = !(isfinite(ℓᵐ) & (ℓᵐ > 0)) | !isfinite(d)
+
+@kernel function _fill_aerodynamic_roughness_gaps!(ℓᵐ, d, ℓᵘ, dᵘ)
     i, j = @index(Global, NTuple)
     @inbounds begin
         ℓᵐᵢⱼ = ℓᵐ[i, j, 1]
         dᵢⱼ  = d[i, j, 1]
-        gap  = !isfinite(ℓᵐᵢⱼ) | !isfinite(dᵢⱼ)
-        ℓᵐ[i, j, 1] = ifelse(gap, ℓˢᵒⁱˡ, ℓᵐᵢⱼ)
-        d[i, j, 1]  = ifelse(gap, dˢᵒⁱˡ, dᵢⱼ)
+        gap  = roughness_gap(ℓᵐᵢⱼ, dᵢⱼ)
+        ℓᵐ[i, j, 1] = ifelse(gap, ℓᵘ, ℓᵐᵢⱼ)
+        d[i, j, 1]  = ifelse(gap, dᵘ, dᵢⱼ)
     end
 end
 
 """
 $(TYPEDSIGNATURES)
 
-Replace the gaps `closure` marks at cells of invalid morphometry with its own bare-soil
-endpoint `aerodynamic_parameters(closure, 0, 0)`, in place. The roughness length `ℓᵐ` and
-zero-plane displacement `d` are filled together, so a gap in either becomes unbuilt
+Replace, in place, the gaps left where `closure` could not evaluate a cell with the
+`unbuilt` pair `(ℓ, d)`, by default the closure's own bare-soil endpoint
+`aerodynamic_parameters(closure, 0, 0)`. A gap is a non-finite `ℓᵐ` or `d`, or a
+non-positive `ℓᵐ`, which a similarity profile cannot take either. The roughness length `ℓᵐ`
+and zero-plane displacement `d` are filled together, so a gap in either becomes unbuilt
 surface in both.
 
-Gaps are the open ocean of a domain that extends offshore: GHSL omits its all-ocean
-Mollweide tiles and marks open water no-data inside the tiles it does publish, so a
-coastal window can be half gaps. Those cells carry no land, and the bare-soil endpoint
-keeps them evaluable. For gaps that fall inside built-up land, inpaint `λᵖ` and `h` with
-`DataWrangling.inpaint_mask!` before evaluating the closure instead, so the fill comes
-from horizontal neighbors.
+GHSL publishes no tile for the all-ocean cells of its Mollweide grid, so the offshore part
+of a coastal window comes back as gaps, as does any no-data pixel inside a published tile.
+The fill makes those cells evaluable and no more: bare soil (`ℓᵐ = 0.03` m by default) is
+two orders of magnitude rougher than a water surface, and the atmosphere-land flux closure
+applies land similarity theory wherever the land component runs. Where the gaps are known
+to be open water, pass a water roughness such as `unbuilt = (1e-4, 0)`, or keep the land
+component off those cells. For gaps that fall inside built-up land, inpaint `λᵖ` and `h`
+with `DataWrangling.inpaint_mask!` before evaluating the closure instead, so the fill comes
+from horizontal neighbors rather than from a constant.
 """
-function fill_aerodynamic_roughness_gaps!(ℓᵐ, d, closure::AbstractUrbanRoughness)
+function fill_aerodynamic_roughness_gaps!(ℓᵐ, d, closure::AbstractUrbanRoughness;
+                                          unbuilt = aerodynamic_parameters(closure, 0, 0))
+    ℓᵘ, dᵘ = unbuilt
+    ℓᵘ > 0 || throw(ArgumentError("the unbuilt roughness length must be positive, got $ℓᵘ"))
+    dᵘ >= 0 || throw(ArgumentError("the unbuilt zero-plane displacement must be non-negative, got $dᵘ"))
+
     grid = ℓᵐ.grid
     FT = eltype(ℓᵐ)
-    ℓˢᵒⁱˡ, dˢᵒⁱˡ = aerodynamic_parameters(closure, 0, 0)
     launch!(architecture(grid), grid, :xy, _fill_aerodynamic_roughness_gaps!,
-            ℓᵐ, d, convert(FT, ℓˢᵒⁱˡ), convert(FT, dˢᵒⁱˡ))
+            ℓᵐ, d, convert(FT, ℓᵘ), convert(FT, dᵘ))
     return ℓᵐ, d
 end
 
@@ -126,7 +142,8 @@ Momentum roughness length `ℓᵐ` and zero-plane displacement `d` (as `Field`s 
 the fields a footprint-level dataset such as `GlobalBuildingFootprints3D` aggregates. The
 closure (default [`MorphometricRoughness`](@ref)) is fed the measured height heterogeneity
 in place of its frontal-area estimator and `σʰ`/`hᵐᵃˣ` regressions. Where `λᵖ → 0` the
-result reduces to a bare-soil roughness.
+result reduces to a bare-soil roughness. Cells the closure cannot evaluate are `NaN`; fill
+them with [`fill_aerodynamic_roughness_gaps!`](@ref) before passing the pair to a flux closure.
 """
 function urban_roughness(h, λᵖ, σʰ, hᵐᵃˣ, λᶠ; closure = MorphometricRoughness(eltype(h.grid)))
     grid = h.grid

--- a/src/Lands/roughness/urban_roughness_field.jl
+++ b/src/Lands/roughness/urban_roughness_field.jl
@@ -35,13 +35,46 @@ $(TYPEDSIGNATURES)
 Momentum roughness length `ℓᵐ` and zero-plane displacement `d` (as `Field`s on the grid
 of `h`) from a mean building-height field `h` and a plan-area index field `λᵖ`,
 under `closure` (default [`MorphometricRoughness`](@ref)). Where `λᵖ → 0` the result
-reduces to a bare-soil roughness.
+reduces to a bare-soil roughness, and cells of invalid morphometry are `NaN`; fill them
+with [`fill_aerodynamic_roughness_gaps!`](@ref) before passing the pair to a flux closure.
 """
 function urban_roughness(h, λᵖ; closure = MorphometricRoughness(eltype(h.grid)))
     grid = h.grid
     ℓᵐ = Field{Center, Center, Nothing}(grid)
     d  = Field{Center, Center, Nothing}(grid)
     compute_aerodynamic_roughness!(ℓᵐ, d, closure, (; plan_area_index = λᵖ, mean_building_height = h), grid)
+    return ℓᵐ, d
+end
+
+@kernel function _fill_aerodynamic_roughness_gaps!(ℓᵐ, d, ℓˢᵒⁱˡ, dˢᵒⁱˡ)
+    i, j = @index(Global, NTuple)
+    @inbounds begin
+        ℓᵐᵢⱼ = ℓᵐ[i, j, 1]
+        dᵢⱼ  = d[i, j, 1]
+        gap  = !isfinite(ℓᵐᵢⱼ) | !isfinite(dᵢⱼ)
+        ℓᵐ[i, j, 1] = ifelse(gap, ℓˢᵒⁱˡ, ℓᵐᵢⱼ)
+        d[i, j, 1]  = ifelse(gap, dˢᵒⁱˡ, dᵢⱼ)
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Replace the gaps `closure` marks at cells of invalid morphometry with its own bare-soil
+endpoint `aerodynamic_parameters(closure, 0, 0)`, in place. The roughness length `ℓᵐ` and
+zero-plane displacement `d` are filled together, so a gap in either becomes unbuilt
+surface in both.
+
+Where the morphometry that produced `ℓᵐ` and `d` is still to hand, inpainting `λᵖ` and `h`
+with `DataWrangling.inpaint_mask!` before evaluating the closure fills from horizontal
+neighbors instead, and a hole in a city stays a city.
+"""
+function fill_aerodynamic_roughness_gaps!(ℓᵐ, d, closure::AbstractUrbanRoughness)
+    grid = ℓᵐ.grid
+    FT = eltype(ℓᵐ)
+    ℓˢᵒⁱˡ, dˢᵒⁱˡ = aerodynamic_parameters(closure, 0, 0)
+    launch!(architecture(grid), grid, :xy, _fill_aerodynamic_roughness_gaps!,
+            ℓᵐ, d, convert(FT, ℓˢᵒⁱˡ), convert(FT, dˢᵒⁱˡ))
     return ℓᵐ, d
 end
 

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -104,6 +104,7 @@ export
     IsotropicFrontalArea, EmpiricalFrontalArea,
     UniformHeight, VariableHeight,
     urban_roughness, compute_aerodynamic_roughness!, aerodynamic_parameters,
+    fill_aerodynamic_roughness_gaps!,
     surface_temperature,
     regrid_bathymetry,
     regrid_topography,

--- a/test/test_urban_roughness.jl
+++ b/test/test_urban_roughness.jl
@@ -352,3 +352,31 @@ end
     @test all(≈(ℓᵐref), interior(ℓᵐ))
     @test all(≈(dref), interior(d))
 end
+
+@testset "Gap filling to the closure's bare-soil endpoint" begin
+    closure = MorphometricRoughness()
+    grid = LatitudeLongitudeGrid(CPU(), Float64; size = (4, 4),
+                                 longitude = (-0.1, 0.1), latitude = (51.4, 51.6),
+                                 topology = (Bounded, Bounded, Flat))
+
+    # A building dataset with a missing tile: the closure marks it NaN by design.
+    λᵖ = Field{Center, Center, Nothing}(grid)
+    h  = Field{Center, Center, Nothing}(grid)
+    set!(λᵖ, (λ, φ) -> ifelse(λ < 0, 0.3, NaN))
+    set!(h,  (λ, φ) -> ifelse(λ < 0, 15.0, NaN))
+
+    ℓᵐ, d = urban_roughness(h, λᵖ; closure)
+    @test any(isnan, interior(ℓᵐ))
+
+    ℓᵐbuilt, dbuilt = aerodynamic_parameters(closure, 0.3, 15.0)
+    ℓˢᵒⁱˡ, dˢᵒⁱˡ = aerodynamic_parameters(closure, 0, 0)
+
+    fill_aerodynamic_roughness_gaps!(ℓᵐ, d, closure)
+
+    @test all(isfinite, interior(ℓᵐ))
+    @test all(isfinite, interior(d))
+    @test ℓᵐ[1, 1, 1] ≈ ℓᵐbuilt      # built cells are untouched
+    @test d[1, 1, 1] ≈ dbuilt
+    @test ℓᵐ[4, 1, 1] ≈ ℓˢᵒⁱˡ        # the gap becomes unbuilt surface
+    @test d[4, 1, 1] ≈ dˢᵒⁱˡ
+end

--- a/test/test_urban_roughness.jl
+++ b/test/test_urban_roughness.jl
@@ -353,30 +353,42 @@ end
     @test all(≈(dref), interior(d))
 end
 
-@testset "Gap filling to the closure's bare-soil endpoint" begin
+@testset "Gap filling to an unbuilt surface" begin
     closure = MorphometricRoughness()
     grid = LatitudeLongitudeGrid(CPU(), Float64; size = (4, 4),
                                  longitude = (-0.1, 0.1), latitude = (51.4, 51.6),
                                  topology = (Bounded, Bounded, Flat))
+    Nx = size(grid, 1)
+    built_roughness, built_displacement = aerodynamic_parameters(closure, 0.3, 15.0)
+    ℓˢᵒⁱˡ, dˢᵒⁱˡ = aerodynamic_parameters(closure, 0, 0)
 
     # A building dataset with a missing tile: the closure marks it NaN by design.
     λᵖ = Field{Center, Center, Nothing}(grid)
     h  = Field{Center, Center, Nothing}(grid)
     set!(λᵖ, (λ, φ) -> ifelse(λ < 0, 0.3, NaN))
     set!(h,  (λ, φ) -> ifelse(λ < 0, 15.0, NaN))
+    roughness_and_displacement() = urban_roughness(h, λᵖ; closure)
 
-    ℓᵐ, d = urban_roughness(h, λᵖ; closure)
+    ℓᵐ, d = roughness_and_displacement()
     @test any(isnan, interior(ℓᵐ))
-
-    built_roughness, built_displacement = aerodynamic_parameters(closure, 0.3, 15.0)
-    ℓˢᵒⁱˡ, dˢᵒⁱˡ = aerodynamic_parameters(closure, 0, 0)
-
     fill_aerodynamic_roughness_gaps!(ℓᵐ, d, closure)
+    @test all(isfinite, interior(ℓᵐ)) && all(isfinite, interior(d))
+    @test ℓᵐ[1, 1, 1] ≈ built_roughness && d[1, 1, 1] ≈ built_displacement   # built cells are untouched
+    @test ℓᵐ[Nx, 1, 1] ≈ ℓˢᵒⁱˡ && d[Nx, 1, 1] ≈ dˢᵒⁱˡ                          # the gap becomes unbuilt surface
 
-    @test all(isfinite, interior(ℓᵐ))
-    @test all(isfinite, interior(d))
-    @test ℓᵐ[1, 1, 1] ≈ built_roughness      # built cells are untouched
-    @test d[1, 1, 1] ≈ built_displacement
-    @test ℓᵐ[4, 1, 1] ≈ ℓˢᵒⁱˡ        # the gap becomes unbuilt surface
-    @test d[4, 1, 1] ≈ dˢᵒⁱˡ
+    # The unbuilt surface can be prescribed, e.g. open water.
+    ℓᵐ, d = roughness_and_displacement()
+    fill_aerodynamic_roughness_gaps!(ℓᵐ, d, closure; unbuilt = (1e-4, 0))
+    @test ℓᵐ[Nx, 1, 1] ≈ 1e-4 && d[Nx, 1, 1] == 0
+    @test ℓᵐ[1, 1, 1] ≈ built_roughness
+
+    # A non-positive roughness is a gap too.
+    ℓᵐ, d = roughness_and_displacement()
+    ℓᵐ[1, 1, 1] = 0
+    fill_aerodynamic_roughness_gaps!(ℓᵐ, d, closure)
+    @test ℓᵐ[1, 1, 1] ≈ ℓˢᵒⁱˡ && d[1, 1, 1] == 0
+
+    # The unbuilt surface itself must be evaluable.
+    @test_throws ArgumentError fill_aerodynamic_roughness_gaps!(ℓᵐ, d, closure; unbuilt = (0, 0))
+    @test_throws ArgumentError fill_aerodynamic_roughness_gaps!(ℓᵐ, d, closure; unbuilt = (0.03, -1))
 end

--- a/test/test_urban_roughness.jl
+++ b/test/test_urban_roughness.jl
@@ -368,15 +368,15 @@ end
     ℓᵐ, d = urban_roughness(h, λᵖ; closure)
     @test any(isnan, interior(ℓᵐ))
 
-    ℓᵐbuilt, dbuilt = aerodynamic_parameters(closure, 0.3, 15.0)
+    built_roughness, built_displacement = aerodynamic_parameters(closure, 0.3, 15.0)
     ℓˢᵒⁱˡ, dˢᵒⁱˡ = aerodynamic_parameters(closure, 0, 0)
 
     fill_aerodynamic_roughness_gaps!(ℓᵐ, d, closure)
 
     @test all(isfinite, interior(ℓᵐ))
     @test all(isfinite, interior(d))
-    @test ℓᵐ[1, 1, 1] ≈ ℓᵐbuilt      # built cells are untouched
-    @test d[1, 1, 1] ≈ dbuilt
+    @test ℓᵐ[1, 1, 1] ≈ built_roughness      # built cells are untouched
+    @test d[1, 1, 1] ≈ built_displacement
     @test ℓᵐ[4, 1, 1] ≈ ℓˢᵒⁱˡ        # the gap becomes unbuilt surface
     @test d[4, 1, 1] ≈ dˢᵒⁱˡ
 end


### PR DESCRIPTION
`aerodynamic_parameters` marks cells of invalid morphometry `NaN` by design, so an `(ℓᵐ, d)` pair from `urban_roughness` over a building dataset with missing tiles carries gaps, and there was no supported way to turn that into something a flux closure can consume.

```julia
ℓᵐ, d = urban_roughness(h, λᵖ; closure)
fill_aerodynamic_roughness_gaps!(ℓᵐ, d, closure)
```

Gaps become the closure's own bare-soil endpoint `aerodynamic_parameters(closure, 0, 0)`; the pair is filled together, so a gap in either becomes unbuilt surface in both. Where the morphometry is still to hand, the docstring points at inpainting `λᵖ` and `h` instead, which fills from horizontal neighbors and keeps a hole in a city a city.

Closes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)