### PR TITLE
Republish RRTMGP surface optics only for solvers Breeze does not refresh

### DIFF
--- a/ext/NumericalEarthBreezeExt/breeze_air_land_radiation.jl
+++ b/ext/NumericalEarthBreezeExt/breeze_air_land_radiation.jl
@@ -53,6 +53,8 @@ end
 end
 
 function NumericalEarth.EarthSystemModels.update_net_fluxes!(coupled_model, rtm::BreezeRTM)
+    # The all-sky and clear-sky solvers re-read the surface properties at every solve themselves.
+    hasproperty(rtm.longwave_solver, :bcs) || return nothing
     grid = coupled_model.interfaces.exchanger.grid
     properties = rtm.surface_properties
     launch!(architecture(grid), grid, :xy,


### PR DESCRIPTION
`update_net_fluxes!(coupled_model, ::BreezeRTM)` republishes field-valued surface emissivity/albedo into `rtm.longwave_solver.bcs` and `rtm.shortwave_solver.bcs`. Only the gray-optics RTE solvers have a `bcs` field; with `AllSkyOptics()` (or clear-sky) the `RRTMGPSolver` wraps them and the first coupled `update_state!` throws

```
FieldError: type RRTMGP.RRTMGPSolver has no field `bcs`
```

Breeze's `_update_radiation!` re-reads `rtm.surface_properties` for those solvers at every radiation update (through RRTMGP's accessors), so the republish is skipped when the solver has no `bcs`. Verified with a 12 km CONUS nest + `CanopyAirSpace` + all-sky RRTMGP: the canopy's effective albedo reaches the solver (surface ℐꜛˢʷ/ℐꜜˢʷ = 0.19 = the land albedo) and the run steps at the same cost as with prescribed radiation.

The existing test only covers `GrayOptics`, which is why this went unnoticed. Since Breeze refreshes the gray solvers at each update as well, the republish could be deleted entirely; the test's assertion on `rtm.shortwave_solver.bcs.sfc_alb_direct` after one step is what keeps it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)