### PR TITLE
Blend tiled land fluxes with literal weights

### DIFF
--- a/src/EarthSystemModels/InterfaceComputations/tiled_land_interface.jl
+++ b/src/EarthSystemModels/InterfaceComputations/tiled_land_interface.jl
@@ -184,7 +184,7 @@ function compute_atmosphere_land_fluxes!(coupled_model, ti::TiledLandInterface)
             ti.fluxes, ti.temperature,
             ti.vegetated.fluxes, ti.vegetated.temperature,
             ti.bare.fluxes, ti.bare.temperature,
-            fraction, fraction_time_interpolator, grid)
+            fraction, fraction_time_interpolator)
 
     return nothing
 end
@@ -192,11 +192,10 @@ end
 @kernel function _blend_tiled_land_fluxes!(blended_fluxes, blended_temperature,
                                            veg_fluxes, veg_temperature,
                                            bare_fluxes, bare_temperature,
-                                           fraction, fraction_time_interpolator, grid)
+                                           fraction, fraction_time_interpolator)
     i, j = @index(Global, NTuple)
-    FT = eltype(grid)
-    f = clamp(convert(FT, surface_field_value(fraction, i, j, fraction_time_interpolator)), zero(FT), one(FT))
-    g = one(FT) - f
+    f = clamp(surface_field_value(fraction, i, j, fraction_time_interpolator), 0, 1)
+    g = 1 - f
 
     @inbounds begin
         blended_fluxes.latent_heat[i, j, 1]       = f * veg_fluxes.latent_heat[i, j, 1]       + g * bare_fluxes.latent_heat[i, j, 1]
@@ -224,6 +223,6 @@ end
         vegetated_temperature = veg_temperature.effective[i, j, 1]
         bare_effective_temperature = bare_temperature.effective[i, j, 1]
         blended_temperature.effective[i, j, 1] =
-            (f * vegetated_temperature^4 + g * bare_effective_temperature^4)^convert(FT, 1//4)
+            sqrt(sqrt(f * vegetated_temperature^4 + g * bare_effective_temperature^4))
     end
 end

--- a/src/Lands/hydrology/intercepting_hydrology.jl
+++ b/src/Lands/hydrology/intercepting_hydrology.jl
@@ -145,7 +145,7 @@ end
         rain  = Pl[i, j, 1]       # raw rain, positive down
         Eʷᵉᵗ = Cev[i, j, 1]      # interface-demanded wet-canopy evaporation, positive up
     end
-    FT    = eltype(grid)
+    FT    = typeof(Wcⁿ)
     # `Time(time)` so a time-varying (`FieldTimeSeries`) LAI interpolates to the clock;
     # a `Number`/`Field` LAI ignores the time argument.
     LAI   = convert(FT, stateindex(h.leaf_area_index, i, j, 1, grid, Time(time), (Center, Center, Center)))
@@ -191,7 +191,7 @@ end
 
 @kernel function _canopy_capacity!(capacity, h, grid, time)
     i, j = @index(Global, NTuple)
-    FT  = eltype(grid)
+    FT  = eltype(capacity)
     LAI = convert(FT, stateindex(h.leaf_area_index, i, j, 1, grid, Time(time), (Center, Center, Center)))
     @inbounds capacity[i, j, 1] = h.capacity_per_leaf_area * LAI
 end


### PR DESCRIPTION
`_blend_tiled_land_fluxes!`, `_interception_step!` and `_canopy_capacity!` typed their literals with `FT = eltype(grid)`. Under Reactant the grid reaches a kernel with that parameter retyped to a traced number, so `zero(FT)`, `one(FT)` and `convert(FT, …)` route through a `promote_rule` that GPUCompiler cannot compile, and a 2D `TiledLandInterface` fails to build under Reactant. The blend kernel now uses literal weights and `sqrt(sqrt(…))` for the quarter power and no longer takes the grid; the interception kernels take `FT` from the state they update.

Fixes #617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)