### PR TITLE
Cut tests that cannot fail, and comments that restate the code

### DIFF
--- a/test/runtests_setup.jl
+++ b/test/runtests_setup.jl
@@ -25,9 +25,9 @@ test_architectures = gpu_test ? [GPU()] : [CPU()]
 
 start_date = DateTimeProlepticGregorian(1993, 1, 1)
 
-test_datasets = (ECCO2Monthly(), 
-                 ECCO2Daily(), 
-                 ECCO4Monthly(), 
+test_datasets = (ECCO2Monthly(),
+                 ECCO2Daily(),
+                 ECCO4Monthly(),
                  ECCO2DarwinMonthly(),
                  ECCO4DarwinMonthly(),
                  EN4Monthly(),
@@ -291,7 +291,7 @@ function test_cycling_dataset_restoring(arch, dataset, dates, inpainting;
         mod1.(Tuple(range(length(times), length=time_indices_in_memory)), length(times))
 end
 
-function test_inpainting_algorithm(arch, dataset, start_date, inpainting; 
+function test_inpainting_algorithm(arch, dataset, start_date, inpainting;
                                    varnames = (:temperature, :salinity),
                                   )
     for name in varnames

--- a/test/test_aviso_downloading.jl
+++ b/test/test_aviso_downloading.jl
@@ -55,7 +55,6 @@ end
     for arch in test_architectures
         datum = first(metadata)
         source = Field(datum, arch; inpainting=nothing)
-        @test source isa Field
         @test size(interior(source), 3) == 1
         @test topology(source.grid) == (Bounded, Bounded, Flat)
         @test all(isfinite.(Array(interior(source))))
@@ -70,7 +69,6 @@ end
         @test all(isfinite.(Array(interior(target))))
 
         fts = FieldTimeSeries(metadata, arch; inpainting=nothing)
-        @test fts isa FieldTimeSeries
         @test size(interior(fts), 3) == 1
         @test length(fts.times) == length(dates)
         @test time_indices(fts) == Tuple(1:length(dates))

--- a/test/test_bathymetry.jl
+++ b/test/test_bathymetry.jl
@@ -40,7 +40,6 @@ end
                                      latitude = (0, 50),
                                      z = (-6000, 0))
 
-        # Test that remove_minor_basins!(Z, Inf) does nothing
         control_bottom_height = regrid_bathymetry(grid, ETOPOmetadata)
         bottom_height = deepcopy(control_bottom_height)
         @test_throws ArgumentError remove_minor_basins!(bottom_height, Inf)
@@ -120,9 +119,7 @@ end
     # Integer and float parameter values key identically
     @test key(minimum_depth = 10) == key(minimum_depth = 10.0)
 
-    # Test cache filename: same config → same filename
     @test field_cache_filename(config1) == field_cache_filename(config2)
-    # Different config → different filename
     @test field_cache_filename(config1) != field_cache_filename(config3)
 
     # Test JLD2 round-trip of the key

--- a/test/test_breeze_coupling.jl
+++ b/test/test_breeze_coupling.jl
@@ -126,23 +126,15 @@ end
         @testset "Construction on $A" begin
             model = build_test_model(arch)
 
-            @test model isa EarthSystemModel
             @test model.ocean isa SlabOcean
             @test model.atmosphere isa Simulation
             @test model.atmosphere.model isa Breeze.AtmosphereModel
             @test model.architecture isa typeof(arch)
-
-            # Check that interfaces were created
-            @test !isnothing(model.interfaces)
-            @test !isnothing(model.interfaces.atmosphere_ocean_interface)
         end
 
         @testset "Time stepping on $A" begin
-            # KNOWN BROKEN on Breeze 0.7 (NumericalEarth/Breeze.jl#827): the coupled solver is
-            # unstable at Δt = 10 s — the stable Δt dropped below 5 s vs ≥10 s on Breeze 0.6. The
-            # failure mode is arch-dependent: CPU throws a θ^γ DomainError, GPU integrates to NaN.
-            # Fold the would-be success into ONE @test_broken so it records broken on either arch
-            # (throw or false) and flips to an error (prompting re-enable) once the run is clean again.
+            # Broken on Breeze 0.7 (NumericalEarth/Breeze.jl#827): the coupled solver is unstable
+            # at Δt = 10 s. CPU throws a θ^γ DomainError, GPU integrates to NaN.
             @test_broken begin
                 model = build_test_model(arch)
                 SST_before = Array(interior(model.ocean.temperature))
@@ -153,8 +145,7 @@ end
         end
 
         @testset "SST responds to fluxes on $A" begin
-            # KNOWN BROKEN on Breeze 0.7 (same coupled-solver instability at Δt = 10 s as above;
-            # NumericalEarth/Breeze.jl#827). CPU throws, GPU yields NaN fluxes — both record broken.
+            # Broken on Breeze 0.7 (NumericalEarth/Breeze.jl#827): CPU throws, GPU yields NaN fluxes.
             @test_broken begin
                 model = build_test_model(arch)
                 run!(Simulation(model, Δt=10, stop_iteration=50))
@@ -175,7 +166,6 @@ end
 
             atmos = model.atmosphere.model
             al = model.interfaces.atmosphere_land_interface
-            @test !isnothing(al)
 
             ρu_bc = atmos.momentum.ρu.boundary_conditions.bottom.condition
             ρv_bc = atmos.momentum.ρv.boundary_conditions.bottom.condition

--- a/test/test_breeze_dry_layer_land.jl
+++ b/test/test_breeze_dry_layer_land.jl
@@ -94,9 +94,6 @@ end
             @test model.land.hydrology isa VariablySaturatedHydrology
             @test model.land.energy isa WaterCoupledEnergy
 
-            interface = model.interfaces.atmosphere_land_interface
-            @test !isnothing(interface)
-
             simulation = Simulation(model; Δt = 0.2, stop_iteration = 10)
             run!(simulation)
 
@@ -132,12 +129,8 @@ end
         end
 
         @testset "Radiation adds to surface_energy_flux, not overwritten, on $A" begin
-            # Regression guard for the radiation→land coupling: the radiative
-            # flux must be *added* to the turbulent `surface_energy_flux` that
-            # `WaterCoupledEnergy` reads — not overwrite it, and not be
-            # overwritten by the turbulent assembly. Covers the call ordering in
-            # `time_step_earth_system_model.jl` and the accumulator/sign choice in
-            # `apply_air_land_radiative_fluxes.jl`.
+            # The radiative flux is added to the turbulent `surface_energy_flux` that
+            # `WaterCoupledEnergy` reads, rather than either one overwriting the other.
             model_with_radiation = build_coupled_test_model(arch; M₀ = 200.0, T₀ = 295.0, with_radiation = true)
             @test haskey(model_with_radiation.radiation.interface_fluxes, :land)
             update_state!(model_with_radiation)

--- a/test/test_cds_downloading.jl
+++ b/test/test_cds_downloading.jl
@@ -48,30 +48,22 @@ start_date = DateTime(2005, 2, 16, 12)
         end
         @test isfile(filepath)
 
-        # Verify the NetCDF file structure
         ds = NCDataset(filepath)
 
-        # Check that it has the expected variable (t2m for 2m_temperature)
         @test haskey(ds, "t2m")
 
-        # Check that it has coordinate variables
         @test haskey(ds, "longitude")
         @test haskey(ds, "latitude")
         @test haskey(ds, "time") || haskey(ds, "valid_time")
 
-        # Check data dimensions
         lon = ds["longitude"][:]
         lat = ds["latitude"][:]
-        @test length(lon) > 0
-        @test length(lat) > 0
 
-        # Check that data is within expected bounds
         @test minimum(lon) ≥ -1  # Allow some tolerance
         @test maximum(lon) ≤ 6
         @test minimum(lat) ≥ 39
         @test maximum(lat) ≤ 46
 
-        # Check that the temperature data exists and is valid
         t2m = ds["t2m"]
         @test ndims(t2m) ≥ 2
 
@@ -81,7 +73,6 @@ start_date = DateTime(2005, 2, 16, 12)
     end
 
     @testset "Availability of ERA5 variables" begin
-        # Test that we have defined the key ERA5 variables
         @test haskey(ERA5_dataset_variable_names, :temperature)
         @test haskey(ERA5_dataset_variable_names, :eastward_velocity)
         @test haskey(ERA5_dataset_variable_names, :northward_velocity)
@@ -89,7 +80,6 @@ start_date = DateTime(2005, 2, 16, 12)
         @test haskey(ERA5_dataset_variable_names, :downwelling_shortwave_radiation)
         @test haskey(ERA5_dataset_variable_names, :downwelling_longwave_radiation)
 
-        # Verify variable name mappings
         @test ERA5_dataset_variable_names[:temperature] == "2m_temperature"
         @test ERA5_dataset_variable_names[:eastward_velocity] == "10m_u_component_of_wind"
         @test ERA5_dataset_variable_names[:northward_velocity] == "10m_v_component_of_wind"
@@ -99,7 +89,6 @@ start_date = DateTime(2005, 2, 16, 12)
         variable = :temperature
         metadatum = Metadatum(variable; dataset, region, date=start_date)
 
-        # Test metadata properties
         @test metadatum.name == :temperature
         @test metadatum.dataset isa ERA5HourlySingleLevel
         @test metadatum.dates == start_date
@@ -112,7 +101,6 @@ start_date = DateTime(2005, 2, 16, 12)
         @test Nz == 1     # 2D surface data
         @test Nt == 1     # Single time step
 
-        # Test that ERA5 is correctly identified as 2D
         @test is_three_dimensional(metadatum) == false
     end
 
@@ -141,9 +129,7 @@ start_date = DateTime(2005, 2, 16, 12)
 
     @testset "ERA5 Monthly dataset" begin
         monthly_dataset = ERA5MonthlySingleLevel()
-        @test monthly_dataset isa ERA5MonthlySingleLevel
 
-        # Test that all_dates returns a valid range
         dates = NumericalEarth.DataWrangling.all_dates(monthly_dataset, :temperature)
         @test first(dates) == DateTime("1940-01-01")
         @test step(dates) == Month(1)
@@ -196,12 +182,6 @@ start_date = DateTime(2005, 2, 16, 12)
 
         @test convert_units(3600, Jm²ph()) ≈ 1               # 3600 J/m²/hr → 1 W/m²
         @test convert_units(3.6, MetersPerHour()) ≈ 1        # 3.6 m/hr → 1 kg/m²/s
-
-        # The regional hindcast prescribed components are first-class, top-level API.
-        # `ERA5PrescribedAtmosphere` is a `PrescribedAtmosphere{<:ERA5Dataset}` type alias
-        # (dispatch on provenance) with constructor methods; `ERA5PrescribedRadiation` is a function.
-        @test ERA5PrescribedAtmosphere isa Type
-        @test ERA5PrescribedRadiation  isa Function
     end
 
     @testset "ERA5 single-level metadata_prefix" begin
@@ -237,17 +217,12 @@ start_date = DateTime(2005, 2, 16, 12)
     @testset "ERA5HourlyPressureLevels construction and metadata" begin
         # Default constructor uses all 37 standard levels
         ds_full = ERA5HourlyPressureLevels()
-        @test ds_full isa ERA5HourlyPressureLevels
         @test length(ds_full.pressure_levels) == 37
         @test Base.size(ds_full, :temperature) == (1440, 720, 37)
 
         # Subset constructor
         ds_sub = ERA5HourlyPressureLevels(pressure_levels=[850, 500]hPa)
         @test Base.size(ds_sub, :temperature) == (1440, 720, 2)
-
-        # Monthly variant
-        ds_monthly = ERA5MonthlyPressureLevels()
-        @test ds_monthly isa ERA5MonthlyPressureLevels
 
         # Metadatum size propagates Nz correctly
         meta = Metadatum(:temperature; dataset=ds_sub, region=region, date=start_date)
@@ -336,7 +311,6 @@ start_date = DateTime(2005, 2, 16, 12)
 
             # Create a Field from the downloaded data
             ψ = Field(metadatum, arch)
-            @test ψ isa Field
 
             # ERA5 is 2D data, so field should have Nz=1
             Nx, Ny, Nz = size(ψ)
@@ -372,7 +346,6 @@ start_date = DateTime(2005, 2, 16, 12)
             # Set the field from metadata
             set!(field, metadatum)
 
-            # Verify the field was set with non-zero data
             @allowscalar begin
                 @test !all(iszero, interior(field))
             end
@@ -403,7 +376,6 @@ start_date = DateTime(2005, 2, 16, 12)
             close(ds_nc)
 
             f = Field(meta, arch)
-            @test f isa Field
             Nx, Ny, Nz = size(f)
             @test Nz == 2
 
@@ -665,7 +637,6 @@ end
                                           region, dir=tmp, skip_existing=true)
             @test plan.dt_path_pairs == [(dt1, p1), (dt2, p2)]
             @test length(plan.pending) == 2
-            @test plan.request !== nothing
             @test plan.request["time"] == ["00:00", "12:00"]
             @test plan.tmp_path == joinpath(tmp, "_tmp_20050216.nc")
             @test length(plan.nc_triples) == 2
@@ -934,10 +905,8 @@ end
 end
 
 @testset "ERA5 CDSAPIExt skip_existing short-circuit" begin
-    # Build a temporary directory and pre-create the expected output files so
-    # `download(...; skip_existing=true)` returns without contacting CDS.
-    # If the short-circuit ever regresses, these tests will throw a credentials
-    # error (or 4xx from the CDS API) and fail loudly.
+    # The expected output files are pre-created so `download(...; skip_existing=true)` returns
+    # without contacting CDS.
     region = NumericalEarth.DataWrangling.BoundingBox(longitude=(0, 5), latitude=(40, 45))
     mktempdir() do tmp
         ds_pl  = ERA5HourlyPressureLevels(pressure_levels=[850, 500]hPa)
@@ -1197,10 +1166,8 @@ end
     end
 
     @testset "split_era5_nc_by_datetime selects timesteps by valid_time, not request position" begin
-        # Regression: CDS expands `day × time` into a Cartesian product, so a window that
-        # crosses midnight (e.g. requesting [day N 23:00, day N+1 00:00]) comes back with
-        # extra, sorted timesteps. The split must key on valid_time; keying on the request
-        # position silently assigns the wrong hour to each output file.
+        # CDS expands `day × time` into a Cartesian product, so a window crossing midnight comes
+        # back with extra, sorted timesteps. The split keys on valid_time.
         mktempdir() do dir
             src_path = joinpath(dir, "src.nc")
             # What CDS returns for day=[16,17] × time=[23:00, 00:00], sorted ascending:

--- a/test/test_conservation.jl
+++ b/test/test_conservation.jl
@@ -19,13 +19,9 @@ using NumericalEarth.EarthSystemModels: OceanSeaIceModel, update_state!
 using NumericalEarth.Oceans: ocean_simulation
 using NumericalEarth.SeaIces: sea_ice_simulation
 
-# Diagnostic-side override: ClimaSeaIce's slab mass balance uses a
-# T-dependent latent heat. A single state-based
-# `Eᵢₛ = −ℵ * ρᵢ * ℒ * h * Az` cannot match both freeze at the ice-base
-# temperature and top-melt at 0 ᵒC under `ℒ(T)`. Overriding `latent_heat`
-# to the constant `pt.reference_latent_heat` isolates coupler-side
-# bookkeeping errors from this intrinsic mismatch. The override is local to
-# this test's process; it does not touch any package source.
+# A single state-based `Eᵢₛ = −ℵ ρᵢ ℒ h Az` cannot match both freeze at the ice-base temperature
+# and top-melt at 0 ᵒC under a T-dependent `ℒ(T)`, so `latent_heat` is overridden to the constant
+# `pt.reference_latent_heat` to isolate coupler-side bookkeeping errors.
 
 @inline function ClimaSeaIce.SeaIceThermodynamics.latent_heat(
         pt::ClimaSeaIce.SeaIceThermodynamics.PhaseTransitions, T)
@@ -214,11 +210,8 @@ function test_coupled_energy_conservation(grid, atmosphere_grid; ocean_kwargs...
 
     record!(history, coupled_model, 0, 0.0, 0.0, 0.0)
 
-    # The phase-boundary `update_state!` would zero the pending frazil flux
-    # written at the end of the previous phase's final step, stranding the
-    # latent energy that was already deposited into the ocean by that same
-    # frazil mutation. We preserve `𝒬ᶠʳᶻ` across the refresh and add it
-    # back into the sea-ice bottom heat flux that the slab will read.
+    # `𝒬ᶠʳᶻ` is preserved across the phase-boundary refresh and added back into the sea-ice bottom
+    # heat flux, so the latent energy the frazil already deposited into the ocean is not stranded.
     function run_phase!(coupled_model, spec, phase_id; Nsteps, Δt, history, atmosphere, radiation)
         set_forcing!(atmosphere, radiation;
                      T_air = spec.T_air, q_air = spec.q_air,

--- a/test/test_copernicus_albedo.jl
+++ b/test/test_copernicus_albedo.jl
@@ -110,7 +110,6 @@ end
         grid = native_grid(metadatum)
 
         win = albedo_read_window(metadatum)
-        @test win !== nothing
         icols, jrows = win
 
         # The window is EXACTLY the native-grid cell count, so

--- a/test/test_copernicus_climate_datastore.jl
+++ b/test/test_copernicus_climate_datastore.jl
@@ -23,21 +23,18 @@ const CDSExt = Base.get_extension(NumericalEarth, :NumericalEarthCopernicusClima
     end
 
     @testset "Downloads.download methods are defined" begin
-        # Test that the extension defines Downloads.download for ERA5Metadata/Metadatum types
         dataset = ERA5HourlySingleLevel()
         date = DateTime(2020, 1, 1, 0)
 
         # Create a metadatum (single timestep)
         metadatum = Metadatum(:temperature; dataset, date)
 
-        # Check that Downloads.download method exists for ERA5Metadatum
         @test hasmethod(Downloads.download, Tuple{typeof(metadatum)})
 
         # Create metadata (multiple timesteps)
         dates = DateTime(2020, 1, 1, 0):Hour(1):DateTime(2020, 1, 1, 2)
         metadata = Metadata(:temperature; dataset, dates)
 
-        # Check that Downloads.download method exists for ERA5Metadata
         @test hasmethod(Downloads.download, Tuple{typeof(metadata)})
     end
 
@@ -111,19 +108,13 @@ const CDSExt = Base.get_extension(NumericalEarth, :NumericalEarthCopernicusClima
     end
 
     @testset "Area builder utilities" begin
-        # Test that the bounding box area builder is accessible
-        @test isdefined(CDSExt, :build_era5_area)
-
-        # Test with nothing
         @test isnothing(CDSExt.build_era5_area(nothing))
 
-        # Test with a bounding box
         bbox = NumericalEarth.DataWrangling.BoundingBox(
             longitude = (0, 10),
             latitude = (40, 50)
         )
         area = CDSExt.build_era5_area(bbox)
-        @test !isnothing(area)
         @test length(area) == 4
         @test area[1] == 40   # south
         @test area[2] == 0    # west
@@ -132,57 +123,27 @@ const CDSExt = Base.get_extension(NumericalEarth, :NumericalEarthCopernicusClima
     end
 
     @testset "New ERA5 dataset types" begin
-        # Test ERA5YearlySingleLevel
         yearly_dataset = ERA5YearlySingleLevel()
         @test yearly_dataset isa ERA5.ERA5Dataset
 
-        # Test ERA5MonthlySingleLevel
         monthly_dataset = ERA5MonthlySingleLevel()
         @test monthly_dataset isa ERA5.ERA5Dataset
 
-        # Test ERA5HourlyPressureLevels
         pressure_levels = [100000.0, 85000.0, 50000.0]  # Pa
         hourly_pl = ERA5HourlyPressureLevels(pressure_levels)
         @test hourly_pl isa ERA5.ERA5Dataset
         @test hourly_pl.pressure_levels == pressure_levels
 
-        # Test ERA5MonthlyPressureLevels
         monthly_pl = ERA5MonthlyPressureLevels(pressure_levels)
         @test monthly_pl isa ERA5.ERA5Dataset
         @test monthly_pl.pressure_levels == pressure_levels
     end
 
-    @testset "Download methods for new dataset types" begin
-        # Test ERA5YearlySingleLevel
-        date = DateTime(2020, 1, 1)
-        metadatum = Metadatum(:temperature; dataset=ERA5YearlySingleLevel(), date)
-        @test hasmethod(Downloads.download, Tuple{typeof(metadatum)})
-
-        # Test ERA5MonthlySingleLevel
-        metadatum = Metadatum(:temperature; dataset=ERA5MonthlySingleLevel(), date)
-        @test hasmethod(Downloads.download, Tuple{typeof(metadatum)})
-
-        # Test ERA5HourlyPressureLevels
-        metadatum = Metadatum(:temperature; dataset=ERA5HourlyPressureLevels([100000.0]), date)
-        @test hasmethod(Downloads.download, Tuple{typeof(metadatum)})
-
-        # Test ERA5MonthlyPressureLevels
-        metadatum = Metadatum(:temperature; dataset=ERA5MonthlyPressureLevels([100000.0]), date)
-        @test hasmethod(Downloads.download, Tuple{typeof(metadatum)})
-    end
-
     @testset "Helper function dispatch" begin
-        # Test variable_name_mapping
-        @test isdefined(CDSExt, :variable_name_mapping)
-
-        # Test pressure_levels extraction
-        @test isdefined(CDSExt, :pressure_levels)
         pl_dataset = ERA5HourlyPressureLevels([100000.0, 50000.0])
         @test CDSExt.pressure_levels(pl_dataset) == [100000.0, 50000.0]
         @test isnothing(CDSExt.pressure_levels(ERA5YearlySingleLevel()))
 
-        # Test date_keywords
-        @test isdefined(CDSExt, :date_keywords)
         date = DateTime(2020, 6, 15, 12)
 
         # Yearly
@@ -206,8 +167,6 @@ const CDSExt = Base.get_extension(NumericalEarth, :NumericalEarthCopernicusClima
         @test kw.year == 2020
         @test kw.month == 6
 
-        # Test cds_download_function
-        @test isdefined(CDSExt, :cds_download_function)
         @test CDSExt.cds_download_function(ERA5YearlySingleLevel()) == CopernicusClimateDataStore.yearly
         @test CDSExt.cds_download_function(ERA5MonthlySingleLevel()) == CopernicusClimateDataStore.monthly
         @test CDSExt.cds_download_function(ERA5HourlyPressureLevels([100000.0])) == CopernicusClimateDataStore.hourly

--- a/test/test_copernicus_climate_datastore_downloading.jl
+++ b/test/test_copernicus_climate_datastore_downloading.jl
@@ -41,10 +41,7 @@ const era5_land_region = BoundingBox(longitude=(12.5, 13.0), latitude=(42.8, 43.
 end
 
 @testset "ERA5YearlySingleLevel FieldTimeSeries spans a year boundary" begin
-    # Before the fix, build_filename collapsed every requested date to the FIRST
-    # date's year file — reading Jan 1's timestamp from the 2020 file would find
-    # no matching time and error() loudly. This confirms the real fix reads each
-    # date from its own (correct) yearly file with real downloaded data.
+    # Each requested date is read from its own yearly file, with real downloaded data.
     dataset = ERA5YearlySingleLevel()
     variable = :temperature
     dates = [DateTime(2020, 12, 31, 22), DateTime(2020, 12, 31, 23),
@@ -65,10 +62,8 @@ end
 end
 
 @testset "ERA5MonthlySingleLevel FieldTimeSeries spans a year boundary" begin
-    # The dangerous variant: each monthly file holds a SINGLE timestep, so the
-    # pre-fix collapse silently returned December's data for January too (no
-    # error — retrieve_data just reads the only timestep in whatever file it's
-    # given). The `v1 != v2` check below is the direct regression guard.
+    # Each monthly file holds a single timestep, so collapsing two dates onto one file would return
+    # the same data twice without erroring. The `v1 != v2` check below is the guard.
     dataset = ERA5MonthlySingleLevel()
     variable = :temperature
     dates = [DateTime(2020, 12, 1), DateTime(2021, 1, 1)]

--- a/test/test_dataset_region.jl
+++ b/test/test_dataset_region.jl
@@ -28,10 +28,8 @@ using Dates
         @test maximum(φg) ≤  30 + 1.0
         @test any(!iszero, interior(f))
 
-        # Correctness: hand-extract the reference value at (0°, 0°, surface)
-        # directly from the NetCDF file and compare against the bbox-restricted
-        # field at the same physical point. This catches the silent SW-corner
-        # positional-indexing bug in `set_metadata_field!`.
+        # The reference value at (0°, 0°, surface), read straight from the NetCDF file, must match
+        # the bbox-restricted field at the same physical point.
         path = metadata_path(md)
         ds = Dataset(path)
         # ECCO4 surface is k=1 in the raw file (Z=-5 m). After

--- a/test/test_ecco2_daily.jl
+++ b/test/test_ecco2_daily.jl
@@ -43,8 +43,7 @@ for arch in test_architectures
                 end
 
                 datum = first(metadata)
-                ψ = Field(datum, arch, inpainting=NearestNeighborInpainting(2))
-                @test ψ isa Field
+                Field(datum, arch, inpainting=NearestNeighborInpainting(2))
                 datapath = NumericalEarth.DataWrangling.inpainted_metadata_path(datum)
                 @test isfile(datapath)
             end

--- a/test/test_ecco2_monthly.jl
+++ b/test/test_ecco2_monthly.jl
@@ -49,15 +49,14 @@ for arch in test_architectures, dataset in test_ecco_datasets
                     end
 
                     datum = first(metadata)
-                    ψ = Field(datum, arch, inpainting=NearestNeighborInpainting(2))
-                    @test ψ isa Field
+                    Field(datum, arch, inpainting=NearestNeighborInpainting(2))
                     datapath = NumericalEarth.DataWrangling.inpainted_metadata_path(datum)
                     @test isfile(datapath)
                 end
             end
 
             @testset "Setting a field from a dataset" begin
-                test_setting_from_metadata(arch, dataset, start_date, inpainting, 
+                test_setting_from_metadata(arch, dataset, start_date, inpainting,
                                         varnames=test_names[dataset])
             end
 
@@ -67,14 +66,14 @@ for arch in test_architectures, dataset in test_ecco_datasets
             end
 
             @testset "DatasetRestoring with LinearlyTaperedPolarMask" begin
-                test_dataset_restoring(arch, dataset, dates, inpainting, 
+                test_dataset_restoring(arch, dataset, dates, inpainting,
                                     varnames=test_names[dataset],
                                     fldnames=test_fields[dataset])
             end
 
             @testset "Timestepping with DatasetRestoring" begin
-                test_timestepping_with_dataset_restoring(arch, dataset, dates, inpainting, 
-                                                        varnames=test_names[dataset], 
+                test_timestepping_with_dataset_restoring(arch, dataset, dates, inpainting,
+                                                        varnames=test_names[dataset],
                                                         fldnames=test_fields[dataset])
             end
 
@@ -95,10 +94,7 @@ for arch in test_architectures, dataset in test_ecco_datasets
                 @test_throws "The vertical range" set!(field, datum; inpainting=nothing)
             end
 
-            # Expensive due to the high resolution of ECCO2
-            # @testset "Inpainting algorithm" begin
-            #     test_inpainting_algorithm(arch, dataset, start_date, inpainting)
-            # end
+            # The inpainting algorithm is not exercised here: ECCO2's resolution makes it too slow.
         end
     end
 end

--- a/test/test_ecco4_en4.jl
+++ b/test/test_ecco4_en4.jl
@@ -46,49 +46,48 @@ for arch in test_architectures, dataset in test_ecco_en4_datasets
                 end
 
                 datum = first(metadata)
-                ψ = Field(datum, arch, inpainting=NearestNeighborInpainting(2))
-                @test ψ isa Field
+                Field(datum, arch, inpainting=NearestNeighborInpainting(2))
                 datapath = NumericalEarth.DataWrangling.inpainted_metadata_path(datum)
                 @test isfile(datapath)
             end
         end
 
         @testset "Setting a field from a dataset" begin
-            test_setting_from_metadata(arch, dataset, start_date, inpainting, 
+            test_setting_from_metadata(arch, dataset, start_date, inpainting,
                                        varnames=test_names[dataset])
         end
 
         @testset "Timestepping with fields from Dataset" begin
-            test_timestepping_with_dataset(arch, dataset, start_date, inpainting, 
-                                           varnames=test_names[dataset], 
+            test_timestepping_with_dataset(arch, dataset, start_date, inpainting,
+                                           varnames=test_names[dataset],
                                            fldnames=test_fields[dataset])
         end
 
         @testset "Field utilities" begin
-            test_ocean_metadata_utilities(arch, dataset, dates, inpainting, 
+            test_ocean_metadata_utilities(arch, dataset, dates, inpainting,
                                           varnames=test_names[dataset])
         end
 
         @testset "DatasetRestoring with LinearlyTaperedPolarMask" begin
-            test_dataset_restoring(arch, dataset, dates, inpainting, 
-                                   varnames=test_names[dataset], 
+            test_dataset_restoring(arch, dataset, dates, inpainting,
+                                   varnames=test_names[dataset],
                                    fldnames=test_fields[dataset])
         end
 
         @testset "Timestepping with DatasetRestoring" begin
-            test_timestepping_with_dataset_restoring(arch, dataset, dates, inpainting, 
-                                                     varnames=test_names[dataset], 
+            test_timestepping_with_dataset_restoring(arch, dataset, dates, inpainting,
+                                                     varnames=test_names[dataset],
                                                      fldnames=test_fields[dataset])
         end
 
         @testset "Dataset cycling boundaries" begin
-            test_cycling_dataset_restoring(arch, dataset, dates, inpainting, 
-                                           varnames=test_names[dataset], 
+            test_cycling_dataset_restoring(arch, dataset, dates, inpainting,
+                                           varnames=test_names[dataset],
                                            fldnames=test_fields[dataset])
         end
 
         @testset "Inpainting algorithm" begin
-            test_inpainting_algorithm(arch, dataset, start_date, inpainting, 
+            test_inpainting_algorithm(arch, dataset, start_date, inpainting,
                                       varnames=test_names[dataset])
         end
     end

--- a/test/test_ecco_atmosphere.jl
+++ b/test/test_ecco_atmosphere.jl
@@ -7,10 +7,8 @@ using NumericalEarth.Radiations: PrescribedRadiation
 using NumericalEarth.ECCO: ECCOPrescribedAtmosphere, ECCOPrescribedRadiation, ECCO4Monthly
 using NumericalEarth.DataWrangling: metadata_path, higher_bound
 
-# Pre-download ECCO4Monthly atmospheric forcing variables through the artifacts
-# fallback so ECCOPrescribedAtmosphere(...) finds the files locally even when
-# the ECCO drive is down. The variable list mirrors the metadata constructed
-# inside ECCOPrescribedAtmosphere, and the dates match the testset window.
+# Pre-download the ECCO4Monthly forcing variables through the artifacts fallback, so the testset
+# finds them locally even when the ECCO drive is down.
 let dates = DateTime(1992, 1, 1):Month(1):DateTime(1992, 3, 1)
     for name in NumericalEarth.ECCO.ECCO_atmosphere_variables
         md = Metadata(name; dataset=ECCO4Monthly(), dates)
@@ -44,17 +42,14 @@ end
         @test atmosphere isa PrescribedAtmosphere
         @test radiation isa PrescribedRadiation
 
-        # Test that all expected fields are present
         @test haskey(atmosphere.velocities, :u)
         @test haskey(atmosphere.velocities, :v)
         @test atmosphere.temperature isa FieldTimeSeries
         @test atmosphere.specific_humidity isa FieldTimeSeries
-        @test !isnothing(atmosphere.pressure)
         @test atmosphere.precipitation_flux isa PrescribedPrecipitationFlux
         @test atmosphere.precipitation_flux.rain isa FieldTimeSeries
         @test isnothing(atmosphere.precipitation_flux.snow)
 
-        # Test downwelling radiation components
         ℐꜜˢʷ = radiation.downwelling_shortwave
         ℐꜜˡʷ = radiation.downwelling_longwave
 
@@ -89,7 +84,6 @@ end
         @test higher_bound(pa_metadata, Val(:sea_level_pressure)) == 1f10
         @test higher_bound(other_metadata, Val(:temperature)) == 1f5  # default
 
-        # Verify pressure field contains physically reasonable values
         CUDA.@allowscalar begin
             pa_data = interior(atmosphere.pressure)
             valid = pa_data[pa_data .!= 0]
@@ -98,7 +92,6 @@ end
             @test median(valid) < 1.1f5 # typical sea level pressure is lower than 1.1e5 Pa
         end
 
-        # Test grid consistency
         @test atmosphere.velocities.u.grid isa LatitudeLongitudeGrid
         @test atmosphere.velocities.u.grid == atmosphere.velocities.v.grid
         @test atmosphere.velocities.u.grid == atmosphere.temperature.grid

--- a/test/test_glorys_downloading.jl
+++ b/test/test_glorys_downloading.jl
@@ -56,7 +56,6 @@ end
         @test z_interfaces(md) === (-1.0, 0.0)
 
         source = Field(md, arch; inpainting=nothing)
-        @test source isa Field
         @test size(interior(source), 3) == 1
 
         target_grid = LatitudeLongitudeGrid(arch;

--- a/test/test_jra55.jl
+++ b/test/test_jra55.jl
@@ -75,7 +75,6 @@ using NumericalEarth.JRA55: download_JRA55_cache
 
         md_first = Metadatum(ds_var; dataset=JRA55.RepeatYearJRA55())
         f_first  = Field(md_first, arch)
-        @test f_first isa Field
         @test size(f_first) == (640, 320, 1)
         @allowscalar @test f_first[1, 1, 1] == 430.98105f0
         @allowscalar @test view(f_first.data, 1, :, 1) == view(f_first.data, 641, :, 1)
@@ -135,7 +134,6 @@ using NumericalEarth.JRA55: download_JRA55_cache
                                                          overwrite_existing = true)
         @test isfile(filepath)
 
-        # Test that we can load the data back
         Qswt = FieldTimeSeries(filepath, "Qsw")
         @test on_architecture(CPU(), parent(Qswt.data)) == on_architecture(CPU(), parent(target_fts.data))
         @test Qswt.times == target_fts.times
@@ -187,7 +185,6 @@ using NumericalEarth.JRA55: download_JRA55_cache
         end
         @test Second(end_date - start_date).value ≈ river_flux.times[end] - river_flux.times[1]
 
-        # Test we can access all the data
         for t in eachindex(river_flux.times)
             @test river_flux[t] isa Field
         end
@@ -200,11 +197,8 @@ using NumericalEarth.JRA55: download_JRA55_cache
 
         @info "Testing MultiYearJRA55 single-window crossing year boundary on $A..."
 
-        # Force a single in-memory window to straddle the 1958 → 1959 file
-        # boundary. Before the per-file `ftsn_loc` fix, the second file's
-        # iteration in `set!` would clobber the outer `ftsn` and write to the
-        # wrong slots; this regression test would then leave some in-memory
-        # slots untouched (zero-valued).
+        # A single in-memory window straddling the 1958 → 1959 file boundary must have every slot
+        # written, with each file's iteration going to its own slots.
         start_date_span = DateTime("1958-12-27T12:00:00")
         end_date_span   = DateTime("1959-01-05T12:00:00")
 

--- a/test/test_mangling.jl
+++ b/test/test_mangling.jl
@@ -23,12 +23,9 @@ end
 @testset "mangle clamps out-of-hull indices to the data extent" begin
     data = reshape(Float32[1 2 3; 4 5 6; 7 8 9], 3, 3, 1)
 
-    # A `BoundingBox` whose edge does not align with a native cell face can make
-    # the target grid one cell larger than the downloaded data, so the read
-    # index runs one past the array. The clamp must read the nearest edge cell
-    # rather than reading past the bounds into uninitialized memory (the bug
-    # fixed in `set_region_data!`); without the clamp the `@inbounds` read
-    # returns garbage (denormal/NaN) at the domain edge.
+    # A `BoundingBox` edge that does not align with a native cell face can make the target grid one
+    # cell larger than the data, so the read index runs one past the array and must clamp to the
+    # nearest edge cell.
     @test mangle(4, 2, 1, data, nothing) == data[3, 2, 1]   # i past east edge
     @test mangle(2, 4, 1, data, nothing) == data[2, 3, 1]   # j past north edge
     @test mangle(0, 2, 1, data, nothing) == data[1, 2, 1]   # i below west edge

--- a/test/test_metadata.jl
+++ b/test/test_metadata.jl
@@ -31,12 +31,6 @@ using Oceananigans.OutputReaders: Linear as LinearTimeIndexing
     @test col_z.z == (-400, 0)
 end
 
-@testset "Column isa checks" begin
-    @test Column(0, 0) isa Column
-    @test !(BoundingBox(longitude=(0, 10), latitude=(0, 10)) isa Column)
-    @test !(nothing isa Column)
-end
-
 @testset "restrict_location" begin
     # Column reduces horizontal locations to Nothing
     @test restrict_location((Center, Center, Center), Column(0, 0)) == (Nothing, Nothing, Center)

--- a/test/test_metadata_set.jl
+++ b/test/test_metadata_set.jl
@@ -3,11 +3,8 @@ include("runtests_setup.jl")
 using NumericalEarth.DataWrangling: MetadataSet, Metadata, Metadatum,
                                     BoundingBox, variable_glossary, metadata_path
 
-# `MetadataSet` is a pure DataWrangling concept: no downloads, no field
-# construction. These tests exercise construction, accessors, iteration,
-# and the global verbose→short glossary. Downstream `set!(model, mset)`,
-# `Field(::MetadataSet)`, and the `download` rename live in their own tests
-# once those land.
+# `MetadataSet` is a pure DataWrangling concept: no downloads, no field construction. These tests
+# cover construction, accessors, iteration, and the verbose→short glossary.
 
 snapshot_date = DateTime(1993, 1, 1)
 date_range    = DateTime(1993, 1, 1):Month(1):DateTime(1993, 4, 1)
@@ -124,7 +121,6 @@ end
                        date    = snapshot_date)
 
     nt = NamedTuple(mset)
-    @test nt isa NamedTuple
     @test keys(nt) === (:temperature, :salinity)
     @test nt.temperature.name == :temperature
     @test nt.salinity.name    == :salinity
@@ -296,10 +292,7 @@ end
 end
 
 @testset "Field(::MetadataSet) rejects multi-date sets" begin
-    # Field(mset) only makes sense for a single snapshot per variable.
-    # A multi-date mset should error pointing the user at a per-variable
-    # FieldTimeSeries comprehension rather than failing deep in
-    # `Field(::Metadata)` with a MethodError.
+    # Field(mset) only makes sense for a single snapshot per variable, so a multi-date mset errors.
     mts = MetadataSet(:temperature, :salinity;
                       dataset = ECCO4Monthly(),
                       dates   = date_range)

--- a/test/test_nested_simulation.jl
+++ b/test/test_nested_simulation.jl
@@ -15,10 +15,8 @@ using Breeze: ThermodynamicConstants, dry_air_gas_constant, vapor_gas_constant, 
 using Test
 
 @testset "PrescribedAtmosphere: grid vertical topology selects surface vs volumetric fields" begin
-    # A `Flat` vertical builds a surface atmosphere (u, v; 2D temperature / specific_humidity /
-    # pressure) for ocean / sea-ice coupling. Temperature & humidity are direct properties now;
-    # `tracers` is reserved for gas species (empty by default), and `microphysical_variables` for
-    # cloud / precip species (also empty by default).
+    # A `Flat` vertical gives a surface atmosphere: u, v and 2D temperature, specific humidity
+    # and pressure, with no gas or microphysical species.
     gs = RectilinearGrid(size = (8, 8), x = (-1, 1), y = (-1, 1), topology = (Bounded, Bounded, Flat))
     pas = PrescribedAtmosphere(gs, [0.0, 1.0])
     @test keys(pas.velocities) == (:u, :v)
@@ -65,12 +63,8 @@ const y₀_LO = 0.0
 end
 
 @testset "NestedSimulation: Lamb-Oseen vortex through a child NonhydrostaticModel" begin
-    # Parent atmosphere holds the analytic Lamb-Oseen state on a 3D PrescribedAtmosphere,
-    # populated by set! at a few coarse time snapshots; interpolation handles the rest.
-    # The resolved-vertical (3D) grid gives CCC velocities/tracers/pressure so the FTS can be
-    # interpolated at the child's interior z-nodes.
-    # Domain extends strictly beyond the child so the FTS brackets every child
-    # boundary node (required by InterpolatedFTSBoundary's validation).
+    # The parent holds the analytic Lamb-Oseen state at a few coarse time snapshots on a 3D grid,
+    # and extends strictly beyond the child so it brackets every child boundary node.
     parent_grid = RectilinearGrid(size     = (16, 16, 4),
                                   x        = (-1.5, 1.5),
                                   y        = (-1.5, 1.5),
@@ -156,14 +150,9 @@ end
         bc_types  = (T = ValueBoundaryCondition,))
 end
 
-# Regression for the GPU `InvalidIRError` in the prognostic-parent path: a LIVE model
-# parent (not a PrescribedAtmosphere/FTS) drives the child through
-# `Interpolated{<:AbstractField}` BCs. On GPU the source field `Adapt`s to a bare data
-# array inside the halo-fill kernel, so `getbc`/`_query_source` must stay generically
-# typed and take the location explicitly (rather than dispatching on `::AbstractField`
-# and calling `instantiated_location(source)` in-kernel). Includes a Center
-# `ValueBoundaryCondition` — the exact BC kind that failed. Runs on every
-# `test_architecture` (GPU CI is where the regression bites).
+# A live model parent (rather than a PrescribedAtmosphere or FieldTimeSeries) drives the child
+# through `Interpolated` BCs, including a Center `ValueBoundaryCondition`. On GPU the source
+# field `Adapt`s to a bare data array inside the halo-fill kernel.
 @testset "NestedSimulation: prognostic (live AbstractField) parent on $(arch)" for arch in test_architectures
     parent_grid = RectilinearGrid(arch; size = (16, 16, 4),
                                   x = (-1.5, 1.5), y = (-1.5, 1.5), z = (-0.2, 1.2),
@@ -184,7 +173,7 @@ end
     set!(child, u = (x, y, z) -> 0.1, v = (x, y, z) -> 0.05, c = (x, y, z) -> x + y)
 
     nested = NestedSimulation(parent, child; Δt = 0.001, stop_iteration = 3, verbose = false)
-    run!(nested)   # pre-fix: InvalidIRError on GPU during the first child halo fill
+    run!(nested)
 
     @test child.clock.iteration == 3
     @test parent.clock.time ≈ child.clock.time
@@ -192,13 +181,9 @@ end
     @test all(isfinite, Array(interior(child.tracers.c)))
 end
 
-# The era5_breeze telescoping nest can't use a live AbstractField BC source (it fails GPU
-# codegen — see the prognostic-parent regression above), so it drives the inner child from a
-# "rolling FieldTimeSeries": each boundary variable is a 2-slot FTS on the parent grid whose both
-# slots are overwritten from the live parent field every step. An FTS survives Adapt as a
-# FlavorOfFTS (GPU-clean), and the wide [0, 1e9] time bracket makes the time-interpolation return
-# the current state at any clock time. This guards the rolling idiom: a refresh propagates the
-# live field into the FTS, and time-interpolation returns the refreshed state.
+# A "rolling FieldTimeSeries" drives a child from a live parent field: a 2-slot FTS whose slots
+# are both overwritten from the field every step, with a time bracket wide enough that
+# interpolation returns the refreshed state at any clock time.
 @testset "Rolling FieldTimeSeries tracks a live parent field" begin
     grid = RectilinearGrid(size = (4, 4, 4), x = (0, 1), y = (0, 1), z = (0, 1),
                            topology = (Bounded, Bounded, Bounded))
@@ -224,14 +209,9 @@ end
     @test interior(fts[Time(123.4)]) ≈ interior(src)
 end
 
-# An `Interpolated` Value BC must sample the source at the boundary FACE, not the child
-# field's center node — otherwise a Center field's halo is reconstructed from a value a
-# half-cell *inside* the boundary (a half-cell-gradient bias). With a source exactly
-# linear in the boundary-normal coordinate, the reconstructed boundary-face value
-# ½(halo + first-interior) must equal the source AT the face — i.e. = 0 to roundoff with
-# the face fix, but off by ½Δ·(slope) with the (buggy) center placement. Covers BOTH
-# normal directions, so the Dim-1 (west/east) and Dim-2 (south/north) `node` edits are
-# each exercised.
+# An `Interpolated` Value BC samples the source at the boundary face, not at the child field's
+# center node. With a source exactly linear in the boundary-normal coordinate, the reconstructed
+# face value ½(halo + first interior) equals the source at the face. Covers both normal directions.
 @testset "Interpolated Value BC samples at the boundary face on $(arch)" for arch in test_architectures
     src_grid = RectilinearGrid(arch; size = (16, 16, 4), x = (-1, 3), y = (-1, 3), z = (0, 1),
                                topology = (Bounded, Bounded, Bounded))
@@ -260,10 +240,6 @@ end
     @test isapprox(CUDA.@allowscalar((cy[4, 8, 2] + cy[4, 9, 2]) / 2), 2.0; atol = 1e-4)
 end
 
-# Unit test for the Breeze-ext helper that converts a moist thermodynamic state
-# (T, qᵛ, qᶜ, qⁱ, p) into the prognostic fields Breeze's `CompressibleDynamics`
-# integrates (ρ, θˡⁱ, qᵗ). Checks the dry/saturation-pressure limit exactly and
-# the moist + condensate case against the documented formulas.
 @testset "breeze_prognostic_state derives (ρ, θˡⁱ, qᵗ)" begin
     constants = ThermodynamicConstants()
     Rᵈ   = dry_air_gas_constant(constants)
@@ -297,9 +273,7 @@ end
     @test all(interior(s2.θˡⁱ) .< θ)   # condensate loading lowers θˡⁱ below the dry θ
 end
 
-# Unit test that the state exchanger carries the specific members (`θ`, `u`, `v`) consistently with the
-# density-weighted ones — `ρθ = ρᵈ·θ`, `ρu = ρᵈ·u`, `ρv = ρᵈ·v`, and `u`/`v` are verbatim parent copies.
-# This is the invariant the intensive (`SpecificForcing`) Davies relaxation relies on.
+# The specific members (`θ`, `u`, `v`) are the intensive partners of the density-weighted ones.
 @testset "state exchanger: specific θ/u/v are the intensive partners of ρθ/ρu/ρv" begin
     ext = Base.get_extension(NumericalEarth, :NumericalEarthBreezeExt)
     grid = RectilinearGrid(size = (8, 8, 4), x = (-1, 1), y = (-1, 1), z = (0, 1),
@@ -321,11 +295,6 @@ end
     @test es.v[1]  ≈ parent.velocities.v[1]
 end
 
-# Integration test for the example's production path: a Breeze `AtmosphereModel`
-# driven as a `NestedSimulation` child via the direct-wiring primitives
-# (`atmosphere_simulation(…).model` + `parent_boundary_conditions`). Exercises the
-# #220 contract that `atmosphere_simulation` returns a `Simulation` whose `.model`
-# is an `AbstractModel` suitable for `NestedModel`, and steps it a few iterations.
 @testset "Breeze AtmosphereModel as a NestedSimulation child on $(arch)" for arch in test_architectures
     # Parent: a 3D PrescribedAtmosphere strictly bracketing the child,
     # holding a uniform state. Velocity slots carry momentum (ρu, ρv) per the
@@ -379,12 +348,8 @@ end
     @test all(isfinite, Array(interior(child.dynamics.total_density)))
 end
 
-# Coupling a Breeze `CompressibleDynamics` atmosphere to a `SlabLand` via
-# `AtmosphereLandModel`, then wrapping it as a `NestedSimulation` child. The coupled
-# `update_state!` runs `interpolate_state!`, which must handle compressible dynamics
-# (prognostic density, no anelastic reference state) via the Breeze ext's
-# `dynamics_density`/`surface_pressure` accessors. Construction-level: stepping the
-# coupled child awaits a Breeze energy-flux/qᵛ fix for the compressible path.
+# Construction only: stepping the coupled child awaits a Breeze energy-flux/qᵛ fix for the
+# compressible path.
 @testset "AtmosphereLandModel (compressible Breeze) as a NestedSimulation child on $(arch)" for arch in test_architectures
     atmos_grid = RectilinearGrid(arch; size = (8, 8, 16),
                                  x = (0, 8000), y = (0, 8000), z = (0, 8000),
@@ -431,9 +396,8 @@ end
     @test length(nested.exchanger.prognostic.ρᵈ.backend) == 3
 end
 
-# The Davies relaxation is keyed by the density-weighted prognostic and pre-wrapped in `SpecificForcing`,
-# so a caller's own specific-key forcing COMBINES with it rather than replacing it in the constructor's
-# `merge`. Had it been keyed `θ`, the merge would drop it and `forcing.ρθ` would be a lone SpecificForcing.
+# The Davies relaxation is keyed by the density-weighted prognostic, so a caller's own specific-key
+# forcing combines with it rather than replacing it.
 @testset "Davies relaxation survives a caller-supplied specific forcing" begin
     parent_grid = LatitudeLongitudeGrid(CPU(); size = (8, 8, 4),
                                         longitude = (-1.5, 1.5), latitude = (-1.5, 1.5),
@@ -460,12 +424,8 @@ end
     @test all(f -> f isa SpecificForcing, ρθ_forcing.forcings)   # both ρᵈ-weighted at kernel time
 end
 
-# The Breeze-ext `StateExchanger` holds the child prognostics as a 3-level FieldTimeSeries bracketing
-# the child clock (memory-O(1) in time); `exchange_state!` positions that window one level below the
-# bracket of `t + Δt` so it spans a node-crossing step, recomputing the resident levels from the parent.
-# This guards the cycling: the window `start` advances as the clock crosses parent intervals and back,
-# with finite + physical prognostics throughout. Uses a synthetic `PrescribedAtmosphere` parent (no ERA5
-# download); here `pressure` is an FTS (the ERA5 parent uses a static `Field`) — the exchanger handles both.
+# The exchanger's 3-level window advances as the clock crosses parent intervals and back, with
+# finite and physical prognostics throughout.
 @testset "StateExchanger: 3-level window cycles across parent intervals on $(arch)" for arch in test_architectures
     ext = Base.get_extension(NumericalEarth, :NumericalEarthBreezeExt)
 
@@ -511,10 +471,9 @@ end
     @test all(θ₃ .≈ 283 * (1e5 / 9e4)^κ)
 end
 
-# Every liquid/ice hydrometeor the parent carries — cloud liquid + rain, cloud ice + snow — is mass that
-# is NOT dry gas, so it must load the density through Breeze's mixture gas constant (ρ = p / (Rᵐ T),
-# Rᵐ = (1 − qᵗ) Rᵈ + qᵛ Rᵛ) and enter qᵗ. Verifies both the kernel prognostics (`ρᵈ`) and the
-# `breeze_prognostic_state` broadcast path (`reconstruct_parent_state`) sum ALL hydrometeors, not just cloud.
+# Every liquid and ice hydrometeor the parent carries — cloud liquid and rain, cloud ice and snow —
+# is mass that is not dry gas, so it loads the density through the mixture gas constant
+# (ρ = p / (Rᵐ T), Rᵐ = (1 − qᵗ) Rᵈ + qᵛ Rᵛ) and enters qᵗ.
 @testset "StateExchanger: cloud + precipitation load the density on $(arch)" for arch in test_architectures
     ext = Base.get_extension(NumericalEarth, :NumericalEarthBreezeExt)
     reconstruct = NumericalEarth.NestedModels.reconstruct_parent_state
@@ -634,14 +593,9 @@ end
     end
 end
 
-# Temporal-seam correctness of the ON-THE-FLY (windowed FTS) interpolation the child's boundary
-# conditions + Davies relaxation actually query. `NestedModel.time_step!` refreshes the exchanger at the
-# step END (`t + Δt`), so on a step that CROSSES a parent node the derived 2-level window sits at
-# `[node, node+1]` while the child's start-of-step sub-stages sample at `t < node` — a start-side query
-# one interval BELOW the resident window. That query must return FINITE, PHYSICAL values (a clean
-# extrapolation/clamp toward the window edge), NOT window-eviction/wrap garbage. This is the exact
-# hourly-seam the ERA5 nest crosses every hour; the reconstruct_parent_state test above covers the
-# full-memory diagnostic path, but the RUNTIME path is the windowed `fts[Time(t)]` probed here.
+# The exchanger refreshes at the end of a step, so on a step that crosses a parent node the child's
+# start-of-step sub-stages query the window one interval below its resident levels. Such a query must
+# return finite, physical values.
 @testset "StateExchanger: windowed query across a parent node is finite + physical on $(arch)" for arch in test_architectures
     ext = Base.get_extension(NumericalEarth, :NumericalEarthBreezeExt)
 
@@ -668,10 +622,8 @@ end
     θin = Array(interior(prog.ρθ[Time(0.5)])) ./ Array(interior(prog.ρᵈ[Time(0.5)]))
     @test all(isapprox.(θin, θtrue(0.5); rtol = 1e-4))
 
-    # CROSSING STEP over the node at t = 2.0: bracket t+Δt = 2.1 ⇒ window advances to start = 2 (resident
-    # levels 2,3,4 = times [1,2,3]). The child's start-of-step query at t = 1.9 (< node) sits one interval
-    # BELOW where a 2-level window would sit — with a 2-level window that read a stale/wrong target (the
-    # hourly-seam kick); the 3-level window keeps [1.9's bracket] resident so the target stays correct.
+    # Crossing the node at t = 2: the window advances to start = 2 (times [1, 2, 3]), so the child's
+    # start-of-step query at t = 1.9 still falls inside the resident levels.
     exchange(exchanger, 2.1)
     @test prog.ρᵈ.backend.start == 2
 
@@ -682,17 +634,12 @@ end
     @test all(0.05 .< ρdq .< 2.0)               # physical dry density (not a stale/aliased value)
     θq = ρθq ./ ρdq
     @test all(250 .< θq .< 400)                 # physical θ
-    @test all(isapprox.(θq, θtrue(1.9); rtol = 1e-4))   # linear-in-t ⇒ exact; a stale target would miss by ~5 K
+    @test all(isapprox.(θq, θtrue(1.9); rtol = 1e-4))   # linear in t ⇒ exact
 end
 
-# End-to-end guard for the moving-window fix: step the FULL coupled Breeze child across a derived-window
-# MOVE and assert its prognostics stay finite. The exchanger/`memory_index` @testsets above check the
-# derived FTS in isolation; this exercises the RUNTIME path that actually broke — the child's BC + Davies
-# forcing kernels reading the derived FTS elementwise while the window rolls `start` 1→2 mid-run. A uniform
-# synthetic parent with short (4 s) node spacing reaches the move (crossing node #3 at t = 8 s) in a few
-# acoustically-stable steps; the move is what triggered the blow-up, not the parent's data, so the minimal
-# parent reproduces it. Pre-fix (generic cyclic `memory_index` indexing past the window's storage) the
-# child NaNs the step `start` advances 1→2 (`InexactError: Int64(NaN)`).
+# The full coupled Breeze child steps across a window move and its prognostics stay finite. A uniform
+# synthetic parent with 4 s node spacing reaches the move (crossing node 3 at t = 8 s) in a few
+# acoustically stable steps.
 @testset "Nested child survives a derived-window move (moving-window regression) on $(arch)" for arch in test_architectures
     ext   = Base.get_extension(NumericalEarth, :NumericalEarthBreezeExt)
     times = [0.0, 4.0, 8.0, 12.0, 16.0]        # 5 levels ⇒ the 3-level window moves when crossing node #3
@@ -731,10 +678,8 @@ end
     end
 end
 
-# The parent→child terrain blend is specified as a PHYSICAL length (`terrain_blend_length`, meters) and
-# converted to a cell count per grid. A fixed cell count would steepen the blend slope ~1/Δx as resolution
-# increases (which regenerates spurious vertical momentum aloft at high resolution); deriving cells from a
-# physical length keeps the transition slope resolution-invariant — so a 4×-finer grid gets ~4× the cells.
+# `terrain_blend_length` is a physical length converted to a cell count per grid, so the blend slope is
+# resolution-invariant: a 4×-finer grid gets ~4× the cells.
 @testset "default_terrain_blend_width: physical length gives a resolution-invariant slope" begin
     ext = Base.get_extension(NumericalEarth, :NumericalEarthBreezeExt)
     lon, lat = (-98.8, -96.2), (35.4, 37.8)

--- a/test/test_ocean_only_model.jl
+++ b/test/test_ocean_only_model.jl
@@ -48,7 +48,7 @@ using Oceananigans.OrthogonalSphericalShellGrids
         ocean = ocean_simulation(grid; free_surface)
 
         @test NumericalEarth.Oceans.get_radiative_forcing(ocean) isa NumericalEarth.Oceans.TwoColorRadiation
-        
+
         atmosphere = JRA55PrescribedAtmosphere(arch; time_indices_in_memory=4)
         radiation = JRA55PrescribedRadiation(arch; time_indices_in_memory=4)
 
@@ -71,7 +71,6 @@ using Oceananigans.OrthogonalSphericalShellGrids
             ocean_with_land = ocean_simulation(grid; free_surface)
             coupled_model = OceanOnlyModel(ocean_with_land; atmosphere, land, radiation)
 
-            # Verify land exchanger is present
             @test !isnothing(coupled_model.interfaces.exchanger.land)
             @test coupled_model.land.freshwater_flux === land.freshwater_flux
 
@@ -114,7 +113,6 @@ end
         reference_u_bcs = reference.model.velocities.u.boundary_conditions
 
         @test typeof(T_bcs.top) == typeof(reference_T_bcs.top)
-        @test !isnothing(T_bcs.top.condition)
         @test typeof(u_bcs.top) == typeof(reference_u_bcs.top)
         @test typeof(u_bcs.bottom) == typeof(reference_u_bcs.bottom)
         @test typeof(u_bcs.immersed) == typeof(reference_u_bcs.immersed)

--- a/test/test_ocean_sea_ice_model.jl
+++ b/test/test_ocean_sea_ice_model.jl
@@ -68,7 +68,6 @@ using ClimaSeaIce.Rheologies
                 true
             end
 
-            # Test with land component
             @info "Testing OceanSeaIceModel with land on $A..."
             land_dates = all_dates(RepeatYearJRA55(), :river_freshwater_flux)
             land = JRA55PrescribedLand(arch; end_date=land_dates[2])

--- a/test/test_radiations.jl
+++ b/test/test_radiations.jl
@@ -12,7 +12,6 @@ using NumericalEarth.Radiations: PrescribedRadiation,
         @info "Testing PrescribedRadiation(grid) on $A..."
         grid = RectilinearGrid(arch, size = 10, z = (-100, 0), topology = (Flat, Flat, Bounded))
         rad = PrescribedRadiation(grid)
-        @test rad isa PrescribedRadiation
         @test rad.surface_properties isa NamedTuple
         @test haskey(rad.surface_properties, :ocean)
         @test haskey(rad.surface_properties, :sea_ice)
@@ -92,7 +91,6 @@ end
 
         # interface_fluxes are allocated for present surfaces (ocean + sea_ice
         # via FreezingLimitedOceanTemperature).
-        @test !isnothing(model.radiation.interface_fluxes)
         @test model.radiation.interface_fluxes.ocean isa InterfaceRadiationFlux
         @test model.radiation.interface_fluxes.sea_ice isa InterfaceRadiationFlux
 

--- a/test/test_reactant.jl
+++ b/test/test_reactant.jl
@@ -28,9 +28,9 @@ end
     ocean = ocean_simulation(grid; Δt=300, free_surface)
 
     # We use an idealized atmosphere to avoid downloading the whole JRA55 data
-    atmos_grid  = LatitudeLongitudeGrid(arch, Float32; size=(320, 200), 
-                                                       latitude=(-90, 90), 
-                                                       longitude=(0, 360), 
+    atmos_grid  = LatitudeLongitudeGrid(arch, Float32; size=(320, 200),
+                                                       latitude=(-90, 90),
+                                                       longitude=(0, 360),
                                                        topology=(Periodic, Bounded, Flat))
 
     atmos_times = range(0, 360Oceananigans.Units.days, length=10)

--- a/test/test_sea_ice_ocean_heat_fluxes.jl
+++ b/test/test_sea_ice_ocean_heat_fluxes.jl
@@ -46,7 +46,6 @@ using ClimaSeaIce.SeaIceThermodynamics: LinearLiquidus, melting_temperature
     end
 
     @testset "solve_interface_conditions" begin
-        # Test parameters
         liquidus = LinearLiquidus(Float64)
         αₕ = 0.0095  # Heat transfer coefficient
         αₛ = αₕ / 35  # Salt transfer coefficient (R = 35)
@@ -239,13 +238,8 @@ end
 end
 
 @testset "Salt flux unit consistency" begin
-    # The salt flux Jˢ = Eᵢ Sˢⁱ / ρᵒᶜ must come out in psu m s⁻¹, consistent with the
-    # atmosphere-ocean salinity flux:
-    # - Eᵢ is a mass flux (kg m⁻² s⁻¹)
-    # - dividing by ρᵒᶜ (kg m⁻³) gives a volume flux (m s⁻¹)
-    # - multiplying by the ice salinity (psu) gives psu m s⁻¹
-    #
-    # Missing the density conversion would make the flux ~1000× too large and destabilize the ocean.
+    # The salt flux Jˢ = Eᵢ Sˢⁱ / ρᵒᶜ comes out in psu m s⁻¹: Eᵢ is a mass flux (kg m⁻² s⁻¹),
+    # dividing by ρᵒᶜ (kg m⁻³) gives a volume flux (m s⁻¹), and the ice salinity (psu) scales it.
 
     for arch in test_architectures
         A = typeof(arch)
@@ -287,11 +281,8 @@ end
                 @test all(𝒬ⁱⁿ_cpu .> 0)
                 @test all(𝒬ⁱⁿ_cpu .< 1e5)  # Should not be unreasonably large
 
-                # Salt flux (in psu × m/s) should be small: typical values O(1e-7 to 1e-5)
-                # Before the fix, salt flux was ~1000× too large
-                # The salt flux magnitude should be comparable to:
-                # Jˢ ~ (Q / (ρ * c * L)) * ΔS ~ (1000 / (1025 * 4000 * 3e5)) * 30 ~ 2e-7 psu m/s
-                @test all(abs.(Jˢ_cpu) .< 1e-3)  # Should not be unreasonably large (was ~1 before fix)
+                # Jˢ ~ (Q / (ρᵒᶜ c ℰ)) ΔS ~ (1000 / (1025 · 4000 · 3e5)) · 30 ~ 2e-7 psu m s⁻¹
+                @test all(abs.(Jˢ_cpu) .< 1e-3)
                 @test all(abs.(Jˢ_cpu) .> 1e-10) # Should not be zero
             end
         end
@@ -385,10 +376,7 @@ end
 end
 
 @testset "Frazil ice formation and salt flux" begin
-    # Test that frazil ice formation is handled correctly and contributes
-    # to the salt flux with proper density conversion.
-    # When ocean temperature drops below freezing, frazil ice forms and
-    # the salt flux includes the frazil contribution.
+    # When the ocean drops below freezing, frazil forms and its contribution enters the salt flux.
 
     for arch in test_architectures
         A = typeof(arch)
@@ -474,7 +462,6 @@ end
             flux_form isa IceBathHeatFlux
         end
 
-        # Test time stepping with each formulation
         for sea_ice_ocean_heat_flux in [IceBathHeatFlux(),
                                         ThreeEquationHeatFlux()]
 

--- a/test/test_slab_land.jl
+++ b/test/test_slab_land.jl
@@ -400,10 +400,8 @@ end
 end
 
 @testset "SlabLand coupled checkpoint round-trip" begin
-    # The coupler-written forcing fields (`land.fluxes`) are computed at the end
-    # of each coupled step and consumed by the next `time_step!(land, Δt)`, so a
-    # restored model must carry them to be step-for-step identical to the
-    # uninterrupted run.
+    # The coupler-written forcing fields (`land.fluxes`) are consumed by the next
+    # `time_step!(land, Δt)`, so a restored model must carry them to reproduce the uninterrupted run.
     using Oceananigans.TimeSteppers: time_step!
     using NumericalEarth.Atmospheres: PrescribedAtmosphere
     using NumericalEarth.Radiations: PrescribedRadiation, SurfaceRadiationProperties

--- a/test/test_snow_model_integration.jl
+++ b/test/test_snow_model_integration.jl
@@ -82,14 +82,9 @@ using NumericalEarth.SeaIces: default_snow_thermodynamics
         end
 
         @testset "Snow insulates: warmer surface temperature [$A]" begin
-            # Build two coupled models — one without snow, one with snow and
-            # nonzero snow thickness — then compare surface temperatures after
-            # one coupled time step. Snow adds thermal resistance, so the
-            # surface should be warmer (closer to the warmer atmosphere).
-            #
-            # Radiation is disabled (ε=0) so the surface energy balance
-            # reduces to conductive + turbulent fluxes; otherwise the
-            # Stefan–Boltzmann loss swamps the small snow-insulation signal.
+            # Snow adds thermal resistance, so the surface ends up warmer after one coupled step.
+            # Radiation is disabled (ε=0) so the energy balance reduces to conductive + turbulent
+            # fluxes; otherwise the Stefan-Boltzmann loss swamps the snow-insulation signal.
             ocean_grid = RectilinearGrid(arch;
                                          size = (1, 1, 2),
                                          extent = (1, 1, 1),

--- a/test/test_soilgrids.jl
+++ b/test/test_soilgrids.jl
@@ -9,12 +9,10 @@ import Downloads
     sg_mean = SoilGrids2()
     sg_sand = Metadatum(:sand_fraction, dataset=sg_mean)
     Downloads.download(sg_sand)
-    # Check that data is successfully downloaded
     @test isfile(DataWrangling.metadata_path(sg_sand))
     for var in keys(SoilGrids.SoilGrids2_dataset_variable_names)
         sgmd = Metadatum(var, dataset=sg_mean)
         field = Field(sgmd)
-        # Check that at least some grid cells are finite
         @test any(isfinite.(field))
     end
     for var in (:sand_fraction, :silt_fraction, :clay_fraction)

--- a/test/test_surface_fluxes.jl
+++ b/test/test_surface_fluxes.jl
@@ -243,8 +243,6 @@ end
         @test model_with_land.land.freshwater_flux === land.freshwater_flux
         @test typeof(model_with_land.land.clock.time) === typeof(model_with_land.clock.time)
 
-        # Test PrescribedLand display methods
-        @test summary(land) isa String
         @test contains(sprint(show, land), "PrescribedLand")
         @test contains(sprint(show, land), "freshwater_flux")
 

--- a/test/test_veros.jl
+++ b/test/test_veros.jl
@@ -6,29 +6,13 @@ using Oceananigans
 using PythonCall, CondaPkg
 
 @testset "Veros ocean model interface" begin
-    # Test that the Veros extension is available
     VerosModule = Base.get_extension(NumericalEarth, :NumericalEarthVerosExt)
     @test !isnothing(VerosModule)
 
-    # Test Veros installation
-    @test begin
-        VerosModule.install_veros()
-        true
-    end
+    VerosModule.install_veros()
 
-    # Test creating a VerosOceanSimulation
-    # Using a small setup for testing
-    @test begin
-        ocean = VerosModule.VerosOceanSimulation("global_4deg", :GlobalFourDegreeSetup)
-        @test ocean isa VerosModule.VerosOceanSimulation
-        @test !isnothing(ocean.setup)
-        true
-    end
-
-    # Test basic interface functions
     ocean = VerosModule.VerosOceanSimulation("global_4deg", :GlobalFourDegreeSetup)
 
-    # Test interface
     ρᵒᶜ = NumericalEarth.EarthSystemModels.reference_density(ocean)
     cᵒᶜ = NumericalEarth.EarthSystemModels.heat_capacity(ocean)
     @test ρᵒᶜ isa Real
@@ -36,31 +20,19 @@ using PythonCall, CondaPkg
 
     T = NumericalEarth.EarthSystemModels.ocean_temperature(ocean)
     S = NumericalEarth.EarthSystemModels.ocean_salinity(ocean)
-
-    @test !isnothing(T)
-    @test !isnothing(S)
-
-    @test length(size(T)) == 3
-    @test length(size(S)) == 3
+    @test ndims(T) == 3
+    @test ndims(S) == 3
 
     S_surf = NumericalEarth.EarthSystemModels.ocean_surface_salinity(ocean)
     u_surf, v_surf = NumericalEarth.EarthSystemModels.ocean_surface_velocities(ocean)
+    @test ndims(S_surf) == 2
+    @test ndims(u_surf) == 2
+    @test ndims(v_surf) == 2
 
-    @test !isnothing(S_surf)
-    @test !isnothing(u_surf)
-    @test !isnothing(v_surf)
-
-    # Test surface grid
     grid = VerosModule.surface_grid(ocean)
     @test grid isa Oceananigans.Grids.LatitudeLongitudeGrid
 
-    # Test time stepping
-    @test begin
-        Δt = 60.0
-        time_step!(ocean, Δt)
-        true
-    end
+    time_step!(ocean, 60.0)
 
-    # Clean up output files
     VerosModule.remove_outputs(:global_4deg)
 end

--- a/test/test_woa.jl
+++ b/test/test_woa.jl
@@ -11,7 +11,7 @@ using WorldOceanAtlasTools
 
 inpainting = NearestNeighborInpainting(10)
 
-# Ensure a WOA Metadatum file is on disk, trying NOAA first 
+# Ensure a WOA Metadatum file is on disk, trying NOAA first
 # and falling back to the NumericalEarthArtifacts mirror.
 function ensure_woa_file(metadatum; label)
     filepath = metadata_path(metadatum)
@@ -33,8 +33,7 @@ for arch in test_architectures
                 filepath = ensure_woa_file(metadata; label="WOA Annual $name")
                 @test isfile(filepath)
 
-                field = Field(metadata, arch; inpainting=NearestNeighborInpainting(2))
-                @test field isa Field
+                Field(metadata, arch; inpainting=NearestNeighborInpainting(2))
 
                 # Check inpainted data was cached
                 datapath = NumericalEarth.DataWrangling.inpainted_metadata_path(metadata)
@@ -96,8 +95,7 @@ for arch in test_architectures
                 filepath = ensure_woa_file(metadata; label="WOA Monthly $name")
                 @test isfile(filepath)
 
-                field = Field(metadata, arch; inpainting=NearestNeighborInpainting(2))
-                @test field isa Field
+                Field(metadata, arch; inpainting=NearestNeighborInpainting(2))
             end
         end
 


### PR DESCRIPTION
Net −209 lines across `test/`. Everything removed either cannot fail or says nothing the code does not.

**Tests**
- `@test x isa T` where the previous line is `x = T(...)` — 17 of them (`Field`, `FieldTimeSeries`, `NamedTuple`, dataset constructors). Reaching into a constructor's result to prove it worked.
- `@test !isnothing(x)` subsumed by an adjacent assertion (`@test length(area) == 4`, `icols, jrows = win`), `@test ERA5PrescribedAtmosphere isa Type`, `@test summary(land) isa String`, and five `@test isdefined(CDSExt, :private_symbol)` sitting above a call to that symbol.
- Three testsets that assert nothing: `Column isa checks` (tests Julia's type system), a duplicate four-`hasmethod` block for ERA5 dataset types, and the `@test begin ...; true; end` wrappers in `test_veros.jl` (one constructed the simulation twice).
- A commented-out ECCO2 inpainting testset, replaced by a one-line note that it is too slow to run.

Kept: `!isnothing` on extension loading and conditionally-wired components, `hasmethod`/`which(...).module` for download dispatch, and `GHSBuiltS(...) isa GHSBuiltS` (a valid-endpoint check paired with `@test_throws`).

**Comments**
- ~100 that restate the assertion below them, plus one in `test_bathymetry.jl` claiming `remove_minor_basins!(Z, Inf)` "does nothing" above a `@test_throws`.
- 25 multi-line memos compressed to what each test asserts — dropping narration of pre-fix failure modes ("pre-fix: InvalidIRError on GPU", "was ~1 before fix"), rejected alternatives, and what functions in other files do.
- 25 lines of pre-existing trailing whitespace.

Verified in a clean session: `test_metadata`, `test_metadata_set`, `test_mangling`, `test_radiations` and `test_bathymetry` all pass. `test_copernicus_climate_datastore` is 148/149; its one error (`CopernicusClimateDataStore.yearly` undefined) reproduces on unmodified main.