### PR TITLE
(0.8.0) Implement a time anchor for different datsets

### DIFF
--- a/docs/src/developers/implement_a_dataset.jl
+++ b/docs/src/developers/implement_a_dataset.jl
@@ -203,14 +203,13 @@ nothing #hide
 # materializes as a `FieldTimeSeries`. Keeping every snapshot in memory lets us draw the whole record at
 # once as a Hovmöller diagram (depth versus time):
 
-using Oceananigans.Units: days
-
 dates = DateTime(2012, 10, 1):Day(1):DateTime(2012, 12, 1)
 
 temperature = Metadata(:temperature; dataset = OceanStationPapa(), dates)
 Tt = FieldTimeSeries(temperature; time_indices_in_memory = length(dates))
 
-t = Tt.times ./ days
+## The time axis carries dates, so the elapsed days come from differences against the first one.
+t = (Tt.times .- first(dates)) ./ Day(1)
 z = znodes(Tt)
 hovmoller = Array(interior(Tt, 1, 1, :, :))
 

--- a/docs/src/developers/slab_ocean.jl
+++ b/docs/src/developers/slab_ocean.jl
@@ -135,15 +135,16 @@ slab_ocean = SlabOcean(grid)
 set!(slab_ocean.temperature, Metadatum(:temperature, dataset=ECCO4Monthly()))
 
 atmosphere = NumericalEarth.JRA55PrescribedAtmosphere(arch)
+start_date = atmosphere.clock.time
 
-sea_ice = NumericalEarth.sea_ice_simulation(grid, slab_ocean, advection=WENO(order=7))
+sea_ice = NumericalEarth.sea_ice_simulation(grid, slab_ocean; start_date, advection=WENO(order=7))
 set!(sea_ice.model, h=Metadatum(:sea_ice_thickness,     dataset=ECCO4Monthly()),
                     ℵ=Metadatum(:sea_ice_concentration, dataset=ECCO4Monthly()))
 
 interfaces = ComponentInterfaces(atmosphere, slab_ocean, sea_ice; exchange_grid=grid)
 coupled_model = NumericalEarth.EarthSystemModel(; atmosphere, sea_ice, ocean=slab_ocean, interfaces)
 
-simulation = Simulation(coupled_model, Δt=60minutes, stop_time=120days)
+simulation = Simulation(coupled_model; Δt=60minutes, stop_time=start_date + Day(120))
 run!(simulation)
 
 # And now visualize.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -63,8 +63,8 @@ bathymetry = NumericalEarth.regrid_bathymetry(grid) # builds gridded bathymetry 
 grid = ImmersedBoundaryGrid(grid, GridFittedBottom(bathymetry))
 
 # Build an ocean simulation initialized to the ECCO state estimate version 2 on Jan 1, 1993
-ocean = NumericalEarth.ocean_simulation(grid)
 start_date = DateTime(1993, 1, 1)
+ocean = NumericalEarth.ocean_simulation(grid; start_date)
 set!(ocean.model,
      NumericalEarth.MetadataSet(:temperature, :salinity;
                                 dataset = NumericalEarth.ECCO2Daily(),
@@ -73,7 +73,7 @@ set!(ocean.model,
 # Build and run an EarthSystemModel (with no sea ice component) forced by JRA55 reanalysis
 atmosphere = NumericalEarth.JRA55PrescribedAtmosphere(arch)
 coupled_model = NumericalEarth.OceanOnlyModel(ocean; atmosphere)
-simulation = Simulation(coupled_model, Δt=20minutes, stop_time=30days)
+simulation = Simulation(coupled_model; Δt=20minutes, stop_time=start_date + Day(30))
 run!(simulation)
 ```
 

--- a/examples/exploring_era5_reanalysis_data.jl
+++ b/examples/exploring_era5_reanalysis_data.jl
@@ -296,7 +296,10 @@ ax2 = Axis(fig2[1, 1],
            ylabel = "Precipitation [W m⁻²]",
            xticks = (day_ticks, day_labels))
 
-lines!(ax2, precip_col_series.times, precip_W_m2; color=:steelblue, label="ERA5 hourly data")
+## The time axis carries dates; the ticks below count seconds from the first one.
+elapsed_seconds(times) = (times .- first(dates)) ./ Second(1)
+
+lines!(ax2, elapsed_seconds(precip_col_series.times), precip_W_m2; color=:steelblue, label="ERA5 hourly data")
 hlines!(ax2, [21.0]; color=:black, linestyle=:dash, label="van Zanten mean (21 W m⁻²)")
 
 axislegend(ax2; position=:rt)
@@ -382,8 +385,8 @@ ax_qr = Axis(fig3[2, 1],
              ylabel = "Height [m]",
              xticks = (day_ticks, day_labels))
 
-hm_qc = heatmap!(ax_qc, qᶜ_col_series.times, z_col, qᶜ_data; colormap=:Blues)
-hm_qr = heatmap!(ax_qr, qʳ_col_series.times, z_col, qʳ_data; colormap=:Blues)
+hm_qc = heatmap!(ax_qc, elapsed_seconds(qᶜ_col_series.times), z_col, qᶜ_data; colormap=:Blues)
+hm_qr = heatmap!(ax_qr, elapsed_seconds(qʳ_col_series.times), z_col, qʳ_data; colormap=:Blues)
 
 Colorbar(fig3[1, 2], hm_qc, label="qᶜˡ [g kg⁻¹]")
 Colorbar(fig3[2, 2], hm_qr, label="qʳ [g kg⁻¹]")

--- a/examples/generate_surface_fluxes.jl
+++ b/examples/generate_surface_fluxes.jl
@@ -48,7 +48,7 @@ save("ECCO_continents.png", fig)
 # (at 00:00 AM and 03:00 AM), by using `time_indices_in_memory = 2`.
 
 atmosphere = JRA55PrescribedAtmosphere(; time_indices_in_memory = 2)
-ocean = ocean_simulation(grid, closure=nothing)
+ocean = ocean_simulation(grid; start_date = atmosphere.clock.time, closure = nothing)
 
 # Now that we have an atmosphere and ocean, we `set!` the ocean temperature and salinity
 # to the ECCO2 data by first creating T, S metadata objects,

--- a/examples/mediterranean_simulation_with_ecco_restoring.jl
+++ b/examples/mediterranean_simulation_with_ecco_restoring.jl
@@ -84,7 +84,7 @@ FS = ECCO_restoring_forcing(:salinity;    start_date, end_date, architecture = G
 # We construct an ocean simulation that evolves two tracers, temperature (:T), salinity (:S)
 # and we pass the previously defined forcing that nudge these tracers.
 
-ocean = ocean_simulation(grid; forcing = (T = FT, S = FS))
+ocean = ocean_simulation(grid; start_date, forcing = (T = FT, S = FS))
 
 # Initializing the model
 #
@@ -138,11 +138,11 @@ ocean.callbacks[:wizard] = Callback(wizard, IterationInterval(10))
 
 # Let's reset the maximum number of iterations
 ocean.stop_iteration = Inf
-ocean.stop_time = 200days
+ocean.stop_time = start_date + Day(200)
 
 ocean.output_writers[:surface_fields] = JLD2Writer(ocean.model, merge(model.velocities, model.tracers);
                                                    indices = (:, :, Nz),
-                                                   schedule = TimeInterval(1days),
+                                                   schedule = TimeInterval(Day(1)),
                                                    overwrite_existing = true,
                                                    including = [:grid],
                                                    filename = "med_surface_field")

--- a/examples/meridional_heat_transport_ecco.jl
+++ b/examples/meridional_heat_transport_ecco.jl
@@ -28,14 +28,15 @@ free_surface       = SplitExplicitFreeSurface(grid; substeps=70)
 momentum_advection = WENOVectorInvariant(order=5)
 tracer_advection   = WENO(order=5)
 vertical_mixing = NumericalEarth.Oceans.default_ocean_closure()
-ocean = ocean_simulation(grid; momentum_advection, tracer_advection, free_surface,
-                         closure=(vertical_mixing,))
-sea_ice = sea_ice_simulation(grid, ocean; advection=tracer_advection)
+start_date = DateTime(1993, 1, 1)
 
-date = DateTime(1993, 1, 1)
+ocean = ocean_simulation(grid; start_date, momentum_advection, tracer_advection, free_surface,
+                         closure=(vertical_mixing,))
+sea_ice = sea_ice_simulation(grid, ocean; start_date, advection=tracer_advection)
+
 ecco_set = MetadataSet(:temperature, :salinity,
                        :sea_ice_thickness, :sea_ice_concentration;
-                       dataset = ECCO4Monthly(), date)
+                       dataset = ECCO4Monthly(), date = start_date)
 
 set!(ocean.model,   ecco_set)   # T, S
 set!(sea_ice.model, ecco_set)   # h, ℵ
@@ -45,7 +46,7 @@ land       = JRA55PrescribedLand(arch)
 radiation  = JRA55PrescribedRadiation(arch)
 esm = OceanSeaIceModel(ocean, sea_ice; atmosphere, land, radiation)
 
-simulation = Simulation(esm; Δt=20minutes, stop_time=5*365days)
+simulation = Simulation(esm; Δt=20minutes, stop_time=start_date + Year(5))
 
 wall_time = Ref(time_ns())
 
@@ -78,7 +79,7 @@ add_callback!(simulation, progress, IterationInterval(200))
 mht = Field(meridional_heat_transport(esm))
 
 ocean.output_writers[:mth] = JLD2Writer(ocean.model, (; mht);
-                                        schedule = TimeInterval(3hours),
+                                        schedule = TimeInterval(Hour(3)),
                                         filename = "ocean_one_degree_mht",
                                         overwrite_existing = true)
 

--- a/examples/near_global_ocean_simulation.jl
+++ b/examples/near_global_ocean_simulation.jl
@@ -73,15 +73,15 @@ nothing #hide
 #
 # We build our ocean model using `ocean_simulation`,
 
-ocean = ocean_simulation(grid)
+start_date = DateTime(1992, 1, 1)
+ocean = ocean_simulation(grid; start_date)
 
 # which uses the default `ocean.model`,
 
 ocean.model
 
-# We initialize the ocean model with ECCO4 temperature and salinity for January 1, 1992.
-date = DateTime(1992, 1, 1)
-set!(ocean.model, MetadataSet(:temperature, :salinity; dataset=ECCO4Monthly(), date))
+# We initialize the ocean model with ECCO4 temperature and salinity for the date the run opens at.
+set!(ocean.model, MetadataSet(:temperature, :salinity; dataset=ECCO4Monthly(), date=start_date))
 
 # ### Prescribed atmosphere and radiation
 #
@@ -102,7 +102,7 @@ coupled_model = OceanOnlyModel(ocean; atmosphere, land, radiation)
 
 # We then create a coupled simulation.
 
-simulation = Simulation(coupled_model; Δt=25minutes, stop_time=60days)
+simulation = Simulation(coupled_model; Δt=25minutes, stop_time=start_date + Day(60))
 
 # We define a callback function to monitor the simulation's progress,
 
@@ -131,7 +131,7 @@ function progress(sim)
     wall_time[] = time_ns()
 end
 
-simulation.callbacks[:progress] = Callback(progress, TimeInterval(5days))
+simulation.callbacks[:progress] = Callback(progress, TimeInterval(Day(5)))
 
 # ### Set up output writers
 #
@@ -142,7 +142,7 @@ simulation.callbacks[:progress] = Callback(progress, TimeInterval(5days))
 
 outputs = merge(ocean.model.tracers, ocean.model.velocities)
 ocean.output_writers[:surface] = JLD2Writer(ocean.model, outputs;
-                                            schedule = TimeInterval(1days),
+                                            schedule = TimeInterval(Day(1)),
                                             including = [:grid],
                                             filename = "near_global_surface_fields",
                                             indices = (:, :, grid.Nz),
@@ -199,7 +199,7 @@ sn = @lift begin
 end
 
 title = @lift string("Near-global 1/4 degree ocean simulation after ",
-                     prettytime(times[$n] - times[1]))
+                     prettytime((times[$n] - times[1]) / Second(1)))
 
 λ, φ, _ = nodes(T) # T, e, and s all live on the same grid locations
 

--- a/examples/one_degree_simulation.jl
+++ b/examples/one_degree_simulation.jl
@@ -64,7 +64,9 @@ free_surface       = SplitExplicitFreeSurface(grid; substeps=70)
 momentum_advection = WENOVectorInvariant(order=5)
 tracer_advection   = WENO(order=5)
 
-ocean = ocean_simulation(grid; momentum_advection, tracer_advection, free_surface,
+start_date = DateTime(1993, 1, 1)
+
+ocean = ocean_simulation(grid; start_date, momentum_advection, tracer_advection, free_surface,
                          closure=(eddy_closure, vertical_mixing))
 
 @info "We've built an ocean simulation with model:"
@@ -76,15 +78,14 @@ ocean = ocean_simulation(grid; momentum_advection, tracer_advection, free_surfac
 # EVP rheology and a zero-layer thermodynamic model that advances thickness
 # and concentration.
 
-sea_ice = sea_ice_simulation(grid, ocean; advection=tracer_advection)
+sea_ice = sea_ice_simulation(grid, ocean; start_date, advection=tracer_advection)
 
 # ### Initial condition
 
 # We initialize the ocean and sea ice models with data from the ECCO state estimate.
 
-date = DateTime(1993, 1, 1)
 ecco_variables = (:temperature, :salinity, :sea_ice_thickness, :sea_ice_concentration)
-ecco_set = MetadataSet(ecco_variables; dataset = ECCO4Monthly(), date)
+ecco_set = MetadataSet(ecco_variables; dataset = ECCO4Monthly(), date = start_date)
 
 # A single MetadataSet drives both components; variables not in
 # `variable_glossary` for a given model fall through silently.
@@ -114,7 +115,7 @@ radiation = JRA55PrescribedRadiation(arch; ocean_surface)
 # With Runge-Kutta 3rd order time-stepping we can safely use a timestep of 20 minutes.
 
 coupled_model = OceanSeaIceModel(ocean, sea_ice; atmosphere, land, radiation)
-simulation = Simulation(coupled_model; Δt=20minutes, stop_time=90days)
+simulation = Simulation(coupled_model; Δt=20minutes, stop_time=start_date + Day(90))
 
 # ### A progress messenger
 #
@@ -147,7 +148,7 @@ function progress(sim)
 end
 
 # And add it as a callback to the simulation.
-add_callback!(simulation, progress, TimeInterval(5days))
+add_callback!(simulation, progress, TimeInterval(Day(5)))
 
 # ### Output
 #
@@ -164,18 +165,18 @@ sea_ice_outputs = merge((h = sea_ice.model.ice_thickness,
                          sea_ice.model.velocities)
 
 ocean.output_writers[:surface] = JLD2Writer(ocean.model, ocean_outputs;
-                                            schedule = TimeInterval(1days),
+                                            schedule = TimeInterval(Day(1)),
                                             filename = "ocean_one_degree_surface_fields",
                                             indices = (:, :, grid.Nz),
                                             overwrite_existing = true)
 
 ocean.output_writers[:free_surface] = JLD2Writer(ocean.model, (; η = free_surface);
-                                                 schedule = TimeInterval(1days),
+                                                 schedule = TimeInterval(Day(1)),
                                                  filename = "ocean_one_degree_free_surface",
                                                  overwrite_existing = true)
 
 sea_ice.output_writers[:surface] = JLD2Writer(sea_ice.model, sea_ice_outputs;
-                                              schedule = TimeInterval(1days),
+                                              schedule = TimeInterval(Day(1)),
                                               filename = "sea_ice_one_degree_surface_fields",
                                               overwrite_existing = true)
 
@@ -274,7 +275,7 @@ end
 # sea ice speed and the effective sea ice thickness.
 fig = Figure(size=(900, 750))
 
-title = @lift string("Global 1ᵒ ocean simulation after ", prettytime(times[$n] - times[1]))
+title = @lift string("Global 1ᵒ ocean simulation after ", prettytime((times[$n] - times[1]) / Second(1)))
 
 axso = Axis(fig[1, 1])
 axηo = Axis(fig[1, 3])

--- a/examples/single_column_os_papa_simulation.jl
+++ b/examples/single_column_os_papa_simulation.jl
@@ -43,7 +43,10 @@ grid = RectilinearGrid(size = 200,
 # Next, we use NumericalEarth's `ocean_simulation` constructor to build a realistic
 # ocean simulation on the single-column grid,
 
-ocean = ocean_simulation(grid; Δt=10minutes, coriolis=FPlane(latitude = φ★))
+start_date = DateTime(1990, 1, 1)
+stop_date  = DateTime(1990, 1, 31) # Last day of the simulation
+
+ocean = ocean_simulation(grid; start_date, Δt=10minutes, coriolis=FPlane(latitude = φ★))
 
 # which wraps around the ocean model
 
@@ -64,11 +67,11 @@ set!(ocean.model, T=Metadatum(:temperature, dataset=GLORYSMonthly(), region=col)
 # which is based on the JRA55 reanalysis.
 
 atmosphere = JRA55PrescribedAtmosphere(region   = Column(λ★, φ★),
-                                       end_date = DateTime(1990, 1, 31), # Last day of the simulation
+                                       end_date = stop_date,
                                        time_indices_in_memory = 1000)
 
 radiation = JRA55PrescribedRadiation(region   = Column(λ★, φ★),
-                                     end_date = DateTime(1990, 1, 31),
+                                     end_date = stop_date,
                                      time_indices_in_memory = 1000)
 
 # This builds a representation of the atmosphere on the small grid
@@ -81,7 +84,7 @@ ua = interior(atmosphere.velocities.u, 1, 1, 1, :)
 va = interior(atmosphere.velocities.v, 1, 1, 1, :)
 Ta = interior(atmosphere.temperature, 1, 1, 1, :)
 qa = interior(atmosphere.specific_humidity, 1, 1, 1, :)
-t_days = atmosphere.times / days
+t_days = (atmosphere.times .- start_date) ./ Day(1)
 
 using CairoMakie
 
@@ -105,7 +108,7 @@ current_figure()
 
 # We continue constructing a simulation.
 coupled_model = OceanOnlyModel(ocean; atmosphere, radiation)
-simulation = Simulation(coupled_model, Δt=ocean.Δt, stop_time=30days)
+simulation = Simulation(coupled_model; Δt=ocean.Δt, stop_time=stop_date)
 
 wall_clock = Ref(time_ns())
 
@@ -253,7 +256,7 @@ Label(fig[0, 1:6], title)
 
 n = Observable(1)
 
-times = (times .- times[1]) ./days
+times = (times .- times[1]) ./ Day(1)
 Nt = length(times)
 tn = @lift times[$n]
 

--- a/examples/veros_ocean_forced_simulation.jl
+++ b/examples/veros_ocean_forced_simulation.jl
@@ -11,6 +11,7 @@ using NumericalEarth
 using PythonCall
 using Oceananigans, Oceananigans.Units
 using CairoMakie
+using Dates
 using Printf
 
 # We import the Veros 4 degree ocean simulation setup, which consists of a near-global ocean
@@ -80,8 +81,9 @@ radiation = JRA55PrescribedRadiation()
 
 # The coupled ocean--atmosphere model. We do not couple an ice model for simplicity.
 
+start_date = atmos.clock.time
 coupled_model = OceanSeaIceModel(ocean, nothing; atmosphere=atmos, radiation)
-simulation = Simulation(coupled_model; Δt = 30minutes, stop_time = 60days)
+simulation = Simulation(coupled_model; Δt = 30minutes, stop_time = start_date + Day(60))
 
 # We set up a progress callback that will print the current time, iteration, and maximum velocities
 # every 10days. We also set up another callback that collects the surface prognostic variables
@@ -116,7 +118,7 @@ function save_variables(sim)
     push!(v, deepcopy(sim.model.interfaces.exchanger.ocean.state.v))
 end
 
-add_callback!(simulation, progress, TimeInterval(10days))
+add_callback!(simulation, progress, TimeInterval(Day(10)))
 add_callback!(simulation, save_variables, IterationInterval(10))
 
 # Let's run the simulation!

--- a/ext/NumericalEarthSpeedyWeatherExt/speedy_atmosphere_simulations.jl
+++ b/ext/NumericalEarthSpeedyWeatherExt/speedy_atmosphere_simulations.jl
@@ -2,6 +2,9 @@ const SpeedySimulation = SpeedyWeather.Simulation
 const SpeedyEarthSystemModel = NumericalEarth.EarthSystemModel{<:Any, <:SpeedySimulation}
 const SpeedyNoSeaIceEarthSystemModel = NumericalEarth.EarthSystemModel{<:Union{Nothing, NumericalEarth.SeaIces.FreezingLimitedOceanTemperature}, <:SpeedySimulation}
 
+# SpeedyWeather models contain no FieldTimeSeries objects.
+Oceananigans.OutputReaders.extract_field_time_series(::SpeedyWeather.PrimitiveWetModel) = ()
+
 Base.summary(::SpeedySimulation) = "SpeedyWeather.Simulation"
 
 # Take one time-step or more depending on the global timestep

--- a/src/Atmospheres/Atmospheres.jl
+++ b/src/Atmospheres/Atmospheres.jl
@@ -19,8 +19,7 @@ using Oceananigans.Utils: Utils, prettysummary, launch!
 using Thermodynamics.Parameters: AbstractThermodynamicsParameters
 
 using ...NumericalEarth: NumericalEarth
-using ..EarthSystemModels: EarthSystemModels, AbstractPrescribedComponent, set_prescribed_field!
-using ...EarthSystemModels: default_component_clock
+using ..EarthSystemModels: EarthSystemModels, AbstractPrescribedComponent, set_prescribed_field!, default_component_clock
 using ..EarthSystemModels.InterfaceComputations: interface_kernel_parameters, ComponentExchanger
 
 # Can be extended by atmosphere models. `atmosphere_model` builds the model; `atmosphere_simulation`

--- a/src/Atmospheres/Atmospheres.jl
+++ b/src/Atmospheres/Atmospheres.jl
@@ -20,6 +20,7 @@ using Thermodynamics.Parameters: AbstractThermodynamicsParameters
 
 using ...NumericalEarth: NumericalEarth
 using ..EarthSystemModels: EarthSystemModels, AbstractPrescribedComponent, set_prescribed_field!
+using ...EarthSystemModels: default_component_clock
 using ..EarthSystemModels.InterfaceComputations: interface_kernel_parameters, ComponentExchanger
 
 # Can be extended by atmosphere models. `atmosphere_model` builds the model; `atmosphere_simulation`

--- a/src/Atmospheres/prescribed_atmosphere.jl
+++ b/src/Atmospheres/prescribed_atmosphere.jl
@@ -182,7 +182,7 @@ EarthSystemModels.adopt_clock(atmos::PrescribedAtmosphere, clock) = EarthSystemM
 """
     PrescribedAtmosphere(grid, times=[zero(grid)];
                          source = nothing,
-                         clock = Clock{Float64}(time = 0),
+                         clock = default_component_clock(times),
                          surface_layer_height = 10, # meters
                          boundary_layer_height = 512, # meters
                          thermodynamics_parameters = AtmosphereThermodynamicsParameters(eltype(grid)),
@@ -218,7 +218,7 @@ Pass any field explicitly to override; pass `precipitation_flux = nothing` to om
 """
 function PrescribedAtmosphere(grid, times=[zero(grid)];
                               source = nothing,
-                              clock = Clock{Float64}(time = 0),
+                              clock = default_component_clock(times),
                               surface_layer_height = 10,
                               boundary_layer_height = 512,
                               thermodynamics_parameters = AtmosphereThermodynamicsParameters(eltype(grid)),

--- a/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
+++ b/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
@@ -171,7 +171,7 @@ DataWrangling.all_dates(::CopernicusAlbedo, variable) = copernicus_albedo_ten_da
 # 12 climatological months; the year is arbitrary, only the month matters.
 DataWrangling.all_dates(::CopernicusAlbedoClimatology, variable) = [DateTime(2018, m, 1) for m in 1:12]
 
-DataWrangling.default_time_anchor(::CopernicusAlbedoClimatology) = DataWrangling.CalendarPhase()
+DataWrangling.default_time_indexing(::CopernicusAlbedoClimatology) = DataWrangling.CalendarPhase()
 DataWrangling.averaging_window(md::Metadatum{<:CopernicusAlbedoClimatology}) = DataWrangling.calendar_month_window(md)
 
 #####

--- a/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
+++ b/src/DataWrangling/CopernicusLandAlbedo/CopernicusLandAlbedo.jl
@@ -171,6 +171,8 @@ DataWrangling.all_dates(::CopernicusAlbedo, variable) = copernicus_albedo_dekada
 # 12 climatological months; the year is arbitrary, only the month matters.
 DataWrangling.all_dates(::CopernicusAlbedoClimatology, variable) = [DateTime(2018, m, 1) for m in 1:12]
 
+DataWrangling.default_time_anchor(::CopernicusAlbedoClimatology) = DataWrangling.CalendarPhase()
+
 #####
 ##### Filenames (date + variable keyed, region-independent — reused across regions)
 #####

--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -17,7 +17,7 @@ export ERA5HourlySingleLevel, ERA5MonthlySingleLevel, ERA5HourlyPressureLevels, 
 export ERA5HourlyLand, ERA5MonthlyLand
 export native_grid
 export CalendarDate, CalendarPhase, SimulationStart
-export default_time_anchor
+export default_time_indexing
 
 using Adapt: Adapt
 using Downloads: Downloads

--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -16,6 +16,8 @@ export DatasetRestoring, SurfaceFluxRestoring
 export ERA5HourlySingleLevel, ERA5MonthlySingleLevel, ERA5HourlyPressureLevels, ERA5MonthlyPressureLevels
 export ERA5HourlyLand, ERA5MonthlyLand
 export native_grid
+export CalendarDate, CalendarPhase, SimulationStart
+export default_time_anchor
 
 using Adapt: Adapt
 using Downloads: Downloads
@@ -264,6 +266,7 @@ z_interfaces(::AbstractStaticBathymetry) = (0, 1)
 Base.size(dataset::AbstractStaticBathymetry, variable) = size(dataset)
 
 # Fundamentals
+include("time_anchoring.jl")
 include("metadata.jl")
 include("set_region_data.jl")
 include("field_cache.jl")

--- a/src/DataWrangling/JRA55/JRA55_metadata.jl
+++ b/src/DataWrangling/JRA55/JRA55_metadata.jl
@@ -64,6 +64,8 @@ end
 
 DataWrangling.all_dates(::MultiYearJRA55, name) = JRA55_multiple_year_dates[name]
 
+DataWrangling.default_time_anchor(::RepeatYearJRA55) = DataWrangling.CalendarPhase()
+
 # Fallback, if we not provide the name, take the highest frequency
 DataWrangling.all_dates(dataset::JRA55Dataset) = all_dates(dataset, :temperature)
 

--- a/src/DataWrangling/JRA55/JRA55_metadata.jl
+++ b/src/DataWrangling/JRA55/JRA55_metadata.jl
@@ -64,7 +64,7 @@ end
 
 DataWrangling.all_dates(::MultiYearJRA55, name) = JRA55_multiple_year_dates[name]
 
-DataWrangling.default_time_anchor(::RepeatYearJRA55) = DataWrangling.CalendarPhase()
+DataWrangling.default_time_indexing(::RepeatYearJRA55) = DataWrangling.CalendarPhase()
 
 # Fallback, if we not provide the name, take the highest frequency
 DataWrangling.all_dates(dataset::JRA55Dataset) = all_dates(dataset, :temperature)

--- a/src/DataWrangling/WOA/WOA.jl
+++ b/src/DataWrangling/WOA/WOA.jl
@@ -52,7 +52,7 @@ DataWrangling.last_date(::WOAAnnual, args...) = nothing
 # Monthly: 12 climatological months (year is arbitrary, month matters)
 DataWrangling.all_dates(::WOAMonthly, args...) = [DateTime(2018, m, 1) for m in 1:12]
 
-DataWrangling.default_time_anchor(::WOAMonthly) = DataWrangling.CalendarPhase()
+DataWrangling.default_time_indexing(::WOAMonthly) = DataWrangling.CalendarPhase()
 DataWrangling.averaging_window(metadatum::Metadatum{<:WOAMonthly}) = DataWrangling.calendar_month_window(metadatum)
 
 # WOA stores depth as positive values, surface first (0 to 5500m)

--- a/src/DataWrangling/WOA/WOA.jl
+++ b/src/DataWrangling/WOA/WOA.jl
@@ -52,6 +52,8 @@ DataWrangling.last_date(::WOAAnnual, args...) = nothing
 # Monthly: 12 climatological months (year is arbitrary, month matters)
 DataWrangling.all_dates(::WOAMonthly, args...) = [DateTime(2018, m, 1) for m in 1:12]
 
+DataWrangling.default_time_anchor(::WOAMonthly) = DataWrangling.CalendarPhase()
+
 DataWrangling.sample_window(metadatum::Metadatum{<:WOAMonthly}) = DataWrangling.calendar_month_window(metadatum)
 
 # WOA stores depth as positive values, surface first (0 to 5500m)

--- a/src/DataWrangling/metadata.jl
+++ b/src/DataWrangling/metadata.jl
@@ -678,34 +678,11 @@ function Downloads.download(mset::MetadataSet; kwargs...)
 end
 
 """
-    native_times(metadata; start_time=first(metadata).dates)
+    native_times(metadata)
 
-Extract the time values from the given `metadata`, calculate the time difference
-from the `start_time`, and return an array of time differences in seconds.
-
-Argument
-========
-- `metadata`: The metadata containing the date information.
-
-Keyword Argument
-================
-- `start_time`: The start time for calculating the time difference. Defaults to the first
-                date in the metadata.
-
-Times are measured to each sample's [`window_center`](@ref), which for a time average is the
-midpoint of its [`averaging_window`](@ref) rather than the date its file is stamped with.
+The date of each sample in `metadata`, taken at its [`window_center`](@ref).
 """
-function native_times(metadata; start_time=first(metadata).dates)
-    times = zeros(length(metadata))
-    reference = comparable_datetime(start_time)
-
-    for (t, data) in enumerate(metadata)
-        delta = window_center(data) - reference
-        times[t] = Dates.value(Dates.Millisecond(delta)) / 1000
-    end
-
-    return times
-end
+native_times(metadata) = [window_center(datum) for datum in metadata]
 
 """
     averaging_window(metadatum)

--- a/src/DataWrangling/metadata_field_time_series.jl
+++ b/src/DataWrangling/metadata_field_time_series.jl
@@ -1,7 +1,7 @@
 """
     FieldTimeSeries(metadata::Metadata [, arch_or_grid=CPU() ];
                     time_indices_in_memory = 2,
-                    time_indexing = Cyclical(),
+                    time_indexing = default_time_indexing(metadata.dataset),
                     inpainting = nothing,
                     cache_inpainted_data = true)
 
@@ -37,7 +37,7 @@ end
 
 function Oceananigans.OutputReaders.FieldTimeSeries(metadata::Metadata, grid::AbstractGrid;
                                                     time_indices_in_memory = 2,
-                                                    time_indexing = Cyclical(),
+                                                    time_indexing = default_time_indexing(metadata.dataset),
                                                     inpainting = default_inpainting(metadata),
                                                     cache_inpainted_data = true)
 

--- a/src/DataWrangling/restoring.jl
+++ b/src/DataWrangling/restoring.jl
@@ -126,7 +126,7 @@ default_time_indices_in_memory(::Metadatum) = 1
                      rate,
                      mask = 1,
                      time_indices_in_memory = 2, # Not more than this if we want to use GPU!
-                     time_indexing = Cyclical(),
+                     time_indexing = default_time_indexing(metadata.dataset),
                      inpainting = NearestNeighborInpainting(Inf),
                      cache_inpainted_data = true)
 
@@ -177,7 +177,8 @@ Keyword Arguments
                             a trade-off between increased performance (more indices in memory) and reduced
                             memory footprint (fewer indices in memory). Default: 2.
 
-- `time_indexing`: The time indexing scheme for the field time series. Default: `Cyclical()`.
+- `time_indexing`: The time indexing scheme for the field time series. Default: the anchor the dataset
+                   asks for through [`default_time_indexing`](@ref).
 
 - `inpainting`: inpainting algorithm, see [`inpaint_mask!`](@ref). Default: `NearestNeighborInpainting(Inf)`.
 
@@ -189,7 +190,7 @@ function DatasetRestoring(metadata::Metadata,
                           rate,
                           mask = 1,
                           time_indices_in_memory = default_time_indices_in_memory(metadata),
-                          time_indexing = Cyclical(),
+                          time_indexing = default_time_indexing(metadata.dataset),
                           inpainting = NearestNeighborInpainting(Inf),
                           cache_inpainted_data = true,
 						  field_name = oceananigans_fieldnames[metadata.name])

--- a/src/DataWrangling/time_anchoring.jl
+++ b/src/DataWrangling/time_anchoring.jl
@@ -79,9 +79,9 @@ a leap year becomes 28 February.
 """
 function substitute_year(date, target_year)
     month(date) == 2 && day(date) == 29 && !isleapyear(target_year) &&
-        return DateTime(target_year, 2, 28, hour(date), minute(date), second(date))
+        return DateTime(target_year, 2, 28, hour(date), minute(date), second(date), Dates.millisecond(date))
 
-    return DateTime(target_year, month(date), day(date), hour(date), minute(date), second(date))
+    return DateTime(target_year, month(date), day(date), hour(date), minute(date), second(date), Dates.millisecond(date))
 end
 
 """

--- a/src/DataWrangling/time_anchoring.jl
+++ b/src/DataWrangling/time_anchoring.jl
@@ -1,11 +1,14 @@
 using Dates: Dates, DateTime, Millisecond, year, month, day, hour, minute, second, isleapyear
+using Oceananigans.OutputReaders: find_time_index
 
 """
     AbstractTimeAnchor
 
-Supertype for the rules mapping a model date onto a dataset's own time stamps.
+Supertype for the `time_indexing` rules that map a model date onto a dataset's own time stamps.
 """
 abstract type AbstractTimeAnchor end
+
+Oceananigans.OutputReaders.interpolating_time_indices(anchor::AbstractTimeAnchor, times, t) = find_time_index(times, lookup_date(anchor, t, times))
 
 """
     CalendarDate()
@@ -49,10 +52,10 @@ function lookup_date(::CalendarDate, model_date, dates)
 
     folded = model_date
     while folded > last_stamp
-        folded = shift_years(folded, -cycle_years)
+        folded = substitute_year(folded, year(folded) - cycle_years)
     end
     while folded < first_stamp
-        folded = shift_years(folded, cycle_years)
+        folded = substitute_year(folded, year(folded) + cycle_years)
     end
 
     return folded
@@ -82,19 +85,12 @@ function substitute_year(date, target_year)
 end
 
 """
-    shift_years(date, n)
+    default_time_indexing(dataset)
 
-`date` shifted by `n` whole calendar years.
+The `time_indexing` `dataset` uses unless the caller overrides it. Climatologies, whose nominal year carries no
+meaning, extend this with `CalendarPhase()`.
 """
-shift_years(date, n) = substitute_year(date, year(date) + n)
-
-"""
-    default_time_anchor(dataset)
-
-The anchor `dataset` uses unless the caller overrides it. Climatologies, whose nominal year carries no meaning,
-extend this with `CalendarPhase()`.
-"""
-default_time_anchor(dataset) = CalendarDate()
+default_time_indexing(dataset) = CalendarDate()
 
 """
     validate_time_anchors(anchored_series)

--- a/src/DataWrangling/time_anchoring.jl
+++ b/src/DataWrangling/time_anchoring.jl
@@ -1,0 +1,111 @@
+using Dates: Dates, DateTime, Millisecond, year, month, day, hour, minute, second, isleapyear
+
+"""
+    AbstractTimeAnchor
+
+Supertype for the rules mapping a model date onto a dataset's own time stamps.
+"""
+abstract type AbstractTimeAnchor end
+
+"""
+    CalendarDate()
+
+Read a dataset at the model's own date, folding back by whole calendar years once the model passes the end of
+the record.
+"""
+struct CalendarDate <: AbstractTimeAnchor end
+
+"""
+    CalendarPhase()
+
+Read a dataset at the model's month, day and time of day resolved in the dataset's own year. A model 29 February
+reads 28 February.
+"""
+struct CalendarPhase <: AbstractTimeAnchor end
+
+"""
+    SimulationStart(start_date)
+
+Read a dataset from its first record at `start_date`, advancing by elapsed time and wrapping by the span of the
+record.
+"""
+struct SimulationStart{D} <: AbstractTimeAnchor
+    start_date :: D
+end
+
+"""
+    lookup_date(anchor, model_date, dates)
+
+The date at which a dataset stamped at `dates` is read for a model at `model_date`.
+"""
+function lookup_date end
+
+function lookup_date(::CalendarDate, model_date, dates)
+    first_stamp, last_stamp = first(dates), last(dates)
+    first_stamp <= model_date <= last_stamp && return model_date
+
+    cycle_years = year(last_stamp) - year(first_stamp)
+    cycle_years < 1 && return model_date
+
+    folded = model_date
+    while folded > last_stamp
+        folded = shift_years(folded, -cycle_years)
+    end
+    while folded < first_stamp
+        folded = shift_years(folded, cycle_years)
+    end
+
+    return folded
+end
+
+lookup_date(::CalendarPhase, model_date, dates) = substitute_year(model_date, year(first(dates)))
+
+function lookup_date(anchor::SimulationStart, model_date, dates)
+    elapsed = Dates.value(Millisecond(model_date - anchor.start_date))
+    # The record runs to the end of the interval its final stamp stands for, so a repeat year ending 31 December
+    # 21:00 at 3-hourly spacing spans 365 days rather than 364 days 21 hours.
+    span = Dates.value(Millisecond(last(dates) - first(dates)) + Millisecond(last(dates) - dates[end - 1]))
+    return first(dates) + Millisecond(mod(elapsed, span))
+end
+
+"""
+    substitute_year(date, target_year)
+
+`date` moved into `target_year`, keeping month, day and time of day. A 29 February moved into a year that is not
+a leap year becomes 28 February.
+"""
+function substitute_year(date, target_year)
+    month(date) == 2 && day(date) == 29 && !isleapyear(target_year) &&
+        return DateTime(target_year, 2, 28, hour(date), minute(date), second(date))
+
+    return DateTime(target_year, month(date), day(date), hour(date), minute(date), second(date))
+end
+
+"""
+    shift_years(date, n)
+
+`date` shifted by `n` whole calendar years.
+"""
+shift_years(date, n) = substitute_year(date, year(date) + n)
+
+"""
+    default_time_anchor(dataset)
+
+The anchor `dataset` uses unless the caller overrides it. Climatologies, whose nominal year carries no meaning,
+extend this with `CalendarPhase()`.
+"""
+default_time_anchor(dataset) = CalendarDate()
+
+"""
+    validate_time_anchors(anchored_series)
+
+Throw if the `(name, anchor)` pairs in `anchored_series` cannot hold a common phase.
+"""
+function validate_time_anchors(anchored_series)
+    unanchored = [name for (name, anchor) in anchored_series if anchor isa SimulationStart]
+
+    isempty(unanchored) && return nothing
+    length(unanchored) == 1 && length(anchored_series) == 1 && return nothing
+
+    throw(ArgumentError("$(first(unanchored)) uses SimulationStart, which drifts unless it is the only series"))
+end

--- a/src/DataWrangling/time_anchoring.jl
+++ b/src/DataWrangling/time_anchoring.jl
@@ -1,5 +1,7 @@
-using Dates: Dates, DateTime, Millisecond, year, month, day, hour, minute, second, isleapyear
-using Oceananigans.OutputReaders: find_time_index
+using Dates: Dates, DateTime, Millisecond, UTInstant, year, isleapyear
+using Oceananigans.OutputReaders: Cyclical, PartlyInMemory, find_time_index, memory_index, time_index
+
+const MILLISECONDS_PER_DAY = 86_400_000
 
 """
     AbstractTimeAnchor
@@ -8,7 +10,12 @@ Supertype for the `time_indexing` rules that map a model date onto a dataset's o
 """
 abstract type AbstractTimeAnchor end
 
-Oceananigans.OutputReaders.interpolating_time_indices(anchor::AbstractTimeAnchor, times, t) = find_time_index(times, lookup_date(anchor, t, times))
+@inline Oceananigans.OutputReaders.interpolating_time_indices(anchor::AbstractTimeAnchor, times, t) =
+    find_time_index(times, lookup_date(anchor, t, times))
+
+# An anchor folds a model date back into the record, so a chunked backend wraps the way `Cyclical` does.
+@inline Oceananigans.OutputReaders.time_index(backend::PartlyInMemory, ::AbstractTimeAnchor, Nt, m) = time_index(backend, Cyclical(), Nt, m)
+@inline Oceananigans.OutputReaders.memory_index(backend::PartlyInMemory, ::AbstractTimeAnchor, Nt, n) = memory_index(backend, Cyclical(), Nt, n)
 
 """
     CalendarDate()
@@ -43,7 +50,7 @@ The date at which a dataset stamped at `dates` is read for a model at `model_dat
 """
 function lookup_date end
 
-function lookup_date(::CalendarDate, model_date, dates)
+@inline function lookup_date(::CalendarDate, model_date, dates)
     first_stamp, last_stamp = first(dates), last(dates)
     first_stamp <= model_date <= last_stamp && return model_date
 
@@ -61,9 +68,9 @@ function lookup_date(::CalendarDate, model_date, dates)
     return folded
 end
 
-lookup_date(::CalendarPhase, model_date, dates) = substitute_year(model_date, year(first(dates)))
+@inline lookup_date(::CalendarPhase, model_date, dates) = substitute_year(model_date, year(first(dates)))
 
-function lookup_date(anchor::SimulationStart, model_date, dates)
+@inline function lookup_date(anchor::SimulationStart, model_date, dates)
     elapsed = Dates.value(Millisecond(model_date - anchor.start_date))
     # The record runs to the end of the interval its final stamp stands for, so a repeat year ending 31 December
     # 21:00 at 3-hourly spacing spans 365 days rather than 364 days 21 hours.
@@ -77,11 +84,13 @@ end
 `date` moved into `target_year`, keeping month, day and time of day. A 29 February moved into a year that is not
 a leap year becomes 28 February.
 """
-function substitute_year(date, target_year)
-    month(date) == 2 && day(date) == 29 && !isleapyear(target_year) &&
-        return DateTime(target_year, 2, 28, hour(date), minute(date), second(date), Dates.millisecond(date))
+@inline function substitute_year(date, target_year)
+    y, m, d = Dates.yearmonthday(date)
+    # Day counts, not the validating `DateTime` constructor: its error string does not compile for the GPU.
+    milliseconds_in_day = Dates.value(date) - MILLISECONDS_PER_DAY * Dates.totaldays(y, m, d)
+    d = ifelse(m == 2 && d == 29 && !isleapyear(target_year), 28, d)
 
-    return DateTime(target_year, month(date), day(date), hour(date), minute(date), second(date), Dates.millisecond(date))
+    return DateTime(UTInstant(Millisecond(MILLISECONDS_PER_DAY * Dates.totaldays(target_year, m, d) + milliseconds_in_day)))
 end
 
 """
@@ -98,7 +107,7 @@ default_time_indexing(dataset) = CalendarDate()
 Throw if the `(name, anchor)` pairs in `anchored_series` cannot hold a common phase.
 """
 function validate_time_anchors(anchored_series)
-    unanchored = [name for (name, anchor) in anchored_series if anchor isa SimulationStart]
+    unanchored = [series_name for (series_name, anchor) in anchored_series if anchor isa SimulationStart]
 
     isempty(unanchored) && return nothing
     length(unanchored) == 1 && length(anchored_series) == 1 && return nothing

--- a/src/EarthSystemModels/EarthSystemModels.jl
+++ b/src/EarthSystemModels/EarthSystemModels.jl
@@ -39,11 +39,13 @@ export
     ThreeEquationHeatFlux,
     # Friction velocity formulations
     MomentumBasedFrictionVelocity,
+    default_simulation_clock,
     default_stop_time
 
 import Dates
 using ClimaSeaIce.SeaIceThermodynamics: melting_temperature
 using DocStringExtensions: TYPEDSIGNATURES
+using GPUArraysCore: @allowscalar
 using KernelAbstractions: @kernel, @index
 using Thermodynamics: Thermodynamics as AtmosphericThermodynamics
 
@@ -55,6 +57,15 @@ using Oceananigans.Fields: ZeroField
 using Oceananigans.Simulations: reset_clock!, Simulation
 using Oceananigans.TimeSteppers: Clock, reset!, tick!, time_step!, update_state!, reconcile_state!
 using Oceananigans.Utils: launch!, prettytime
+
+"""
+$(TYPEDSIGNATURES)
+
+The clock a component `Simulation` keeps time with: numeric and starting at zero without a `start_date`, on the
+calendar with one.
+"""
+default_simulation_clock(grid, start_date) = Clock(time = start_date)
+default_simulation_clock(grid, ::Nothing) = Clock(grid)
 
 # Reactant does not support `stop_time`; it must stay `nothing` there.
 default_stop_time(grid, clock) = default_stop_time(architecture(grid), clock)

--- a/src/EarthSystemModels/components.jl
+++ b/src/EarthSystemModels/components.jl
@@ -137,11 +137,11 @@ end
 
 same_time_type(::TT, ::ST) where {TT, ST} = ST === TT
 
-# Return a clock matching `clock`'s time type (or nothing if clocks are the same)
+# Return a clock reading the same time, in the same type, as `clock` (or nothing if the component's already does)
 function matching_clock(old::Clock, clock)
-    same_time_type(old.time, clock.time) && return nothing
+    same_time_type(old.time, clock.time) && old.time == clock.time && return nothing
     TT = typeof(clock.time)
-    return Clock{TT}(time = convert(TT, old.time),
+    return Clock{TT}(time = clock.time,
                      last_Δt = old.last_Δt,
                      last_stage_Δt = old.last_stage_Δt,
                      iteration = old.iteration,
@@ -155,7 +155,7 @@ warn_clock_coercion(component, new_clock) = @warn string(summary(component), " t
 function reclock(component, clock)
     new_clock = matching_clock(component.clock, clock)
     isnothing(new_clock) && return component
-    warn_clock_coercion(component, new_clock)
+    same_time_type(component.clock.time, new_clock.time) || warn_clock_coercion(component, new_clock)
     names = fieldnames(typeof(component))
     args = ntuple(i -> names[i] === :clock ? new_clock : getfield(component, i), length(names))
     return typeof(component).name.wrapper(args...)

--- a/src/EarthSystemModels/earth_system_model.jl
+++ b/src/EarthSystemModels/earth_system_model.jl
@@ -4,9 +4,10 @@ using Oceananigans.TimeSteppers: Clock
 using Oceananigans.OutputReaders: extract_field_time_series
 using KernelAbstractions: @kernel, @index
 
-mutable struct EarthSystemModel{R, A, L, I, O, F, C, Arch} <: AbstractModel{Nothing, Arch}
+mutable struct EarthSystemModel{R, A, L, I, O, F, C, T, Arch} <: AbstractModel{Nothing, Arch}
     architecture :: Arch
     clock :: C
+    start_time :: T
     radiation :: R
     atmosphere :: A
     land :: L
@@ -79,16 +80,21 @@ Oceananigans.OutputWriters.default_included_properties(::ESM) = tuple()
 Oceananigans.Utils.prettytime(model::ESM) = prettytime(model.clock.time)
 default_clock(TT) = Clock{TT}(0, 0, 1)
 
-Oceananigans.Simulations.reset_clock!(::Nothing) = nothing
 Oceananigans.TimeSteppers.update_state!(::Nothing) = nothing
-Oceananigans.Simulations.reset_clock!(component::Simulation) = reset_clock!(component.model)
-Oceananigans.Simulations.reset_clock!(component) = reset!(getproperty(component, :clock))
+
+# A clock on a calendar has no zero to rewind to, so the coupled model hands every clock the date it opened at.
+# TODO: an Oceananigans `Clock` could carry its own starting time, which would make this a plain `reset!`.
+function rewind_clock!(clock, start_time)
+    reset!(clock)
+    clock.time = start_time
+    return nothing
+end
 
 function Oceananigans.Simulations.reset_clock!(model::ESM)
-    reset!(model.clock)
+    rewind_clock!(model.clock, model.start_time)
 
     for component in components(model)
-        reset_clock!(component)
+        rewind_clock!(component_model(component).clock, model.start_time)
     end
 
     # Keep prescribed atmospheric forcing synchronized during component resets.
@@ -170,14 +176,17 @@ $(TYPEDSIGNATURES)
 
 Return the coupled model's default clock. A `Simulation` atmosphere's clock type is fixed
 by its grid and cannot be coerced, so the coupled clock adopts it (e.g. a `Float32`
-atmosphere gets a `Float32` coupled clock). An atmosphere carrying its own clock hands over
-both its time type and its starting time; with no atmosphere the clock is `Float64` at zero.
+atmosphere gets a `Float32` coupled clock). An atmosphere on a calendar hands over both its
+time type and its starting date, so the coupled model opens where the atmospheric record
+does. Anything else gives `Float64` at zero.
 """
 default_earth_system_clock(atmosphere::Simulation) = Clock{typeof(component_model(atmosphere).clock.time)}(time = 0)
 
 function default_earth_system_clock(atmosphere)
     hasproperty(atmosphere, :clock) || return Clock{Float64}(time = 0)
-    return Clock{typeof(atmosphere.clock.time)}(time = atmosphere.clock.time)
+    atmosphere_time = atmosphere.clock.time
+    return atmosphere_time isa Dates.AbstractTime ? Clock{typeof(atmosphere_time)}(time = atmosphere_time) :
+                                                    Clock{Float64}(time = 0)
 end
 
 """
@@ -186,7 +195,7 @@ end
 A `Clock` keeping time in the same type as `times`, started at the first sample.
 """
 default_component_clock(times) = Clock{Float64}(time = 0)
-default_component_clock(times::AbstractArray{<:Dates.AbstractTime}) = Clock{eltype(times)}(time = first(times))
+default_component_clock(times::AbstractArray{<:Dates.AbstractTime}) = Clock{eltype(times)}(time = @allowscalar first(times))
 
 """
     materialize_sea_ice(sea_ice, ocean)
@@ -317,6 +326,7 @@ function EarthSystemModel(radiation, atmosphere, land, sea_ice, ocean;
 
     earth_system_model = EarthSystemModel(arch,
                                           clock,
+                                          clock.time,
                                           radiation,
                                           atmosphere,
                                           land,

--- a/src/EarthSystemModels/earth_system_model.jl
+++ b/src/EarthSystemModels/earth_system_model.jl
@@ -170,12 +170,23 @@ $(TYPEDSIGNATURES)
 
 Return the coupled model's default clock. A `Simulation` atmosphere's clock type is fixed
 by its grid and cannot be coerced, so the coupled clock adopts it (e.g. a `Float32`
-atmosphere gets a `Float32` coupled clock). Otherwise the clock defaults to `Float64`:
-prescribed atmospheres carry a coercible clock, so `adopt_clock` reconciles them to the
-authoritative model clock rather than the other way around.
+atmosphere gets a `Float32` coupled clock). An atmosphere carrying its own clock hands over
+both its time type and its starting time; with no atmosphere the clock is `Float64` at zero.
 """
 default_earth_system_clock(atmosphere::Simulation) = Clock{typeof(component_model(atmosphere).clock.time)}(time = 0)
-default_earth_system_clock(atmosphere) = Clock{Float64}(time = 0)
+
+function default_earth_system_clock(atmosphere)
+    hasproperty(atmosphere, :clock) || return Clock{Float64}(time = 0)
+    return Clock{typeof(atmosphere.clock.time)}(time = atmosphere.clock.time)
+end
+
+"""
+    default_component_clock(times)
+
+A `Clock` keeping time in the same type as `times`, started at the first sample.
+"""
+default_component_clock(times) = Clock{Float64}(time = 0)
+default_component_clock(times::AbstractArray{<:Dates.AbstractTime}) = Clock{eltype(times)}(time = first(times))
 
 """
     materialize_sea_ice(sea_ice, ocean)

--- a/src/Lands/Lands.jl
+++ b/src/Lands/Lands.jl
@@ -50,8 +50,7 @@ using Oceananigans.Units: Time
 using Oceananigans.Utils: launch!, prettysummary, prettytime
 
 using ..NumericalEarth: NumericalEarth, stateindex
-using ..EarthSystemModels: EarthSystemModels, AbstractPrescribedComponent, surface_temperature
-using ...EarthSystemModels: default_component_clock
+using ..EarthSystemModels: EarthSystemModels, AbstractPrescribedComponent, surface_temperature, default_component_clock
 using ..EarthSystemModels.InterfaceComputations: interface_kernel_parameters, ComponentExchanger
 
 # Closure interfaces

--- a/src/Lands/Lands.jl
+++ b/src/Lands/Lands.jl
@@ -51,6 +51,7 @@ using Oceananigans.Utils: launch!, prettysummary, prettytime
 
 using ..NumericalEarth: NumericalEarth, stateindex
 using ..EarthSystemModels: EarthSystemModels, AbstractPrescribedComponent, surface_temperature
+using ...EarthSystemModels: default_component_clock
 using ..EarthSystemModels.InterfaceComputations: interface_kernel_parameters, ComponentExchanger
 
 # Closure interfaces

--- a/src/Lands/prescribed_land.jl
+++ b/src/Lands/prescribed_land.jl
@@ -47,7 +47,7 @@ function PrescribedLand(freshwater_flux; clock=nothing, river_routing=nothing)
     times = first_flux.times
 
     if isnothing(clock)
-        clock = Clock{eltype(first_flux)}(time=0)
+        clock = default_component_clock(times)
     end
 
     land = PrescribedLand(grid, clock, freshwater_flux, times, river_routing)

--- a/src/Oceans/Oceans.jl
+++ b/src/Oceans/Oceans.jl
@@ -35,6 +35,7 @@ using ..EarthSystemModels: EarthSystemModels,
                            ocean_surface_velocities,
                            ocean_surface_salinity,
                            DegreesKelvin,
+                           default_simulation_clock,
                            default_stop_time,
                            heat_capacity
 using ..EarthSystemModels.InterfaceComputations: InterfaceComputations, ComponentExchanger

--- a/src/Oceans/nonhydrostatic_ocean_simulation.jl
+++ b/src/Oceans/nonhydrostatic_ocean_simulation.jl
@@ -2,7 +2,8 @@ using SeawaterPolynomials.TEOS10: TEOS10EquationOfState
 
 """
     nonhydrostatic_ocean_simulation(grid;
-                                    clock = Clock(grid),
+                                    start_date = nothing,
+                                    clock = default_simulation_clock(grid, start_date),
                                     stop_time = default_stop_time(grid, clock),
                                     Δt = 1,
                                     closure = nothing,
@@ -25,8 +26,9 @@ timestepping is needed.
 
 ## Keyword Arguments
 
-- `clock`: Clock for the underlying model. Defaults to `Clock(grid)`, a numeric clock starting at `time = 0`. 
-  Pass a `DateTime`-based clock to step the simulation in calendar time (e.g. when coupling).
+- `start_date`: Date the simulation opens at. Defaults to `nothing`, a numeric clock starting at `time = 0`.
+  Pass a date to step the simulation in calendar time, which a coupled model driven by dated data requires.
+- `clock`: Clock for the underlying model. Defaults to the clock `start_date` asks for.
 - `stop_time`: Stop time for the simulation. Defaults to `Inf` for numeric clocks, or 
   `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks. On Reactant architectures it defaults to `nothing`, since 
   Reactant does not support `stop_time`.
@@ -43,7 +45,8 @@ timestepping is needed.
 - `verbose`: If `true`, prints additional setup information.
 """
 function nonhydrostatic_ocean_simulation(grid;
-                                         clock = Clock(grid),
+                                         start_date = nothing,
+                                         clock = default_simulation_clock(grid, start_date),
                                          stop_time = default_stop_time(grid, clock),
                                          Δt = 1,
                                          closure = nothing,

--- a/src/Oceans/ocean_simulation.jl
+++ b/src/Oceans/ocean_simulation.jl
@@ -238,7 +238,8 @@ end
 
 """
     hydrostatic_ocean_simulation(grid;
-                                 clock = Clock(grid),
+                                 start_date = nothing,
+                                 clock = default_simulation_clock(grid, start_date),
                                  stop_time = default_stop_time(grid, clock),
                                  Δt = estimate_maximum_Δt(grid),
                                  closure = default_ocean_closure(),
@@ -304,8 +305,9 @@ defaults on a per-field basis.
 
 ## Keyword Arguments
 
-- `clock`: Clock for the underlying model. Defaults to `Clock(grid)`, a numeric clock starting at `time = 0`. 
-  Pass a `DateTime`-based clock to step the simulation in calendar time (e.g. when coupling).
+- `start_date`: Date the simulation opens at. Defaults to `nothing`, a numeric clock starting at `time = 0`.
+  Pass a date to step the simulation in calendar time, which a coupled model driven by dated data requires.
+- `clock`: Clock for the underlying model. Defaults to the clock `start_date` asks for.
 - `stop_time`: Stop time for the simulation. Defaults to `Inf` for numeric clocks, or 
   `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks. On Reactant architectures it defaults to `nothing`, since 
   Reactant does not support `stop_time`.
@@ -331,7 +333,8 @@ defaults on a per-field basis.
 - `verbose`: If `true`, prints additional setup information.
 """
 function hydrostatic_ocean_simulation(grid;
-                                      clock = Clock(grid),
+                                      start_date = nothing,
+                                      clock = default_simulation_clock(grid, start_date),
                                       stop_time = default_stop_time(grid, clock),
                                       Δt = estimate_maximum_Δt(grid),
                                       closure = default_ocean_closure(),

--- a/src/Radiations/Radiations.jl
+++ b/src/Radiations/Radiations.jl
@@ -29,8 +29,7 @@ using Oceananigans.Units: Time
 using Oceananigans.Utils: launch!, prettysummary, interpolator
 
 using ..NumericalEarth: NumericalEarth, stateindex
-using ..EarthSystemModels: EarthSystemModels, AbstractPrescribedComponent, sea_ice_concentration, set_prescribed_field!
-using ...EarthSystemModels: default_component_clock
+using ..EarthSystemModels: EarthSystemModels, AbstractPrescribedComponent, sea_ice_concentration, set_prescribed_field!, default_component_clock
 using ..EarthSystemModels.InterfaceComputations: interface_kernel_parameters,
                                                  ComponentExchanger,
                                                  kernel_radiation_properties,

--- a/src/Radiations/Radiations.jl
+++ b/src/Radiations/Radiations.jl
@@ -30,6 +30,7 @@ using Oceananigans.Utils: launch!, prettysummary, interpolator
 
 using ..NumericalEarth: NumericalEarth, stateindex
 using ..EarthSystemModels: EarthSystemModels, AbstractPrescribedComponent, sea_ice_concentration, set_prescribed_field!
+using ...EarthSystemModels: default_component_clock
 using ..EarthSystemModels.InterfaceComputations: interface_kernel_parameters,
                                                  ComponentExchanger,
                                                  kernel_radiation_properties,

--- a/src/Radiations/prescribed_radiation.jl
+++ b/src/Radiations/prescribed_radiation.jl
@@ -76,7 +76,7 @@ function PrescribedRadiation(downwelling_shortwave::FieldTimeSeries,
     FT    = eltype(downwelling_shortwave)
 
     if isnothing(clock)
-        clock = Clock{Float64}(time = 0)
+        clock = default_component_clock(times)
     end
 
     surface_properties = _filter_surface_properties(ocean = ocean_surface,

--- a/src/SeaIces/SeaIces.jl
+++ b/src/SeaIces/SeaIces.jl
@@ -11,12 +11,11 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceMo
 using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ
 using Oceananigans.OrthogonalSphericalShellGrids: OrthogonalSphericalShellGrids
 using Oceananigans.Simulations: Simulation
-using Oceananigans.TimeSteppers: Clock
 using Oceananigans.Units: minutes
 using Oceananigans.Utils: launch!
 using KernelAbstractions: @kernel, @index
 
-using ..EarthSystemModels: EarthSystemModels, default_stop_time
+using ..EarthSystemModels: EarthSystemModels, default_simulation_clock, default_stop_time
 using ..EarthSystemModels.InterfaceComputations: InterfaceComputations, ComponentExchanger,
                                                  ThreeEquationHeatFlux
 

--- a/src/SeaIces/sea_ice_simulation.jl
+++ b/src/SeaIces/sea_ice_simulation.jl
@@ -25,7 +25,8 @@ end
 
 """
     sea_ice_simulation(grid, ocean=nothing;
-                       clock = Clock(grid),
+                       start_date = nothing,
+                       clock = default_simulation_clock(grid, start_date),
                        stop_time = default_stop_time(grid, clock),
                        Δt = 5minutes,
                        ice_salinity = 4, # psu
@@ -60,8 +61,9 @@ Arguments
 
 Keyword Arguments
 =================
-- `clock`: Clock for the underlying model. Defaults to `Clock(grid)`, a numeric clock starting at `time = 0`. 
-  Pass a `DateTime`-based clock to step the simulation in calendar time (e.g. when coupling).
+- `start_date`: Date the simulation opens at. Defaults to `nothing`, a numeric clock starting at `time = 0`.
+  Pass a date to step the simulation in calendar time, which a coupled model driven by dated data requires.
+- `clock`: Clock for the underlying model. Defaults to the clock `start_date` asks for.
 - `stop_time`: Stop time for the simulation. Defaults to `Inf` for numeric clocks, or 
   `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks. On Reactant architectures it defaults to `nothing`, since 
   Reactant does not support `stop_time`.
@@ -89,7 +91,8 @@ Keyword Arguments
                          specified conductivity and prescribed temperature)
 """
 function sea_ice_simulation(grid, ocean=nothing;
-                            clock = Clock(grid),
+                            start_date = nothing,
+                            clock = default_simulation_clock(grid, start_date),
                             stop_time = default_stop_time(grid, clock),
                             Δt = 5minutes,
                             ice_salinity = 4, # psu

--- a/test/runtests_setup.jl
+++ b/test/runtests_setup.jl
@@ -25,6 +25,10 @@ test_architectures = gpu_test ? [GPU()] : [CPU()]
 
 start_date = DateTimeProlepticGregorian(1993, 1, 1)
 
+# A coupled model puts its clock on the atmosphere's calendar, and a `Simulation`'s clock type is fixed when its
+# model is built: ocean and sea ice open on the same date as the JRA55 forcing that drives them.
+jra55_start_date = first_date(JRA55.RepeatYearJRA55(), :temperature)
+
 test_datasets = (ECCO2Monthly(), 
                  ECCO2Daily(), 
                  ECCO4Monthly(), 
@@ -185,7 +189,7 @@ function test_dataset_restoring(arch, dataset, dates, inpainting;
         field = NamedTuple{fldnames}(ntuple(i->CenterField(grid), length(fldnames)))
 
         # A window-averaged product has no node at its first date: the first sits half a window later.
-        clock = Clock(; time = first(var_restoring.field_time_series.times))
+        clock = @allowscalar Clock(; time = first(var_restoring.field_time_series.times))
 
         @allowscalar begin
             @test var_restoring(1, 1,   10, grid, clock, field) == var_restoring.rate
@@ -222,7 +226,10 @@ function test_timestepping_with_dataset_restoring(arch, dataset, dates, inpainti
     end
     restoring = DatasetRestoring(metadata, arch; inpainting, rate=1/1000)
     forcing = NamedTuple{tuple(fldnames[end])}(tuple(restoring))
-    ocean = ocean_simulation(grid; tracers=fldnames, forcing, verbose=false)
+
+    # The restored series is stamped with dates, so the ocean keeps time on the same calendar.
+    restoring_start_date = @allowscalar first(restoring.field_time_series.times)
+    ocean = ocean_simulation(grid; start_date=restoring_start_date, tracers=fldnames, forcing, verbose=false)
     set!(ocean.model, T=20, S=35)
 
     @test begin
@@ -260,12 +267,12 @@ function test_cycling_dataset_restoring(arch, dataset, dates, inpainting;
             )
 
     times = native_times(forcing[1].field_time_series.backend.metadata)
-    ocean = ocean_simulation(grid, tracers=fldnames, forcing=forcing)
+    ocean = ocean_simulation(grid; start_date=first(times), tracers=fldnames, forcing=forcing)
     set!(ocean.model, T=20, S=35)
 
     # start a bit after time_index
     time_index = 3
-    time_interval = dataset isa ECCO2Daily ? Units.hour : Units.day
+    time_interval = dataset isa ECCO2Daily ? Hour(1) : Day(1)
     ocean.model.clock.time = times[time_index] + 2 * time_interval
     update_state!(ocean.model)
 

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -5,13 +5,16 @@ using Oceananigans.OutputWriters: Checkpointer
 using Oceananigans.TimeSteppers: reset!
 using NumericalEarth.EarthSystemModels: components
 
+# An iteration-driven run on a calendar clock declares a date it will never reach.
+const coupled_stop_time = DateTime(9999, 12, 31)
+
 function make_coupled_model(grid)
     @inline hi(λ, φ) = φ > 70 || φ < -70
 
-    ocean = ocean_simulation(grid, closure=nothing)
+    ocean = ocean_simulation(grid; start_date=jra55_start_date, closure=nothing)
     set!(ocean.model, T=20, S=35, u=0.01, v=-0.005)
 
-    sea_ice = sea_ice_simulation(grid, ocean)
+    sea_ice = sea_ice_simulation(grid, ocean; start_date=jra55_start_date)
     set!(sea_ice.model, h=hi, ℵ=hi)
 
     arch = architecture(grid)
@@ -24,16 +27,14 @@ end
 
 function test_clock_time_and_iteration(simulation, expected_iteration)
     Δt = simulation.Δt
+    expected_time = jra55_start_date + Second(expected_iteration * Δt)
+
     @test simulation.model.clock.iteration == expected_iteration
-    @test simulation.model.clock.time == expected_iteration * Δt
+    @test simulation.model.clock.time == expected_time
     for component in components(simulation.model)
-        if component isa AbstractPrescribedComponent
-            @test component.clock.iteration == expected_iteration
-            @test component.clock.time == expected_iteration * Δt
-        else
-            @test component.model.clock.iteration == expected_iteration
-            @test component.model.clock.time == expected_iteration * Δt
-        end
+        clock = component isa AbstractPrescribedComponent ? component.clock : component.model.clock
+        @test clock.iteration == expected_iteration
+        @test clock.time == expected_time
     end
 end
 
@@ -54,11 +55,11 @@ end
         # (This matches the checkpointed workflow where we create a new Simulation
         # after iteration 3, which is what happens during checkpoint restore)
         model = make_coupled_model(grid)
-        simulation = Simulation(model, Δt=60, stop_iteration=3, verbose=false)
+        simulation = Simulation(model; Δt=60, stop_iteration=3, stop_time=coupled_stop_time, verbose=false)
         run!(simulation)
 
         # Continue on the same model (simulates what happens after checkpoint restore)
-        simulation = Simulation(model, Δt=60, stop_iteration=6, verbose=false)
+        simulation = Simulation(model; Δt=60, stop_iteration=6, stop_time=coupled_stop_time, verbose=false)
         run!(simulation)
 
         # Store reference states at iteration 6
@@ -74,7 +75,7 @@ end
 
         # Checkpointed run: 3 iterations, then checkpoint
         model = make_coupled_model(grid)
-        simulation = Simulation(model, Δt=60, stop_iteration=3, verbose=false)
+        simulation = Simulation(model; Δt=60, stop_iteration=3, stop_time=coupled_stop_time, verbose=false)
 
         prefix = "osm_checkpointer_test_$(typeof(arch))"
         simulation.output_writers[:checkpointer] = Checkpointer(simulation.model;
@@ -87,7 +88,7 @@ end
 
         # Create new model and restore from checkpoint
         model = make_coupled_model(grid)
-        simulation = Simulation(model, Δt=60, stop_iteration=6, verbose=false)
+        simulation = Simulation(model; Δt=60, stop_iteration=6, stop_time=coupled_stop_time, verbose=false)
 
         simulation.output_writers[:checkpointer] = Checkpointer(model;
                                                                 schedule = IterationInterval(3),
@@ -143,7 +144,7 @@ end
                                      halo = (6, 6, 6))
 
         model = make_coupled_model(grid)
-        simulation = Simulation(model; Δt=60, stop_iteration=3, verbose=false)
+        simulation = Simulation(model; Δt=60, stop_iteration=3, stop_time=coupled_stop_time, verbose=false)
 
         # check that clock stops when intended
         @test model.atmosphere isa AbstractPrescribedComponent

--- a/test/test_coefficient_based_fluxes.jl
+++ b/test/test_coefficient_based_fluxes.jl
@@ -79,6 +79,7 @@ end
                                      topology = (Flat, Flat, Bounded))
 
         ocean = ocean_simulation(grid;
+                                 start_date = jra55_start_date,
                                  momentum_advection = nothing,
                                  tracer_advection = nothing,
                                  closure = nothing,
@@ -112,6 +113,7 @@ end
                                      topology = (Flat, Flat, Bounded))
 
         ocean = ocean_simulation(grid;
+                                 start_date = jra55_start_date,
                                  momentum_advection = nothing,
                                  tracer_advection = nothing,
                                  closure = nothing,
@@ -149,6 +151,7 @@ end
                                      topology = (Flat, Flat, Bounded))
 
         ocean = ocean_simulation(grid;
+                                 start_date = jra55_start_date,
                                  momentum_advection = nothing,
                                  tracer_advection = nothing,
                                  closure = nothing,

--- a/test/test_jra55.jl
+++ b/test/test_jra55.jl
@@ -158,7 +158,7 @@ using NumericalEarth.JRA55: download_JRA55_cache
         pressure_times = atmosphere.pressure.times
         @test rivers_times != pressure_times
         @test length(rivers_times) != length(pressure_times)
-        @test rivers_times[2] - rivers_times[1] == 86400
+        @test rivers_times[2] - rivers_times[1] == Day(1)
 
         @info "Testing MultiYearJRA55 data on $A..."
         dataset = JRA55.MultiYearJRA55()
@@ -185,7 +185,7 @@ using NumericalEarth.JRA55: download_JRA55_cache
         river_flux = download_dataset_with_fallback(filepaths; dataset_name="MultiYearJRA55 $multiyear_name") do
             FieldTimeSeries(metadata, arch; time_indices_in_memory=10)
         end
-        @test Second(end_date - start_date).value ≈ river_flux.times[end] - river_flux.times[1]
+        @test river_flux.times[end] - river_flux.times[1] == end_date - start_date
 
         # Test we can access all the data
         for t in eachindex(river_flux.times)

--- a/test/test_metadata.jl
+++ b/test/test_metadata.jl
@@ -256,19 +256,23 @@ end
     @test averaging_window(ecco) == (DateTime(1993, 1, 1), DateTime(1993, 2, 1))
     @test window_center(ecco) == DateTime(1993, 1, 16, 12)
 
-    # A twelve-month axis then reproduces the time coordinates the files themselves carry,
-    # in days from the first of January.
+    # A twelve-month axis then carries each month's mid-point.
     metadata = Metadata(:temperature; dataset = EN4Monthly(),
                         dates = [DateTime(2010, m, 1) for m in 1:12])
-    @test native_times(metadata) ./ 86400 == [15.5, 45.0, 74.5, 105.0, 135.5, 166.0,
-                                              196.5, 227.5, 258.0, 288.5, 319.0, 349.5]
+    @test native_times(metadata) == [DateTime(2010, 1, 16, 12), DateTime(2010, 2, 15),
+                                     DateTime(2010, 3, 16, 12), DateTime(2010, 4, 16),
+                                     DateTime(2010, 5, 16, 12), DateTime(2010, 6, 16),
+                                     DateTime(2010, 7, 16, 12), DateTime(2010, 8, 16, 12),
+                                     DateTime(2010, 9, 16),     DateTime(2010, 10, 16, 12),
+                                     DateTime(2010, 11, 16),    DateTime(2010, 12, 16, 12)]
 
     # A product of values at an instant has no window and is left where its stamp puts it.
     hourly = Metadatum(:temperature; dataset = ERA5HourlySingleLevel(), date = DateTime(2020, 4, 1))
     @test averaging_window(hourly) == (DateTime(2020, 4, 1), DateTime(2020, 4, 1))
     @test window_center(hourly) == DateTime(2020, 4, 1)
     @test native_times(Metadata(:temperature; dataset = ERA5HourlySingleLevel(),
-                                dates = [DateTime(2020, 4, 1, h) for h in 0:2])) == [0, 3600, 7200]
+                                dates = [DateTime(2020, 4, 1, h) for h in 0:2])) ==
+          [DateTime(2020, 4, 1, h) for h in 0:2]
 
     # Every monthly-mean product spans the calendar month its file is named for, whether the
     # stamp is midnight on the first (most of them) or noon (ECCO Darwin).
@@ -317,7 +321,8 @@ end
 
     radiation = Metadata(:downwelling_shortwave_radiation; dataset = ERA5HourlySingleLevel(),
                          dates = [DateTime(2020, 4, 1, h) for h in 1:3])
-    @test native_times(radiation) == [-1800, 1800, 5400]
+    @test native_times(radiation) == [DateTime(2020, 4, 1, 0, 30), DateTime(2020, 4, 1, 1, 30),
+                                     DateTime(2020, 4, 1, 2, 30)]
 end
 
 @testset "JRA55 averaging windows" begin

--- a/test/test_ocean_only_model.jl
+++ b/test/test_ocean_only_model.jl
@@ -13,7 +13,7 @@ using Oceananigans.OrthogonalSphericalShellGrids
         grid = RectilinearGrid(arch, size = 200, x = λ★, y = φ★,
                                 z = (-400, 0), topology = (Flat, Flat, Bounded))
 
-        ocean = ocean_simulation(grid)
+        ocean = ocean_simulation(grid; start_date=jra55_start_date)
         data = Int[]
         pushdata(sim) = push!(data, iteration(sim))
         add_callback!(ocean, pushdata)
@@ -45,7 +45,7 @@ using Oceananigans.OrthogonalSphericalShellGrids
         grid = ImmersedBoundaryGrid(grid, GridFittedBottom(bottom_height); active_cells_map=true)
 
         free_surface = SplitExplicitFreeSurface(grid; substeps=20)
-        ocean = ocean_simulation(grid; free_surface)
+        ocean = ocean_simulation(grid; start_date=jra55_start_date, free_surface)
 
         @test NumericalEarth.Oceans.get_radiative_forcing(ocean) isa NumericalEarth.Oceans.TwoColorRadiation
         
@@ -68,7 +68,7 @@ using Oceananigans.OrthogonalSphericalShellGrids
         land = JRA55PrescribedLand(arch; end_date=land_dates[2])
 
         @test begin
-            ocean_with_land = ocean_simulation(grid; free_surface)
+            ocean_with_land = ocean_simulation(grid; start_date=jra55_start_date, free_surface)
             coupled_model = OceanOnlyModel(ocean_with_land; atmosphere, land, radiation)
 
             # Verify land exchanger is present

--- a/test/test_ocean_sea_ice_model.jl
+++ b/test/test_ocean_sea_ice_model.jl
@@ -41,9 +41,9 @@ using ClimaSeaIce.Rheologies
             initial_state = MetadataSet(:temperature, :salinity;
                                         dataset, date=start_date)
 
-            ocean = ocean_simulation(grid; free_surface)
+            ocean = ocean_simulation(grid; start_date=jra55_start_date, free_surface)
 
-            sea_ice  = sea_ice_simulation(grid, ocean; advection=WENO(order=7))
+            sea_ice  = sea_ice_simulation(grid, ocean; start_date=jra55_start_date, advection=WENO(order=7))
             liquidus = sea_ice.model.phase_transitions.liquidus
 
             # Set the ocean temperature and salinity
@@ -74,9 +74,10 @@ using ClimaSeaIce.Rheologies
             land = JRA55PrescribedLand(arch; end_date=land_dates[2])
 
             @test begin
-                ocean_with_land = ocean_simulation(grid; free_surface)
+                ocean_with_land = ocean_simulation(grid; start_date=jra55_start_date, free_surface)
                 set!(ocean_with_land.model, initial_state)
-                sea_ice_with_land = sea_ice_simulation(grid, ocean_with_land; advection=WENO(order=7))
+                sea_ice_with_land = sea_ice_simulation(grid, ocean_with_land;
+                                                       start_date=jra55_start_date, advection=WENO(order=7))
                 above_freezing_ocean_temperature!(ocean_with_land, grid, sea_ice_with_land)
 
                 coupled_model = OceanSeaIceModel(ocean_with_land, sea_ice_with_land; atmosphere, land, radiation)

--- a/test/test_sea_ice_ocean_heat_fluxes.jl
+++ b/test/test_sea_ice_ocean_heat_fluxes.jl
@@ -197,8 +197,9 @@ end
                                      longitude = (0, 10),
                                      z = (-100, 0))
 
-        ocean = ocean_simulation(grid, momentum_advection=nothing, closure=nothing, tracer_advection=nothing)
-        sea_ice = sea_ice_simulation(grid, ocean)
+        ocean = ocean_simulation(grid; start_date=jra55_start_date,
+                                 momentum_advection=nothing, closure=nothing, tracer_advection=nothing)
+        sea_ice = sea_ice_simulation(grid, ocean; start_date=jra55_start_date)
 
         atmosphere = JRA55PrescribedAtmosphere(arch; time_indices_in_memory=4)
         radiation = JRA55PrescribedRadiation(arch; time_indices_in_memory=4)
@@ -257,8 +258,9 @@ end
                                      longitude = (0, 10),
                                      z = (-100, 0))
 
-        ocean = ocean_simulation(grid, momentum_advection=nothing, closure=nothing, tracer_advection=nothing)
-        sea_ice = sea_ice_simulation(grid, ocean)
+        ocean = ocean_simulation(grid; start_date=jra55_start_date,
+                                 momentum_advection=nothing, closure=nothing, tracer_advection=nothing)
+        sea_ice = sea_ice_simulation(grid, ocean; start_date=jra55_start_date)
 
         atmosphere = JRA55PrescribedAtmosphere(arch; time_indices_in_memory=4)
         radiation = JRA55PrescribedRadiation(arch; time_indices_in_memory=4)
@@ -400,8 +402,9 @@ end
                                      longitude = (0, 10),
                                      z = (-400, 0))
 
-        ocean = ocean_simulation(grid, momentum_advection=nothing, closure=nothing, tracer_advection=nothing)
-        sea_ice = sea_ice_simulation(grid, ocean)
+        ocean = ocean_simulation(grid; start_date=jra55_start_date,
+                                 momentum_advection=nothing, closure=nothing, tracer_advection=nothing)
+        sea_ice = sea_ice_simulation(grid, ocean; start_date=jra55_start_date)
 
         atmosphere = JRA55PrescribedAtmosphere(arch; time_indices_in_memory=4)
         radiation = JRA55PrescribedRadiation(arch; time_indices_in_memory=4)
@@ -450,8 +453,9 @@ end
                                      longitude = (0, 10),
                                      z = (-400, 0))
 
-        ocean = ocean_simulation(grid, momentum_advection=nothing, closure=nothing, tracer_advection=nothing)
-        sea_ice = sea_ice_simulation(grid, ocean)
+        ocean = ocean_simulation(grid; start_date=jra55_start_date,
+                                 momentum_advection=nothing, closure=nothing, tracer_advection=nothing)
+        sea_ice = sea_ice_simulation(grid, ocean; start_date=jra55_start_date)
 
         atmosphere = JRA55PrescribedAtmosphere(arch; time_indices_in_memory=4)
         radiation = JRA55PrescribedRadiation(arch; time_indices_in_memory=4)

--- a/test/test_surface_fluxes.jl
+++ b/test/test_surface_fluxes.jl
@@ -41,6 +41,7 @@ end
                                      topology = (Flat, Flat, Bounded))
 
         ocean = ocean_simulation(grid;
+                                 start_date = jra55_start_date,
                                  momentum_advection = nothing,
                                  tracer_advection = nothing,
                                  closure = nothing,
@@ -120,6 +121,7 @@ end
 
             closure = (VerticalScalarDiffusivity(κ=1e-3), VerticalScalarDiffusivity(κ=2e-3))
             diffusive_ocean = ocean_simulation(column_grid;
+                                               start_date = jra55_start_date,
                                                momentum_advection = nothing,
                                                tracer_advection = nothing,
                                                closure,
@@ -215,6 +217,7 @@ end
 
         # Test that fluxes work with and without land
         ocean_no_land = ocean_simulation(grid;
+                                         start_date = jra55_start_date,
                                          momentum_advection = nothing,
                                          tracer_advection = nothing,
                                          closure = nothing,
@@ -224,6 +227,7 @@ end
         model_no_land = OceanOnlyModel(ocean_no_land; atmosphere)
 
         ocean_with_land = ocean_simulation(grid;
+                                           start_date = jra55_start_date,
                                            momentum_advection = nothing,
                                            tracer_advection = nothing,
                                            closure = nothing,
@@ -264,7 +268,8 @@ end
                                        z = (-1, 0),
                                 topology = (Bounded, Bounded, Bounded))
 
-        ocean = ocean_simulation(grid; momentum_advection = nothing,
+        ocean = ocean_simulation(grid; start_date = jra55_start_date,
+                                       momentum_advection = nothing,
                                          tracer_advection = nothing,
                                                  coriolis = nothing,
                                                   closure = nothing,
@@ -298,7 +303,8 @@ end
                              extent = (1, 1, 1),
                            topology = (Periodic, Periodic, Bounded))
 
-        ocean = ocean_simulation(grid; momentum_advection = nothing,
+        ocean = ocean_simulation(grid; start_date = jra55_start_date,
+                                       momentum_advection = nothing,
                                          tracer_advection = nothing,
                                                  coriolis = nothing,
                                                   closure = nothing,
@@ -317,7 +323,7 @@ end
                                           rheology = nothing,
                                           solver = ExplicitSolver())
 
-        sea_ice = sea_ice_simulation(grid; dynamics, advection=Centered())
+        sea_ice = sea_ice_simulation(grid; start_date = jra55_start_date, dynamics, advection=Centered())
 
         # Set a velocity for the ocean
         fill!(ocean.model.velocities.u, 0.1)
@@ -441,7 +447,8 @@ end
         closure  = nothing
         coriolis = nothing
 
-        ocean = ocean_simulation(grid; momentum_advection, tracer_advection, closure, tracers, coriolis)
+        ocean = ocean_simulation(grid; start_date = jra55_start_date,
+                                       momentum_advection, tracer_advection, closure, tracers, coriolis)
 
         date = DateTimeProlepticGregorian(1993, 1, 1)
         dataset = ECCO4Monthly()

--- a/test/test_time_anchoring.jl
+++ b/test/test_time_anchoring.jl
@@ -2,7 +2,7 @@ include("runtests_setup.jl")
 
 using Dates
 using NumericalEarth.DataWrangling: CalendarDate, CalendarPhase, SimulationStart,
-                                    lookup_date, default_time_anchor, validate_time_anchors
+                                    lookup_date, default_time_indexing, validate_time_anchors
 
 multi_year  = DateTime(1958, 1, 1) : Hour(3) : DateTime(2018, 1, 1)
 repeat_year = DateTime(1990, 1, 1) : Hour(3) : DateTime(1990, 12, 31, 21)
@@ -67,13 +67,13 @@ climatology = [DateTime(2018, m, 1) for m in 1:12]
     end
 
     @testset "Anchors in one model" begin
-        @test default_time_anchor(MultiYearJRA55()) isa CalendarDate
-        @test default_time_anchor(RepeatYearJRA55()) isa CalendarPhase
-        @test default_time_anchor(WOAMonthly()) isa CalendarPhase
+        @test default_time_indexing(MultiYearJRA55()) isa CalendarDate
+        @test default_time_indexing(RepeatYearJRA55()) isa CalendarPhase
+        @test default_time_indexing(WOAMonthly()) isa CalendarPhase
 
         # A reanalysis with a climatological restoring is the common case and holds phase.
-        @test isnothing(validate_time_anchors([(:temperature, default_time_anchor(MultiYearJRA55())),
-                                               (:salinity, default_time_anchor(WOAMonthly()))]))
+        @test isnothing(validate_time_anchors([(:temperature, default_time_indexing(MultiYearJRA55())),
+                                               (:salinity, default_time_indexing(WOAMonthly()))]))
 
         start = SimulationStart(DateTime(1958, 1, 1))
         @test isnothing(validate_time_anchors([(:temperature, start)]))

--- a/test/test_time_anchoring.jl
+++ b/test/test_time_anchoring.jl
@@ -1,0 +1,83 @@
+include("runtests_setup.jl")
+
+using Dates
+using NumericalEarth.DataWrangling: CalendarDate, CalendarPhase, SimulationStart,
+                                    lookup_date, default_time_anchor, validate_time_anchors
+
+multi_year  = DateTime(1958, 1, 1) : Hour(3) : DateTime(2018, 1, 1)
+repeat_year = DateTime(1990, 1, 1) : Hour(3) : DateTime(1990, 12, 31, 21)
+climatology = [DateTime(2018, m, 1) for m in 1:12]
+
+@testset "Time anchoring" begin
+    @testset "CalendarDate" begin
+        @test lookup_date(CalendarDate(), DateTime(1966, 7, 5, 9), multi_year) == DateTime(1966, 7, 5, 9)
+        @test lookup_date(CalendarDate(), DateTime(2018, 1, 1),    multi_year) == DateTime(2018, 1, 1)
+
+        # A run continuing past the record folds back by whole calendar years: a repeated OMIP cycle, with the
+        # model clock left monotonic.
+        @test lookup_date(CalendarDate(), DateTime(2018, 6, 1),     multi_year) == DateTime(1958, 6, 1)
+        @test lookup_date(CalendarDate(), DateTime(2043, 3, 15, 9), multi_year) == DateTime(1983, 3, 15, 9)
+        @test lookup_date(CalendarDate(), DateTime(2100, 3, 15, 9), multi_year) == DateTime(1980, 3, 15, 9)
+
+        # Every day of a full cycle folds by the same whole-year shift, leap days included.
+        mismatches = 0
+        date = DateTime(2018, 1, 2)
+        while date < DateTime(2078, 1, 1)
+            lookup_date(CalendarDate(), date, multi_year) == date - Year(60) || (mismatches += 1)
+            date += Day(1)
+        end
+        @test mismatches == 0
+    end
+
+    @testset "CalendarPhase" begin
+        # Incompatible nominal years coexist because neither is ever the model's.
+        model_date = DateTime(2043, 3, 15, 9)
+        @test lookup_date(CalendarPhase(), model_date, repeat_year) == DateTime(1990, 3, 15, 9)
+        @test lookup_date(CalendarPhase(), model_date, climatology) == DateTime(2018, 3, 15, 9)
+
+        @test lookup_date(CalendarPhase(), DateTime(2044, 2, 29, 9), repeat_year) == DateTime(1990, 2, 28, 9)
+        @test lookup_date(CalendarPhase(), DateTime(2044, 2, 29, 9), climatology) == DateTime(2018, 2, 28, 9)
+
+        leap_nominal = DateTime(1960, 1, 1) : Hour(3) : DateTime(1960, 12, 31, 21)
+        @test lookup_date(CalendarPhase(), DateTime(2044, 2, 29, 9), leap_nominal) == DateTime(1960, 2, 29, 9)
+    end
+
+    @testset "SimulationStart" begin
+        anchor = SimulationStart(DateTime(1958, 1, 1))
+
+        @test lookup_date(anchor, DateTime(1958, 1, 1),    repeat_year) == DateTime(1990, 1, 1)
+        @test lookup_date(anchor, DateTime(1958, 1, 2, 9), repeat_year) == DateTime(1990, 1, 2, 9)
+        @test lookup_date(anchor, DateTime(1959, 1, 1),    repeat_year) == DateTime(1990, 1, 1)
+    end
+
+    @testset "Series of one product resolve to the same instant" begin
+        # JRA55-do stamps instantaneous variables on the hour and window means at the window midpoint, so the
+        # two sets of stamps sit 90 minutes apart.
+        instantaneous = DateTime(1958, 1, 1)        : Hour(3) : DateTime(2018, 1, 1)
+        window_mean   = DateTime(1958, 1, 1, 1, 30) : Hour(3) : DateTime(2018, 1, 1)
+        model_date    = DateTime(1958, 6, 15, 9)
+
+        @test lookup_date(CalendarDate(), model_date, instantaneous) == model_date
+        @test lookup_date(CalendarDate(), model_date, window_mean)   == model_date
+
+        # Counting seconds from each series' own first stamp puts equal offsets at different instants.
+        offset = model_date - DateTime(1958, 1, 1)
+        @test first(instantaneous) + offset == model_date
+        @test first(window_mean)   + offset == model_date + Minute(90)
+    end
+
+    @testset "Anchors in one model" begin
+        @test default_time_anchor(MultiYearJRA55()) isa CalendarDate
+        @test default_time_anchor(RepeatYearJRA55()) isa CalendarPhase
+        @test default_time_anchor(WOAMonthly()) isa CalendarPhase
+
+        # A reanalysis with a climatological restoring is the common case and holds phase.
+        @test isnothing(validate_time_anchors([(:temperature, default_time_anchor(MultiYearJRA55())),
+                                               (:salinity, default_time_anchor(WOAMonthly()))]))
+
+        start = SimulationStart(DateTime(1958, 1, 1))
+        @test isnothing(validate_time_anchors([(:temperature, start)]))
+        @test_throws ArgumentError validate_time_anchors([(:temperature, start), (:salinity, start)])
+        @test_throws ArgumentError validate_time_anchors([(:temperature, start), (:salinity, CalendarPhase())])
+    end
+end

--- a/test/test_tracer_budget.jl
+++ b/test/test_tracer_budget.jl
@@ -68,7 +68,10 @@ function test_tracer_budget(coupled_model, Sᵒᶜ, Δt, nsteps; heat_rtol, fres
         # the freshwater's own enthalpy Σᵢ Tᵢ Jʷᵢ is what remains.
         heat_content_tendency = sum(ρᵒᶜ * cᵒᶜ * ΔVT)
         expected_heat_content_tendency = (previous_radiative_rate - previous_heat_flux + previous_enthalpy) * last_Δt
-        @test isapprox(heat_content_tendency, expected_heat_content_tendency; rtol=heat_rtol)
+
+        # The tendency is recovered by differencing the heat content, so the residual cannot fall below
+        # one ulp of that content however small Δt is. Floor the comparison there.
+        @test isapprox(heat_content_tendency, expected_heat_content_tendency; rtol=heat_rtol, atol=eps(sum(ρᵒᶜ * cᵒᶜ * VT⁻)))
 
         # Volume grows by exactly the surface-integrated freshwater volume flux.
         volume_tendency = sum(ΔVV)

--- a/test/test_tracer_budget.jl
+++ b/test/test_tracer_budget.jl
@@ -123,7 +123,7 @@ end
 
             # Without shortwave penetration
             @testset "Surface-only fluxes" begin
-                ocean = ocean_simulation(deepcopy(grid); free_surface, radiative_forcing=nothing)
+                ocean = ocean_simulation(deepcopy(grid); start_date=jra55_start_date, free_surface, radiative_forcing=nothing)
                 set!(ocean.model, T=Tᵢ, S=Sᵢ)
                 coupled_model = OceanSeaIceModel(ocean, nothing; atmosphere, radiation)
                 test_tracer_budget(coupled_model, Sᵒᶜ, Δt, 4; heat_rtol=1e-11, freshwater_rtol=√eps(eltype(grid)))
@@ -131,7 +131,7 @@ end
 
             # With penetrative shortwave radiation
             @testset "Surface fluxes + Penetrating shortwave radiation" begin
-                ocean = ocean_simulation(deepcopy(grid); free_surface)
+                ocean = ocean_simulation(deepcopy(grid); start_date=jra55_start_date, free_surface)
                 set!(ocean.model, T=Tᵢ, S=Sᵢ)
                 coupled_model = OceanSeaIceModel(ocean, nothing; atmosphere, radiation)
                 test_tracer_budget(coupled_model, Sᵒᶜ, Δt, 4; heat_rtol=1e-11, freshwater_rtol=√eps(eltype(grid)))
@@ -140,8 +140,8 @@ end
             @testset "Surface fluxes + penetrating shortwave radiation + Sea ice" begin
                 @info "    .. Surface fluxes + penetrating shortwave radiation + Sea ice"
                 new_grid = deepcopy(grid) # because the grid is mutable
-                ocean = ocean_simulation(new_grid; free_surface)
-                sea_ice = sea_ice_simulation(new_grid, ocean; dynamics=nothing)
+                ocean = ocean_simulation(new_grid; start_date=jra55_start_date, free_surface)
+                sea_ice = sea_ice_simulation(new_grid, ocean; start_date=jra55_start_date, dynamics=nothing)
                 set!(ocean.model, T=Tᵢ, S=Sᵢ)
                 set!(sea_ice.model, h=hᵢ, ℵ=ℵᵢ)
                 coupled_model = OceanSeaIceModel(ocean, sea_ice; atmosphere, radiation)


### PR DESCRIPTION
Closes stage 2 of #595, on top of #598.

The `EarthSystemModel`, ocean and sea-ice clocks and the `FieldTimeSeries` axes become `DateTime`, and each dataset says how it wants a model date interpreted. `Δt` stays `Float64` seconds.

### What changed

1. We introduced "Anchoring" as a `time_indexing`. The new options are
- `CalendarDate`
- `CalendarPhase`
- `SimulationStart` 
They plug into `interpolating_time_indices`, which is the single dispatch point behind both `update_field_time_series!` and in-kernel `interpolate`, so one method covers the host and the GPU path, and it arrives through the `time_indexing` keyword that already exists on every `FieldTimeSeries` constructor.

Basically these are the calendar-aware siblings of the `Cyclical` time indexing (for all of these behaviors the time is cycled through the period, see later on the behavior).

2. `native_times` returns dates, and collapses doing it:

```julia
native_times(metadata) = [window_center(datum) for datum in metadata]
```

3. Every component clock derives from its own time axis. Previously `PrescribedAtmosphere` and `PrescribedRadiation` hardcoded `Clock{Float64}`, and `PrescribedLand` used `Clock{eltype(first_flux)}`. All three now go through one `default_component_clock(times)`, and `default_earth_system_clock` inherits the atmosphere's time type and starting time.

4. Added a `start_time` field to the `EarthSystemModel` such that we are always able to `reset!` the simulation clock.

### Behaviour

The time axis carries dates, not floats

```julia
julia> md = Metadata(:temperature; dataset=RepeatYearJRA55(), start_date=DateTime(1990,1,1), end_date=DateTime(1990,1,2));

julia> native_times(md)[1:3]
3-element Vector{DateTime}:
 1990-01-01T00:00:00
 1990-01-01T03:00:00
 1990-01-01T06:00:00
```

The clock follows the axis, and the coupled clock follows the atmosphere (by default, we can also change it):

```julia
julia> atmos = PrescribedAtmosphere(grid, collect(DateTime(1958,1,1) : Hour(3) : DateTime(1958,1,10)));

julia> atmos.clock.time
1958-01-01T00:00:00

julia> default_earth_system_clock(atmos).time
1958-01-01T00:00:00
```

Each dataset says how it wants the model date interpreted (also this is a default that can be changed):

```julia
julia> default_time_indexing.((MultiYearJRA55(), RepeatYearJRA55(), WOAMonthly()))
(CalendarDate(), CalendarPhase(), CalendarPhase())
```

A reanalysis reads the model's own date, and folds by whole calendar years once the run passes the end of the record while a second OMIP cycle repeats the same calendar dates, with the model clock left monotonic:

```julia
julia> lookup_date(CalendarDate(), DateTime(1967,2,12), jra)   # in range
1967-02-12T00:00:00

julia> lookup_date(CalendarDate(), DateTime(2018,6,1), jra)    # past the record
1958-06-01T00:00:00

julia> lookup_date(CalendarDate(), DateTime(2027,2,12), jra)   # second cycle
1967-02-12T00:00:00
```

A climatology reads the model's month and day, resolved in whatever year it happens to be stamped in — so `RepeatYearJRA55` (1990) and `WOAMonthly` (2018) can be used together without the model having to be in either year:

```julia
julia> lookup_date(CalendarPhase(), DateTime(1966,3,15,9), ryf)   # repeat year, stamped 1990
1990-03-15T09:00:00

julia> lookup_date(CalendarPhase(), DateTime(1966,3,15,9), woa)   # climatology, stamped 2018
2018-03-15T09:00:00

julia> lookup_date(CalendarPhase(), DateTime(2043,3,15,9), ryf)   # 77 years later, same phase
1990-03-15T09:00:00
```

### Caveat: LEAP YEARS

The difficult part, which requires a decision, is handling leap years. Some "year-agnostic" datasets (like `RepeatYearJRA55`) do not have the 29th of February. This is the decision we came up with Claude and I:
29 February reads 28 February at the same time of day, since a non-leap nominal year has no counterpart for it.
The opposite case (dataset has a leap year, model does not), the simple solution is to skip the 29th of Feb.

Leap model year onto a non-leap dataset — 29 February replays the 28th:

```julia
2044-02-28T00:00:00   -> 1990-02-28T00:00:00
2044-02-28T12:00:00   -> 1990-02-28T12:00:00
2044-02-29T00:00:00   -> 1990-02-28T00:00:00     <-- replayed, midnight to midnight
2044-02-29T12:00:00   -> 1990-02-28T12:00:00     <-- noon to noon
2044-03-01T00:00:00   -> 1990-03-01T00:00:00
2044-03-01T12:00:00   -> 1990-03-01T12:00:00
```

Non-leap model year onto a leap dataset — the dataset's 29 February is never read:

```julia
2043-02-28T00:00:00   -> 1960-02-28T00:00:00
2043-02-28T12:00:00   -> 1960-02-28T12:00:00
2043-03-01T00:00:00   -> 1960-03-01T00:00:00     <-- 1960-02-29 skipped
2043-03-01T12:00:00   -> 1960-03-01T12:00:00
```

This means that in leap years we effectively repeat the 28th of Feb for datasets like RYF, which is probably better than just interpolating between 28th of Feb and 1st of March since at least it preserves the daily cycle and avoids freezing a certain hour.

### Known sharp edge 

(Claude calls it a sharp edge, I call it a desired feature of the implementation)
`CalendarDate`'s fold period comes from the loaded window, not from the dataset. Setting `start_date = 1967-02-12` on JRA55 trims the metadata, so the cycle becomes 51 years instead of 60:

```
model 2027-02-12  ->  full record 1958..2018: 1967-02-12
                      trimmed     1967..2018: 1976-02-12
```

So, exact leap-year preservation might be off because the cycle can not be a multiple of 4, but given the fact that on non-leap years the 29th of feb maps to the 28th it is not a problem.

***Bump major version, as this is a big change to the clock type.***