### PR TITLE
Make ESA WorldCover class fractions shares of the block area

### DIFF
--- a/examples/esa_worldcover_fractions.jl
+++ b/examples/esa_worldcover_fractions.jl
@@ -13,7 +13,7 @@
 # The 10 m `Map` band is *categorical*: its byte value is a class code, not a
 # quantity, so it is never averaged. The ingest counts codes over each aggregated
 # cell to form area fractions. Onto the model grid the fractions are regridded
-# conservatively (area-weighted, so they still sum to one), and the categorical
+# conservatively (area-weighted, so they still sum to the mapped share), and the categorical
 # majority class is the argmax of those fractions — the class covering the most
 # area of each cell, never a blend, so no intermediate code is ever invented.
 
@@ -74,7 +74,7 @@ class_model  = Field(Metadatum(:landcover_class; dataset, region), grid)
 fraction_fields = NamedTuple(name => Field(Metadatum(Symbol(name, :_fraction); dataset, region), grid)
                              for name in class_names)
 
-# Sum of the eleven per-class fractions — a wiring check that must be ≈ 1 over
+# Sum of the eleven per-class fractions — a wiring check that must be ≈ 1 over land
 # every valid cell.
 fraction_sum = sum(interior(f) for f in fraction_fields)
 
@@ -177,7 +177,8 @@ fig
 
 # ## Sum of fractions (wiring check) and native-vs-model comparison
 #
-# The eleven per-class fractions sum to ≈ 1 over every valid cell (left). The
+# The eleven per-class fractions sum to ≈ 1 over land cells and to the mapped share
+# along the coast (left). The
 # aggregated pattern is preserved from the native ~110 m grid to the model grid
 # (right two panels): the conservative regrid area-averages but does not move the
 # forest, cities, or lakes.

--- a/src/DataWrangling/WorldCover/WorldCover.jl
+++ b/src/DataWrangling/WorldCover/WorldCover.jl
@@ -240,33 +240,33 @@ end
 """
     class_fractions(pixels)
 
-Return a `NamedTuple` of per-class area fractions (each in `[0, 1]`) over
-`pixels`, keyed by the verbose class names. The fractions sum to 1 over valid
-pixels, and to 0 when every pixel is no-data.
+Return a `NamedTuple` of per-class area fractions (each in `[0, 1]`) of the block
+`pixels`, keyed by the verbose class names. No-data pixels belong to no class, so
+the fractions sum to the mapped share of the block: `1 - sum(class_fractions(pixels))`
+is the unmapped area — open water outside the product's land mask, in practice.
 """
-class_fractions(pixels::AbstractArray) = class_fractions(class_counts(pixels))
+class_fractions(pixels::AbstractArray) = class_fractions(class_counts(pixels), length(pixels))
 
-function class_fractions(counts::NamedTuple)
-    valid = sum(counts)
-    fractions = map(n -> valid == 0 ? 0.0 : n / valid, values(counts))
+function class_fractions(counts::NamedTuple, pixel_count)
+    fractions = map(n -> n / pixel_count, values(counts))
     return NamedTuple{keys(ESA_WORLDCOVER_CLASS_NAMES)}(fractions)
 end
 
 """
     vegetation_fraction(pixels; vegetated_classes = ESA_WORLDCOVER_VEGETATED_CLASSES)
 
-Return the area fraction of `pixels` belonging to `vegetated_classes` — the
-subgrid `f_veg`. See [`ESA_WORLDCOVER_VEGETATED_CLASSES`](@ref) for the default
-set and why it is a modeling choice.
+Return the area fraction of the block `pixels` belonging to `vegetated_classes` — the
+subgrid `f_veg`. No-data pixels count as unvegetated area. See
+[`ESA_WORLDCOVER_VEGETATED_CLASSES`](@ref) for the default set and why it is a
+modeling choice.
 """
-vegetation_fraction(pixels::AbstractArray; kw...) = vegetation_fraction(class_counts(pixels); kw...)
+vegetation_fraction(pixels::AbstractArray; kw...) =
+    vegetation_fraction(class_counts(pixels), length(pixels); kw...)
 
-function vegetation_fraction(counts::NamedTuple; vegetated_classes = ESA_WORLDCOVER_VEGETATED_CLASSES)
-    valid = sum(counts)
-    valid == 0 && return 0.0
+function vegetation_fraction(counts::NamedTuple, pixel_count; vegetated_classes = ESA_WORLDCOVER_VEGETATED_CLASSES)
     vegetated = sum(map((code, n) -> ifelse(code in vegetated_classes, n, 0),
                         ESA_WORLDCOVER_CLASS_CODES, values(counts)))
-    return vegetated / valid
+    return vegetated / pixel_count
 end
 
 """
@@ -307,10 +307,10 @@ once, with every product derived from the same [`class_counts`](@ref).
 function aggregate_landcover(pixels::AbstractMatrix, factor::Integer;
                              vegetated_classes = ESA_WORLDCOVER_VEGETATED_CLASSES)
     counts = aggregate_blockwise(pixels, factor, class_counts)
-    fractions = map(class_fractions, counts)
+    fractions = map(c -> class_fractions(c, factor^2), counts)
 
     landcover_class = map(majority_class, counts)
-    vegetation = map(c -> vegetation_fraction(c; vegetated_classes), counts)
+    vegetation = map(c -> vegetation_fraction(c, factor^2; vegetated_classes), counts)
     fraction_arrays = map(name -> map(f -> f[name], fractions),
                           keys(ESA_WORLDCOVER_CLASS_NAMES))
     class_fraction_fields = NamedTuple{keys(ESA_WORLDCOVER_CLASS_NAMES)}(fraction_arrays)
@@ -424,7 +424,8 @@ Oceananigans.Fields.location(::ESAWorldCoverMetadatum) = (Center, Center, Center
 #####
 ##### The fraction products ride Oceananigans' conservative (area-weighted)
 ##### `regrid!`, so each target cell carries the true area fraction of every class
-##### and the fractions still sum to one. The categorical `:landcover_class` is the argmax of
+##### and the fractions still sum to the mapped share of the cell. The categorical
+##### `:landcover_class` is the argmax of
 ##### those fractions — the class covering the most area of the target cell.
 ##### Bilinear interpolation of the codes would instead invent intermediate,
 ##### non-legend classes. Both extend the shared `interpolate_physical!` regrid

--- a/test/test_esaworldcover.jl
+++ b/test/test_esaworldcover.jl
@@ -77,18 +77,18 @@ end
     @test majority_class(patch) in ESA_WORLDCOVER_CLASS_CODES
 end
 
-@testset "per-class fractions sum to 1 over valid pixels" begin
+@testset "per-class fractions are shares of the block area" begin
     # 2×2 tree, plus one crop and one no-data pixel.
     codes = UInt8[10 10 40
                   10 10 0]  # 5 valid (four 10s, one 40), one no-data
     fr = class_fractions(codes)
-    @test fr.tree_cover == 4 / 5
-    @test fr.cropland   == 1 / 5
-    @test sum(values(fr)) ≈ 1.0
+    @test fr.tree_cover == 4 / 6
+    @test fr.cropland   == 1 / 6
+    @test sum(values(fr)) ≈ 5 / 6   # the no-data pixel is the unmapped sixth
 
-    # The fractions are the counts normalized by the valid-pixel count.
+    # The fractions are the counts normalized by the block size.
     counts = class_counts(codes)
-    @test values(fr) == values(counts) ./ sum(counts)
+    @test values(fr) == values(counts) ./ length(codes)
 
     # A uniform patch: one class is 1, the rest are 0.
     uniform = fill(UInt8(20), 5, 5)
@@ -104,20 +104,20 @@ end
     @test vegetation_fraction(empty) == 0.0
     @test majority_class(empty) == 0
 
-    # No-data pixels are excluded from the denominator.
+    # No-data pixels stay in the denominator as unmapped area.
     codes = UInt8[10 0 0
-                  0 0 0]  # 1 valid tree pixel out of 6
-    @test class_fractions(codes).tree_cover == 1.0
+                  0 0 0]  # 1 tree pixel out of 6
+    @test class_fractions(codes).tree_cover == 1 / 6
 end
 
 @testset "vegetation fraction" begin
     # tree(10)+crop(40) vegetated; water(80)+built-up(50) not; one no-data.
     codes = UInt8[10 40 80
-                  50 0 10]  # valid: 10,40,80,50,10 → 3 vegetated of 5
-    @test vegetation_fraction(codes) == 3 / 5
+                  50 0 10]  # 3 vegetated of 6 pixels, one of them no-data
+    @test vegetation_fraction(codes) == 3 / 6
 
     # Overriding the vegetated-class set is a modeling choice.
-    @test vegetation_fraction(codes; vegetated_classes = (80,)) == 1 / 5
+    @test vegetation_fraction(codes; vegetated_classes = (80,)) == 1 / 6
 
     # Equals the sum of the vegetated-class fractions.
     fr = class_fractions(codes)


### PR DESCRIPTION
Closes #608.

`class_fractions` and `vegetation_fraction` normalized by the number of *classified* pixels, so a block half covered by unmapped sea reported its land classes as if they filled the block, and an all-no-data block reported zeros — open sea inside a published WorldCover tile reached a model grid as "0% water, 0% vegetation", i.e. bare land (44,958 cells over the CONUS box). Per-valid fractions are also not conservative under the area-weighted `regrid!`: averaging blocks with different denominators does not give the target cell's area fraction.

Fractions are now shares of the block area: no-data pixels belong to no class, `Σ class fractions` is the mapped share of the block, and `1 − Σ` is the unmapped (sea) area. The `:landcover_class` mask for cells with total ≤ ½ now means "less than half mapped".

```julia
codes = UInt8[10 10 40; 10 10 0]      # four tree, one crop, one no-data pixel
class_fractions(codes).tree_cover     # 4/6 (was 4/5)
sum(values(class_fractions(codes)))   # 5/6 (was 1)
```

`class_fractions(counts, pixel_count)` / `vegetation_fraction(counts, pixel_count; …)` replace the counts-only methods; `aggregate_landcover` passes `factor^2`. Tests and the example's wording follow the new semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)