### PR TITLE
Add masked_regrid! for regridding fields with invalid cells

### DIFF
--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -16,6 +16,7 @@ export DatasetRestoring, SurfaceFluxRestoring
 export ERA5HourlySingleLevel, ERA5MonthlySingleLevel, ERA5HourlyPressureLevels, ERA5MonthlyPressureLevels
 export ERA5HourlyLand, ERA5MonthlyLand
 export native_grid
+export masked_regrid!
 
 using Adapt: Adapt
 using Downloads: Downloads
@@ -30,7 +31,7 @@ using Oceananigans.DistributedComputations: DistributedComputations, @root, all_
 using Oceananigans.Grids: AbstractGrid, Center, Flat, Bounded,
                           LatitudeLongitudeGrid, RectilinearGrid, λnodes, φnodes,
                           topology, x_domain, y_domain, z_domain
-using Oceananigans.Fields: Fields, Field, interpolate, interpolate!, interior, set!
+using Oceananigans.Fields: Fields, Field, interpolate, interpolate!, interior, regrid!, set!
 using Oceananigans.Grids: node
 using Oceananigans.OutputReaders: OnDisk, AbstractInMemoryBackend, Cyclical,
                                   FieldTimeSeries, FlavorOfFTS, time_indices
@@ -269,6 +270,7 @@ include("set_region_data.jl")
 include("field_cache.jl")
 include("metadata_field.jl")
 include("tiled_regridding.jl")
+include("masked_regrid.jl")
 include("dataset_backend.jl")
 include("metadata_field_time_series.jl")
 include("inpainting.jl")

--- a/src/DataWrangling/masked_regrid.jl
+++ b/src/DataWrangling/masked_regrid.jl
@@ -1,0 +1,26 @@
+using DocStringExtensions: TYPEDSIGNATURES
+
+"""
+$(TYPEDSIGNATURES)
+
+Fill `target` with the area-weighted mean of the finite `source` cells under each
+target cell. A target cell that no finite source cell overlaps is set to `NaN`.
+"""
+function masked_regrid!(target, source)
+    LX, LY, LZ = location(source)
+    finite_values = Field{LX, LY, LZ}(source.grid)
+    finite_mask   = Field{LX, LY, LZ}(source.grid)
+    finite = isfinite.(interior(source))
+    interior(finite_values) .= ifelse.(finite, interior(source), 0)
+    interior(finite_mask)   .= finite
+
+    TX, TY, TZ = location(target)
+    weight = Field{TX, TY, TZ}(target.grid)
+    regrid!(target, finite_values)
+    regrid!(weight, finite_mask)
+
+    # A cell with no finite coverage divides 0 by 0 and comes out NaN.
+    interior(target) ./= interior(weight)
+
+    return target
+end

--- a/test/test_masked_regrid.jl
+++ b/test/test_masked_regrid.jl
@@ -1,0 +1,29 @@
+include("runtests_setup.jl")
+
+using NumericalEarth.DataWrangling: masked_regrid!
+
+@testset "masked_regrid!" begin
+    topology = (Bounded, Bounded, Flat)
+    source_grid = RectilinearGrid(CPU(); size = (4, 4), x = (0, 4), y = (0, 4), topology)
+    target_grid = RectilinearGrid(CPU(); size = (2, 2), x = (0, 4), y = (0, 4), topology)
+
+    source = CenterField(source_grid)
+    target = CenterField(target_grid)
+
+    interior(source, :, :, 1) .= reshape(1:16, 4, 4)
+    interior(source, 1, 1, 1) .= NaN
+    interior(source, 3:4, 3:4, 1) .= NaN
+
+    masked_regrid!(target, source)
+    result = Array(interior(target, :, :, 1))
+
+    @test result[1, 1] ≈ (2 + 5 + 6) / 3
+    @test result[2, 1] ≈ (3 + 4 + 7 + 8) / 4
+    @test result[1, 2] ≈ (9 + 10 + 13 + 14) / 4
+    @test isnan(result[2, 2])
+
+    set!(source, 3.5)
+    interior(source, 2, 2, 1) .= NaN
+    masked_regrid!(target, source)
+    @test all(Array(interior(target)) .≈ 3.5)
+end


### PR DESCRIPTION
`masked_regrid!(target, source)`, exported from `DataWrangling`: a conservative regrid that ignores non-finite source cells. Each target cell gets the area-weighted mean of the finite source cells under it; a cell with no finite coverage comes out `NaN`.

- Two `regrid!` passes — the source with invalid cells zeroed, and its finite mask as the weight — followed by a division.
- Analytic test: a 4×4 → 2×2 rectilinear coarsening with a NaN hole, plus a constant field regridding to the same constant despite holes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)