### PR TITLE
Compose inpainting with tiled regridding

### DIFF
--- a/src/DataWrangling/tiled_regridding.jl
+++ b/src/DataWrangling/tiled_regridding.jl
@@ -163,9 +163,8 @@ end
 
 # The native grid to regrid `metadata` onto `target` in tiles, or `nothing` where tiling would not
 # reproduce the single-pass regrid.
-function tiled_native_grid(target, metadata, inpainting, halo)
+function tiled_native_grid(target, metadata, halo)
     windowed_retrieval(metadata.dataset) || return nothing
-    isnothing(inpainting) || return nothing
     metadata.region isa BoundingBox || return nothing
     isnothing(horizontal_centers(target.grid)) && return nothing
 
@@ -189,8 +188,9 @@ end
     regrid_from_metadata!(target, metadata; tile_bytes = default_tile_bytes, kw...)
 
 Fill `target` from `metadata`, regridding in tiles of at most `tile_bytes` of source each where
-the dataset reads windows, and in a single pass otherwise. Remaining keyword arguments go to
-`Field(metadata, arch; …)`.
+the dataset reads windows, and in a single pass otherwise. On the tiled path `inpainting` fills
+the gaps of the assembled `target`, which the tiles leave `NaN`. Remaining keyword arguments go
+to `Field(metadata, arch; …)`.
 """
 function regrid_from_metadata!(target, metadata;
                                tile_bytes = default_tile_bytes,
@@ -200,7 +200,7 @@ function regrid_from_metadata!(target, metadata;
 
     Downloads.download(metadata)
 
-    native = tiled_native_grid(target, metadata, inpainting, halo)
+    native = tiled_native_grid(target, metadata, halo)
 
     if isnothing(native)
         source = Field(metadata, architecture(target.grid); inpainting, halo, kw...)
@@ -209,6 +209,11 @@ function regrid_from_metadata!(target, metadata;
     end
 
     validate_vertical_extent(target.grid, native, metadata)
+    regrid_in_tiles!(target, metadata, native, tile_bytes)
 
-    return regrid_in_tiles!(target, metadata, native, tile_bytes)
+    if !isnothing(inpainting)
+        inpaint_mask!(target, compute_mask(metadata, target); inpainting)
+    end
+
+    return target
 end

--- a/test/test_openlandmap.jl
+++ b/test/test_openlandmap.jl
@@ -5,7 +5,7 @@ using NumericalEarth.DataWrangling: longitude_interfaces, latitude_interfaces, z
                                     dataset_variable_name, validate_dataset_coverage,
                                     metadata_filename, conversion_units, convert_units,
                                     default_inpainting, is_three_dimensional,
-                                    WeightPercent, GramPerCubicCentimeter
+                                    NearestNeighborInpainting, WeightPercent, GramPerCubicCentimeter
 using NumericalEarth.DataWrangling.OpenLandMap: cog_window_to_netcdf
 
 using ArchGDAL
@@ -180,6 +180,43 @@ end
         tiled = Array(interior(Field(metadatum, grid; tile_bytes)))
         @test size(tiled) == size(reference)
         @test isequal(tiled, reference)
+    end
+end
+
+@testset "tiled regrid inpaints the assembled target" begin
+    dir = mktempdir()
+
+    # The gap sits inside a constant plateau, so inpainting fills it with the plateau
+    # value whether it runs on the native window or on the assembled target.
+    nx, ny = 512, 512
+    x0, y0, dx, dy = -112.0005, 36.0005, 0.00025, -0.00025
+    raw = Float32[30 + 10 * sinpi(i / 64) * cospi(j / 48) + (i % 7) for i in 1:nx, j in 1:ny]
+    raw[75:165, 35:115] .= 25.0
+    raw[100:140, 60:90] .= -1.0
+
+    tif = write_synthetic_tile(joinpath(dir, "gap.tif");
+                               nx, ny, x0, y0, dx, dy, scale = 1.0, offset = 0.0,
+                               nodata = -1.0, raw, dtype = Float32)
+
+    grid = LatitudeLongitudeGrid(CPU(); size = (10, 10, 3),
+                                 longitude = (-111.98, -111.96), latitude = (35.97, 35.99),
+                                 z = [-1.0, -0.6, -0.3, 0.0])
+    region = BoundingBox(grid)
+    metadatum = Metadatum(:clay_fraction; dataset = OpenLandMapSoilDB(), region, dir)
+    cog_window_to_netcdf(fill(tif, 3), metadata_path(metadatum), "clay", region)
+
+    inpainting = NearestNeighborInpainting(Inf)
+
+    native = Field(metadatum, CPU(); inpainting)
+    untiled = Field{Center, Center, Center}(grid)
+    NumericalEarth.DataWrangling.interpolate_physical!(untiled, native, metadatum)
+    reference = Array(interior(untiled))
+    @test !any(isnan, reference)
+
+    for tile_bytes in (typemax(Int), 20_000)
+        tiled = Array(interior(Field(metadatum, grid; tile_bytes, inpainting)))
+        @test !any(isnan, tiled)
+        @test tiled ≈ reference
     end
 end
 


### PR DESCRIPTION
Passing `inpainting` to `Field(metadatum, grid)` silently disabled tiled regridding, forcing the whole-window path — unbounded memory for granule-heavy datasets whose gaps need filling. Tiled regridding and inpainting now compose.

- `tiled_native_grid` no longer bails out when `inpainting` is set
- the tiled path regrids first, then inpaints the assembled target once (tiles leave gaps as `NaN`)
- test: tiled regrid + inpainting reproduces the whole-window regrid + inpainting on a synthetic tile with a gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)