### PR TITLE
Widen the grid node to Float64 before the longitude wrap

### DIFF
--- a/src/DataWrangling/set_region_data.jl
+++ b/src/DataWrangling/set_region_data.jl
@@ -103,8 +103,9 @@ function region_info(::BoundingBox, target, λc, φc)
 
     # Shift the target's longitude into the file's `[λc[1], λc[1]+360)`, allowing half a cell of
     # slack at the west edge: a Float32 grid node can land a few ulps below `λc[1]`, and wrapping
-    # such a node by +360° would place the window at the far end of the file.
-    λfile = length(λc) > 1 ? convert_to_λ₀_λ₀_plus360(λmin, λc[1] - abs(λc[2] - λc[1]) / 2) : λmin
+    # such a node by +360° would place the window at the far end of the file. The wrap round-trips
+    # through `360 + λ`, which in Float32 costs four decimal digits, so the node is widened first.
+    λfile = length(λc) > 1 ? convert_to_λ₀_λ₀_plus360(Float64(λmin), λc[1] - abs(λc[2] - λc[1]) / 2) : λmin
 
     di = file_cell_index(λfile, λc) - 1
     dj = file_cell_index(φmin, φc) - 1

--- a/test/test_bare_earth_terrain.jl
+++ b/test/test_bare_earth_terrain.jl
@@ -115,6 +115,13 @@ end
     # wrap by 360° and select the far end of the file.
     west = BoundingBox(longitude = (-180, -174), latitude = (0, 4))
     @test region_info(west, window_field(west), longitudes, etopo_latitudes()).di == 0
+
+    # Near the prime meridian the wrap through 360° costs a Float32 node more precision than the
+    # match allows, and the window would start a whole cell east of the node it labels.
+    meridian = BoundingBox(longitude = (0, 6), latitude = (0, 4))
+    field = window_field(meridian)
+    di = region_info(meridian, field, longitudes, etopo_latitudes()).di
+    @test abs(longitudes[di + 1] - minimum(λnodes(field.grid, Center()))) < 1/120
 end
 
 @testset "windowed reads — a window across the seam continues into the file" begin


### PR DESCRIPTION
Fixes #620. `region_info` wrapped the target grid's westernmost node into the file's longitude
convention in Float32, and the `360 + λ` round trip cost more precision than `file_cell_index`
tolerates near the prime meridian: a node sitting on a file label matched the label after it, so
the window was read one whole cell east.

- `region_info` widens the node to `Float64` before the wrap.
- New case in `windowed reads — matching a grid node against the file's labels`, which fails on
  `xk/dsm` by exactly one 1/60° cell.

Based on `xk/dsm` (#465), which is where `file_cell_index` lives.
