### PR TITLE
Validate Field-valued zero-plane displacements against the surface layer height

### DIFF
--- a/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
@@ -271,10 +271,9 @@ end
 validate_zero_plane_displacement(flux_formulation, zᵃᵗ) = nothing
 
 function validate_zero_plane_displacement(fluxes::SimilarityTheoryFluxes, zᵃᵗ)
-    d = fluxes.zero_plane_displacement
-    d isa Number || return nothing
+    dᵐᵃˣ = maximum(fluxes.zero_plane_displacement)
     zᵐⁱⁿ = minimum(zᵃᵗ)
-    d < zᵐⁱⁿ || throw(ArgumentError("zero_plane_displacement ($d m) must be below the surface layer height ($zᵐⁱⁿ m)"))
+    dᵐᵃˣ < zᵐⁱⁿ || throw(ArgumentError("zero_plane_displacement must be below the surface layer height ($zᵐⁱⁿ m), found $dᵐᵃˣ m"))
     return nothing
 end
 

--- a/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
+++ b/src/EarthSystemModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
@@ -271,9 +271,8 @@ end
 validate_zero_plane_displacement(flux_formulation, zᵃᵗ) = nothing
 
 function validate_zero_plane_displacement(fluxes::SimilarityTheoryFluxes, zᵃᵗ)
-    dᵐᵃˣ = maximum(fluxes.zero_plane_displacement)
-    zᵐⁱⁿ = minimum(zᵃᵗ)
-    dᵐᵃˣ < zᵐⁱⁿ || throw(ArgumentError("zero_plane_displacement must be below the surface layer height ($zᵐⁱⁿ m), found $dᵐᵃˣ m"))
+    Δhᵈ = minimum(zᵃᵗ .- fluxes.zero_plane_displacement)
+    Δhᵈ > 0 || throw(ArgumentError("zero_plane_displacement must be below the surface layer height, found a displaced profile height of $Δhᵈ m"))
     return nothing
 end
 

--- a/test/test_slab_land.jl
+++ b/test/test_slab_land.jl
@@ -628,6 +628,18 @@ end
         u★ = Array(interior(model.interfaces.atmosphere_land_interface.fluxes.friction_velocity))
         @test u★[1, 1, 1] ≈ ϰ / log(h / grassland_roughness) * uᵃᵗ
         @test u★[2, 1, 1] ≈ ϰ / log((h - forest_displacement) / forest_roughness) * uᵃᵗ
+
+        # A displacement field reaching the surface layer height anywhere is rejected at
+        # construction, as a scalar one is.
+        tall_displacement = Field{Center, Center, Nothing}(grid)
+        set!(tall_displacement, (λ, φ) -> ifelse(λ < 11, grassland_displacement, h))
+        tall_fluxes = SimilarityTheoryFluxes(; momentum_roughness_length,
+                                               temperature_roughness_length = 0.01,
+                                               water_vapor_roughness_length = 0.01,
+                                               zero_plane_displacement = tall_displacement,
+                                               subgrid_velocities = nothing,
+                                               stability_functions = SimilarityScales(zero_ψ, zero_ψ, zero_ψ))
+        @test_throws ArgumentError AtmosphereLandModel(atmosphere, land; atmosphere_land_fluxes = tall_fluxes, radiation = nothing)
     end
 end
 


### PR DESCRIPTION
Closes #609.

`validate_zero_plane_displacement` returned early for anything but a `Number`, so a per-cell displacement field with `d ≥ zᵃᵗ` in some cell produced `log` of a non-positive number and NaN fluxes there, silently, where a scalar displacement throws `ArgumentError` at construction. The check is now the per-cell clearance `minimum(zᵃᵗ .- d) > 0`, which covers scalar and `Field` displacements against both a scalar and a per-column surface layer height.

```julia
d = Field{Center, Center, Nothing}(grid); set!(d, (λ, φ) -> ifelse(λ < 11, 0.0, 10.0))
fluxes = SimilarityTheoryFluxes(; zero_plane_displacement = d, …)
AtmosphereLandModel(atmosphere, land; atmosphere_land_fluxes = fluxes)   # surface layer height 10 m → ArgumentError
```

Test added to the per-cell roughness/displacement testset in `test_slab_land.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
