### PR TITLE
Accept a per-cell infiltration capacity in InfiltrationCapacityRunoff

### DIFF
--- a/src/Lands/hydrology/runoff_models.jl
+++ b/src/Lands/hydrology/runoff_models.jl
@@ -6,7 +6,8 @@
 ##### * `Rˢᶠᶜ`: surface runoff — rejected liquid input. Returned together with
 #####   the actual surface liquid flux `Jˡˢ` because they are coupled (the
 #####   infiltration-capacity model splits incoming precipitation between the
-#####   two).
+#####   two). The hydrology adds saturation excess (input the remaining pore
+#####   volume cannot hold) to `Rˢᶠᶜ` outside the closure.
 ##### * `Rˡᵃᵗ`: lateral / subsurface runoff — true storage export. Carries
 #####   internal energy with it.
 #####
@@ -24,7 +25,8 @@
 """
     NoRunoff()
 
-No runoff. All precipitation infiltrates (`Jˡˢ = −Pˡ`), no subsurface export.
+No runoff from the closure. All precipitation infiltrates (`Jˡˢ = −Pˡ`) up to
+the pore volume the column has left; no subsurface export.
 """
 struct NoRunoff end
 

--- a/src/Lands/hydrology/runoff_models.jl
+++ b/src/Lands/hydrology/runoff_models.jl
@@ -12,7 +12,7 @@
 #####
 ##### Each closure implements
 #####
-#####     surface_liquid_flux_and_runoff(runoff, Pˡ, M, θˡ, 𝒮, Π, K)
+#####     surface_liquid_flux_and_runoff(runoff, Pˡ, M, θˡ, 𝒮, Π, K, i, j)
 #####         -> (Jˡˢ, Rˢᶠᶜ)
 #####
 #####     subsurface_runoff(runoff, M, Π, K) -> Rˡᵃᵗ
@@ -28,7 +28,7 @@ No runoff. All precipitation infiltrates (`Jˡˢ = −Pˡ`), no subsurface expor
 """
 struct NoRunoff end
 
-@inline function surface_liquid_flux_and_runoff(::NoRunoff, Pˡ, M, θˡ, 𝒮, Π, K)
+@inline function surface_liquid_flux_and_runoff(::NoRunoff, Pˡ, M, θˡ, 𝒮, Π, K, i, j)
     return -Pˡ, zero(Pˡ)
 end
 
@@ -40,8 +40,8 @@ Base.summary(::NoRunoff) = "NoRunoff"
     InfiltrationCapacityRunoff(infiltration_capacity)
 
 Cap the downward infiltration rate at `infiltration_capacity` (kg m⁻² s⁻¹,
-positive magnitude). Any precipitation exceeding the cap becomes surface
-runoff:
+positive magnitude; a number or a per-cell `Field`). Any precipitation exceeding
+the cap becomes surface runoff:
 
 ```math
 J^{ls} = \\max(-P^l, -J^l_{cap}), \\qquad R^{\\mathrm{sfc}} = J^{ls} - (-P^l) \\ge 0.
@@ -49,18 +49,21 @@ J^{ls} = \\max(-P^l, -J^l_{cap}), \\qquad R^{\\mathrm{sfc}} = J^{ls} - (-P^l) \\
 
 No subsurface runoff.
 """
-struct InfiltrationCapacityRunoff{FT}
-    infiltration_capacity :: FT
+struct InfiltrationCapacityRunoff{C}
+    infiltration_capacity :: C
 end
 
 InfiltrationCapacityRunoff(FT::Type = Oceananigans.defaults.FloatType;
                            infiltration_capacity) =
-    InfiltrationCapacityRunoff(convert(FT, infiltration_capacity))
+    InfiltrationCapacityRunoff(normalize_property(FT, infiltration_capacity))
+
+Adapt.adapt_structure(to, c::InfiltrationCapacityRunoff) =
+    InfiltrationCapacityRunoff(Adapt.adapt(to, c.infiltration_capacity))
 
 @inline function surface_liquid_flux_and_runoff(c::InfiltrationCapacityRunoff,
-                                                Pˡ, M, θˡ, 𝒮, Π, K)
+                                                Pˡ, M, θˡ, 𝒮, Π, K, i, j)
     FT   = typeof(Pˡ)
-    Jcap = convert(FT, c.infiltration_capacity)
+    Jcap = convert(FT, property_value(c.infiltration_capacity, i, j))
     # Available downward flux is -Pˡ. Cap its downward magnitude at Jcap.
     Jˡs  = max(-Pˡ, -Jcap)
     Rsfc = Jˡs - (-Pˡ)   # ≥ 0

--- a/src/Lands/hydrology/variably_saturated_hydrology.jl
+++ b/src/Lands/hydrology/variably_saturated_hydrology.jl
@@ -211,7 +211,7 @@ saturation(h::VariablySaturatedHydrology, land) = land.saturation
     Π  = diagnostic_pressure_head(h, Mij, θˡ, 𝒮, i, j)
     K  = hydraulic_conductivity(h.hydraulic_conductivity, 𝒮)
 
-    Jˡs, Rsfc = surface_liquid_flux_and_runoff(h.runoff, Plij, Mij, θˡ, 𝒮, Π, K)
+    Jˡs, Rsfc = surface_liquid_flux_and_runoff(h.runoff, Plij, Mij, θˡ, 𝒮, Π, K, i, j)
     Jˡb       = deep_liquid_flux(h.deep_liquid_flux, Mij, θˡ, 𝒮, Π, K, Πᵈ, time)
     Rlat      = subsurface_runoff(h.runoff, Mij, Π, K)
 

--- a/src/Lands/hydrology/variably_saturated_hydrology.jl
+++ b/src/Lands/hydrology/variably_saturated_hydrology.jl
@@ -10,7 +10,9 @@
 ##### where every term is positive-upward (`Jˡˢ = −Pˡ + Rˢᶠᶜ`). The
 ##### conservative storage variable is the *augmented* liquid fraction
 ##### `ϑˡ = θˡ + max(Π,0)/hˢˢ`, so `Mˡᵃ > Mˡᵃ⁺` is admitted and corresponds to
-##### saturated positive-pressure storage (`Π > 0`).
+##### saturated positive-pressure storage (`Π > 0`), reachable only through an
+##### upward deep liquid flux or dew since infiltration is limited to the
+##### remaining pore volume.
 #####
 ##### Diagnostics published every step:
 #####   * `deep_liquid_flux`        (Jˡᵇ, positive upward)
@@ -154,13 +156,19 @@ end
     return clamp((θˡ - θʳ) / Δ, zero(FT), one(FT))
 end
 
-@inline function diagnostic_pressure_head(h, M, θˡ, 𝒮, i, j)
+@inline function saturated_water_storage(h, M, i, j)
     FT  = typeof(M)
     ν   = convert(FT, property_value(h.porosity, i, j))
+    hˡᵃ = convert(FT, property_value(h.slab_depth, i, j))
+    return convert(FT, h.liquid_density) * ν * hˡᵃ
+end
+
+@inline function diagnostic_pressure_head(h, M, θˡ, 𝒮, i, j)
+    FT  = typeof(M)
     ρˡ  = convert(FT, h.liquid_density)
     hˡᵃ = convert(FT, property_value(h.slab_depth, i, j))
     hˢˢ = convert(FT, property_value(h.storage_height, i, j))
-    Mˡᵃ⁺ = ρˡ * ν * hˡᵃ
+    Mˡᵃ⁺ = saturated_water_storage(h, M, i, j)
     # Unsaturated branch: Π = Π_m(𝒮). Saturated branch: Π = (M − M⁺) hˢˢ/(ρˡ hˡᵃ).
     return ifelse(M < Mˡᵃ⁺,
                   pressure_head(h.retention_curve, 𝒮),
@@ -214,6 +222,13 @@ saturation(h::VariablySaturatedHydrology, land) = land.saturation
     Jˡs, Rsfc = surface_liquid_flux_and_runoff(h.runoff, Plij, Mij, θˡ, 𝒮, Π, K, i, j)
     Jˡb       = deep_liquid_flux(h.deep_liquid_flux, Mij, θˡ, 𝒮, Π, K, Πᵈ, time)
     Rlat      = subsurface_runoff(h.runoff, Mij, Π, K)
+
+    # Infiltration cannot exceed the pore volume the column has left; the surplus
+    # is saturation-excess runoff.
+    pore_limited_flux = -max(saturated_water_storage(h, Mij, i, j) - Mij, 0) / Δt
+    saturation_excess = max(pore_limited_flux - Jˡs, 0)
+    Jˡs  += saturation_excess
+    Rsfc += saturation_excess
 
     dMdt = Jˡb - Jˡs - Jvij - Rlat
 

--- a/test/test_variably_saturated_hydrology.jl
+++ b/test/test_variably_saturated_hydrology.jl
@@ -136,5 +136,28 @@ end
         time_step!(land_drain, 100.0)
         # Expect M to decrease by 100 * 1e-3 = 0.1
         @test only(Array(interior(land_drain.water_storage))) ≈ 399.9 atol = 1e-3
+
+        # Rain on a column at pore capacity runs off: M stays at M⁺ less one step
+        # of drainage, and the runoff is the rain minus the drainage ρˡ K₀ = 1e-3.
+        hydrology_saturating = VariablySaturatedHydrology(eltype(grid);
+            slab_depth = 1.0,
+            porosity = 0.4,
+            storage_height = 1000,
+            retention_curve = VanGenuchtenRetention(α = 1.0, n = 2.0),
+            hydraulic_conductivity = VanGenuchtenConductivity(K_saturated = 1e-6, n = 2.0),
+            deep_liquid_flux = FreeDrainageFlux(),
+            runoff = InfiltrationCapacityRunoff(infiltration_capacity = 7.0),
+        )
+        land_saturating = SlabLand(grid; hydrology = hydrology_saturating)
+        set!(land_saturating; M = 399.0)
+        fill!(land_saturating.fluxes.vapor_flux, 0)
+        fill!(land_saturating.fluxes.liquid_precipitation_flux, 5.0)  # below capacity 7
+        for _ in 1:20
+            time_step!(land_saturating, 1.0)
+        end
+        M = only(Array(interior(land_saturating.water_storage)))
+        @test M ≤ 400.0
+        @test M ≈ 400.0 - 1e-3 atol = 1e-2
+        @test only(Array(interior(land_saturating.diagnostics.surface_runoff))) ≈ 5.0 - 1e-3 atol = 1e-2
     end
 end

--- a/test/test_variably_saturated_hydrology.jl
+++ b/test/test_variably_saturated_hydrology.jl
@@ -98,6 +98,26 @@ end
         @test only(Array(interior(land_capped.water_storage))) ≈ 7.0
         @test only(Array(interior(land_capped.diagnostics.surface_runoff))) ≈ 3.0
 
+        # A per-cell capacity field caps the same way.
+        capacity = Field{Center, Center, Nothing}(grid)
+        set!(capacity, 7.0)
+        hydrology_field_capped = VariablySaturatedHydrology(eltype(grid);
+            slab_depth = 1.0,
+            porosity = 0.4,
+            storage_height = 1000,
+            retention_curve = VanGenuchtenRetention(α = 1.0, n = 2.0),
+            hydraulic_conductivity = VanGenuchtenConductivity(K_saturated = 1e-6, n = 2.0),
+            deep_liquid_flux = NoDeepLiquidFlux(),
+            runoff = InfiltrationCapacityRunoff(infiltration_capacity = capacity),
+        )
+        land_field_capped = SlabLand(grid; hydrology = hydrology_field_capped)
+        set!(land_field_capped; M = 0.0)
+        fill!(land_field_capped.fluxes.vapor_flux, 0.0)
+        fill!(land_field_capped.fluxes.liquid_precipitation_flux, 10.0)
+        time_step!(land_field_capped, 1.0)
+        @test only(Array(interior(land_field_capped.water_storage))) ≈ 7.0
+        @test only(Array(interior(land_field_capped.diagnostics.surface_runoff))) ≈ 3.0
+
         # Free drainage: dM/dt = -ρˡ K_b. With K_sat = 1e-6, ρˡ = 1000:
         # at full saturation, K = K_sat, so Jˡ_b = -1e-3 kg/m²/s.
         hydrology_drain = VariablySaturatedHydrology(eltype(grid);


### PR DESCRIPTION
Closes #610 and #625.

`InfiltrationCapacityRunoff(; infiltration_capacity)` now takes a number or a `Field{Center, Center, Nothing}`, like every other `VariablySaturatedHydrology` parameter, so a texture map's Cosby saturated conductivity can cap infiltration cell by cell. The time-step kernel also limits infiltration to the pore volume the column has left and books the surplus as surface runoff, so rain cannot push `M` past `ρˡ ν hˡᵃ` under any runoff closure.

- `surface_liquid_flux_and_runoff(runoff, Pˡ, M, θˡ, 𝒮, Π, K, i, j)` — the runoff closures take cell indices.
- `Adapt.adapt_structure` for `InfiltrationCapacityRunoff`, so a `Field` capacity moves to the GPU with the hydrology.
- The pore-volume limit sits after the closure's rate cap, so `NoRunoff` and `InfiltrationCapacityRunoff` are unchanged and both get it. `M > ρˡ ν hˡᵃ` stays reachable through an upward deep liquid flux or dew.

```julia
capacity = Field{Center, Center, Nothing}(grid)
set!(capacity, 1000 * saturated_conductivity(CosbyConductivity(), sand))
VariablySaturatedHydrology(; …, runoff = InfiltrationCapacityRunoff(infiltration_capacity = capacity))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
