### PR TITLE
(0.9.0) Evaluate urban roughness at neighborhood scale from building datasets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NumericalEarth"
 uuid = "904d977b-046a-4731-8b86-9235c0d1ef02"
 license = "MIT"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["NumericalEarth contributors"]
 
 [deps]

--- a/examples/globfp3d_building_morphometry.jl
+++ b/examples/globfp3d_building_morphometry.jl
@@ -42,7 +42,7 @@ fig1
 target_grid = LatitudeLongitudeGrid(CPU(), Float64; size = (102, 136),
                                     longitude = region.longitude, latitude = region.latitude,
                                     topology = (Bounded, Bounded, Flat))
-morphometry = building_morphometry(target_grid; dataset, region)
+morphometry = building_morphometry(target_grid, dataset; region)
 
 robust_range(field) = (v = filter(>(0), interior(field, :, :, 1)); isempty(v) ? (0, 1) : (0, quantile(v, 0.98)))
 
@@ -66,7 +66,7 @@ Label(fig2[0, 1:2], "3D-GloBFP building morphometry — Manhattan (3 m raster �
 overview_grid = LatitudeLongitudeGrid(CPU(), Float64; size = size(building_height)[1:2] .÷ 3,
                                       longitude = region.longitude, latitude = region.latitude,
                                       topology = (Bounded, Bounded, Flat))
-building_height_overview = building_morphometry(overview_grid; dataset, region).maximum_building_height
+building_height_overview = building_morphometry(overview_grid, dataset; region).maximum_building_height
 
 left = fig2[1, 1] = GridLayout()
 ax_bh = Axis(left[1, 1]; title = "building height (9 m max of the 3 m raster)",
@@ -184,7 +184,7 @@ end
 kilometer_grid = LatitudeLongitudeGrid(CPU(), Float64; size = (8, 13),
                                        longitude = region.longitude, latitude = region.latitude,
                                        topology = (Bounded, Bounded, Flat))
-kilometer_morphometry = building_morphometry(kilometer_grid; dataset, region)
+kilometer_morphometry = building_morphometry(kilometer_grid, dataset; region)
 
 kilometer_regressed_roughness, kilometer_regressed_displacement =
     urban_roughness(kilometer_morphometry.mean_building_height, kilometer_morphometry.plan_area_index)

--- a/examples/globfp3d_building_morphometry.jl
+++ b/examples/globfp3d_building_morphometry.jl
@@ -42,7 +42,7 @@ fig1
 target_grid = LatitudeLongitudeGrid(CPU(), Float64; size = (102, 136),
                                     longitude = region.longitude, latitude = region.latitude,
                                     topology = (Bounded, Bounded, Flat))
-morphometry = building_morphometry(target_grid, dataset; region)
+morphometry = building_morphometry(target_grid, dataset)
 
 robust_range(field) = (v = filter(>(0), interior(field, :, :, 1)); isempty(v) ? (0, 1) : (0, quantile(v, 0.98)))
 
@@ -66,7 +66,7 @@ Label(fig2[0, 1:2], "3D-GloBFP building morphometry — Manhattan (3 m raster �
 overview_grid = LatitudeLongitudeGrid(CPU(), Float64; size = size(building_height)[1:2] .÷ 3,
                                       longitude = region.longitude, latitude = region.latitude,
                                       topology = (Bounded, Bounded, Flat))
-building_height_overview = building_morphometry(overview_grid, dataset; region).maximum_building_height
+building_height_overview = building_morphometry(overview_grid, dataset).maximum_building_height
 
 left = fig2[1, 1] = GridLayout()
 ax_bh = Axis(left[1, 1]; title = "building height (9 m max of the 3 m raster)",
@@ -184,7 +184,7 @@ end
 kilometer_grid = LatitudeLongitudeGrid(CPU(), Float64; size = (8, 13),
                                        longitude = region.longitude, latitude = region.latitude,
                                        topology = (Bounded, Bounded, Flat))
-kilometer_morphometry = building_morphometry(kilometer_grid, dataset; region)
+kilometer_morphometry = building_morphometry(kilometer_grid, dataset)
 
 kilometer_regressed_roughness, kilometer_regressed_displacement =
     urban_roughness(kilometer_morphometry.mean_building_height, kilometer_morphometry.plan_area_index)

--- a/src/DataWrangling/GHSL/GHSL.jl
+++ b/src/DataWrangling/GHSL/GHSL.jl
@@ -453,21 +453,6 @@ ghsl_tiles_to_netcdf(metadatum, nc_path) =
 ##### urban lattice cells.
 #####
 
-# Regrid in latitude, then in longitude, through a grid sharing the source's longitudes
-# and the target's latitudes.
-function conservative_regrid(target_grid, source)
-    FT = eltype(target_grid)
-    intermediate_grid = LatitudeLongitudeGrid(CPU(), FT; size = (size(source, 1), size(target_grid, 2)),
-                                              longitude = x_domain(source.grid),
-                                              latitude = φnodes(target_grid, Face()),
-                                              topology = (Bounded, Bounded, Flat))
-    intermediate = Field{Center, Center, Nothing}(intermediate_grid)
-    target = Field{Center, Center, Nothing}(target_grid)
-    regrid!(intermediate, source)
-    regrid!(target, intermediate)
-    return target
-end
-
 # Sums over the `refinement × refinement` blocks of a lattice array.
 block_sum(a, refinement) =
     dropdims(sum(reshape(a, refinement, size(a, 1) ÷ refinement, refinement, size(a, 2) ÷ refinement); dims = (1, 3)); dims = (1, 3))
@@ -526,12 +511,17 @@ function Lands.urban_roughness(grid, height_dataset::GHSBuiltH, built_dataset::G
         replace!(interior(built_fraction), NaN => 0)
         replace!(interior(building_height), NaN => 0)
         if built_fraction.grid != building_height.grid  # the 10 m built-up product
-            built_fraction = conservative_regrid(building_height.grid, built_fraction)
+            fraction_on_height_pixels = Field{Center, Center, Center}(building_height.grid)
+            built_fraction = regrid!(fraction_on_height_pixels, built_fraction)
         end
         interior(building_height) .*= interior(built_fraction)  # building volume per pixel area
 
-        interior(λᵖ, a, b, 1) .= interior(conservative_regrid(window_lattice, built_fraction), :, :, 1)
-        interior(h,  a, b, 1) .= interior(conservative_regrid(window_lattice, building_height), :, :, 1)
+        window_fraction = Field{Center, Center, Nothing}(window_lattice)
+        window_volume   = Field{Center, Center, Nothing}(window_lattice)
+        regrid!(window_fraction, built_fraction)
+        regrid!(window_volume, building_height)
+        interior(λᵖ, a, b, 1) .= interior(window_fraction, :, :, 1)
+        interior(h,  a, b, 1) .= interior(window_volume, :, :, 1)
     end
     interior(h) .= ifelse.(interior(λᵖ) .> 0, interior(h) ./ interior(λᵖ), 0)
 

--- a/src/DataWrangling/GHSL/GHSL.jl
+++ b/src/DataWrangling/GHSL/GHSL.jl
@@ -3,14 +3,15 @@ module GHSL
 export GHSBuiltH, GHSBuiltS, GHSBuiltSResolution, GHSBuiltS10m, GHSBuiltS100m
 
 using Downloads: Downloads
-using Oceananigans: Bounded, Center, CPU, Field, Flat, LatitudeLongitudeGrid, interior, set!
+using Oceananigans: Bounded, Center, CPU, Face, Field, Flat, LatitudeLongitudeGrid, interior, set!
+using Oceananigans.Fields: regrid!
 using Oceananigans.DistributedComputations: @root
 using Oceananigans.Grids: x_domain, y_domain, λnodes, φnodes
 
 using NumericalEarth.Lands: Lands, MorphometricRoughness, aerodynamic_parameters, urban_roughness
 
 using ..DataWrangling: DataWrangling, AbstractStaticDataset, Metadatum,
-                       metadata_path, native_grid, BoundingBox, bounding_box_suffix
+                       metadata_path, native_grid, BoundingBox, bounding_box_suffix, tile_indices
 
 using DocStringExtensions: TYPEDSIGNATURES
 
@@ -447,105 +448,106 @@ ghsl_tiles_to_netcdf(metadatum, nc_path) =
           "Load it with `using ArchGDAL`.")
 
 #####
-##### Urban roughness on a model grid: bin the native pixels onto a neighborhood-scale
-##### evaluation lattice, apply the morphometric closure there, reduce with built-area
-##### weighting.
+##### Urban roughness on a model grid: conservative pixel means on a neighborhood-scale
+##### lattice, the morphometric closure evaluated there, reduced to the grid over the
+##### urban lattice cells.
 #####
 
-"""
-$(TYPEDSIGNATURES)
-
-Accumulate the native `building_height` and `built_up_fraction` rasters onto the
-evaluation lattice dividing `domain` into `size(pixels)` cells: `pixels` counts each
-lattice cell's raster pixels of known built fraction, `area` sums their built fraction,
-and `volume` sums their built fraction times height (a pixel of unknown height adds area
-but no volume). Only pixels whose centers fall in `window` — half-open in both
-coordinates, so abutting windows never double count — are binned.
-"""
-function bin_built_pixels!(volume, area, pixels, building_height, built_up_fraction, window, domain)
-    size(building_height) == size(built_up_fraction) ||
-        throw(ArgumentError("the building-height and built-up-fraction rasters differ in size, " *
-                            "$(size(building_height)) vs $(size(built_up_fraction))"))
-
-    λ₁, λ₂ = domain.longitude
-    φ₁, φ₂ = domain.latitude
-    Δλ = (λ₂ - λ₁) / size(pixels, 1)
-    Δφ = (φ₂ - φ₁) / size(pixels, 2)
-
-    λ = λnodes(built_up_fraction.grid, Center())
-    φ = φnodes(built_up_fraction.grid, Center())
-    heights = interior(building_height, :, :, 1)
-    fractions = interior(built_up_fraction, :, :, 1)
-
-    for b in eachindex(φ), a in eachindex(λ)
-        window.longitude[1] <= λ[a] < window.longitude[2] &&
-            window.latitude[1] <= φ[b] < window.latitude[2] || continue
-        λᵖ = fractions[a, b]
-        isfinite(λᵖ) || continue
-        i = floor(Int, (λ[a] - λ₁) / Δλ) + 1
-        j = floor(Int, (φ[b] - φ₁) / Δφ) + 1
-        pixels[i, j] += 1
-        area[i, j] += λᵖ
-        isfinite(heights[a, b]) && (volume[i, j] += λᵖ * heights[a, b])
-    end
-    return nothing
+# Regrid in latitude, then in longitude, through a grid sharing the source's longitudes
+# and the target's latitudes.
+function conservative_regrid(target_grid, source)
+    FT = eltype(target_grid)
+    intermediate_grid = LatitudeLongitudeGrid(CPU(), FT; size = (size(source, 1), size(target_grid, 2)),
+                                              longitude = x_domain(source.grid),
+                                              latitude = φnodes(target_grid, Face()),
+                                              topology = (Bounded, Bounded, Flat))
+    intermediate = Field{Center, Center, Nothing}(intermediate_grid)
+    target = Field{Center, Center, Nothing}(target_grid)
+    regrid!(intermediate, source)
+    regrid!(target, intermediate)
+    return target
 end
 
+# Sums over the `refinement × refinement` blocks of a lattice array.
+block_sum(a, refinement) =
+    dropdims(sum(reshape(a, refinement, size(a, 1) ÷ refinement, refinement, size(a, 2) ÷ refinement); dims = (1, 3)); dims = (1, 3))
+
 """
 $(TYPEDSIGNATURES)
 
-Aerodynamic parameters on `grid` from the binned `volume` (Σ λᵖh), `area` (Σ λᵖ) and
-`pixels` accumulators of its evaluation lattice: `closure` maps each lattice cell's
-plan-area index `area / pixels` and built-area-weighted height `volume / area` to
-`(ℓᵐ, d)`, which then reduce to each grid cell over its built lattice cells (plan-area
-index at least the closure's `minimum_built_fraction`), weighted by built area — the
-log-mean `ℓᵐ` and the mean `d` and building height. A grid cell with no built lattice
-cell takes the closure's bare-soil limit. Returns the NamedTuple of `Field`s
-`(; ℓᵐ, d, urban_fraction, building_height)`, where `urban_fraction` is the built
-share of each cell's lattice.
-"""
-function binned_urban_roughness(grid, volume, area, pixels, closure)
-    FT = eltype(grid)
-    nx, ny = size(pixels)
-    domain = BoundingBox(grid)
-    lattice = LatitudeLongitudeGrid(CPU(), FT; size = (nx, ny),
-                                    longitude = domain.longitude, latitude = domain.latitude,
-                                    topology = (Bounded, Bounded, Flat))
+Momentum roughness length `ℓᵐ` and zero-plane displacement `d` (m) of the built-up
+surface on `grid` from the GHSL building-height and built-up rasters, with the
+`urban_fraction` of each cell and its built-area-weighted mean `building_height` (m),
+as a NamedTuple of `Field`s `(; ℓᵐ, d, urban_fraction, building_height)`.
 
-    h  = Field{Center, Center, Nothing}(lattice)
+The rasters are averaged conservatively onto a lattice `refinement` times finer than
+`grid`: the plan-area index `λᵖ` is the pixel mean of the built fraction and the
+building height the built-area-weighted pixel mean, no-data pixels counting as unbuilt.
+`closure` maps both to `(ℓᵐ, d)` on the lattice. Each grid cell then takes the
+built-area-weighted log-mean `ℓᵐ`, mean `d` and mean height of its urban lattice cells,
+those with `λᵖ` at least the closure's `minimum_built_fraction`, and `urban_fraction`
+is their share of the cell; a cell without urban lattice cells takes the closure's
+bare-soil limit. The rasters are read in windows of at most `window_degrees` a side.
+"""
+function Lands.urban_roughness(grid, height_dataset::GHSBuiltH, built_dataset::GHSBuiltS;
+                               closure = MorphometricRoughness(eltype(grid)),
+                               refinement = 10,
+                               window_degrees = 5)
+    FT = eltype(grid)
+    Nx, Ny, _ = size(grid)
+    λᶠ = λnodes(grid, Face())
+    φᶠ = φnodes(grid, Face())
+
+    lattice_faces(faces) = [[faces[i] + (faces[i + 1] - faces[i]) * k / refinement
+                             for i in 1:length(faces) - 1 for k in 0:refinement - 1]; faces[end]]
+    λ = lattice_faces(λᶠ)
+    φ = lattice_faces(φᶠ)
+    lattice = LatitudeLongitudeGrid(CPU(), FT; size = (refinement * Nx, refinement * Ny),
+                                    longitude = λ, latitude = φ, topology = (Bounded, Bounded, Flat))
     λᵖ = Field{Center, Center, Nothing}(lattice)
-    interior(h, :, :, 1)  .= ifelse.(area .> 0, volume ./ area, 0)
-    interior(λᵖ, :, :, 1) .= ifelse.(pixels .> 0, area ./ pixels, NaN)
+    h  = Field{Center, Center, Nothing}(lattice)
+
+    windows_x = min(ceil(Int, (λᶠ[end] - λᶠ[1]) / window_degrees), Nx)
+    windows_y = min(ceil(Int, (φᶠ[end] - φᶠ[1]) / window_degrees), Ny)
+    for n in 1:windows_y, m in 1:windows_x
+        I = tile_indices(Nx, windows_x, m)
+        J = tile_indices(Ny, windows_y, n)
+        window = BoundingBox(longitude = (λᶠ[first(I)], λᶠ[last(I) + 1]),
+                             latitude  = (φᶠ[first(J)], φᶠ[last(J) + 1]))
+        a = (refinement * (first(I) - 1) + 1):(refinement * last(I))
+        b = (refinement * (first(J) - 1) + 1):(refinement * last(J))
+        window_lattice = LatitudeLongitudeGrid(CPU(), FT; size = (length(a), length(b)),
+                                               longitude = λ[first(a):last(a) + 1],
+                                               latitude  = φ[first(b):last(b) + 1],
+                                               topology = (Bounded, Bounded, Flat))
+
+        built_fraction  = Field(Metadatum(:built_up_fraction; dataset = built_dataset, region = window), CPU())
+        building_height = Field(Metadatum(:building_height; dataset = height_dataset, region = window), CPU())
+        replace!(interior(built_fraction), NaN => 0)
+        replace!(interior(building_height), NaN => 0)
+        if built_fraction.grid != building_height.grid  # the 10 m built-up product
+            built_fraction = conservative_regrid(building_height.grid, built_fraction)
+        end
+        interior(building_height) .*= interior(built_fraction)  # building volume per pixel area
+
+        interior(λᵖ, a, b, 1) .= interior(conservative_regrid(window_lattice, built_fraction), :, :, 1)
+        interior(h,  a, b, 1) .= interior(conservative_regrid(window_lattice, building_height), :, :, 1)
+    end
+    interior(h) .= ifelse.(interior(λᵖ) .> 0, interior(h) ./ interior(λᵖ), 0)
+
     ℓᵐ, d = urban_roughness(h, λᵖ; closure)
 
-    Nx, Ny, _ = size(grid)
-    rx, ry = nx ÷ Nx, ny ÷ Ny
-    λᵖᵐⁱⁿ = closure.minimum_built_fraction
+    # Built-area weights of the urban lattice cells
+    w = interior(λᵖ, :, :, 1)
+    w = ifelse.(w .>= closure.minimum_built_fraction, w, 0)
+    Σw = block_sum(w, refinement)
+    urban = Σw .> 0
     bare_roughness, bare_displacement = aerodynamic_parameters(closure, 0, 0)
 
-    roughness = zeros(FT, Nx, Ny)
-    displacement = zeros(FT, Nx, Ny)
-    urban_fraction = zeros(FT, Nx, Ny)
-    mean_height = zeros(FT, Nx, Ny)
-
-    for j in 1:Ny, i in 1:Nx
-        Σλᵖ = Σlogℓ = Σd = Σh = zero(FT)
-        urban = 0
-        for b in (ry * (j - 1) + 1):(ry * j), a in (rx * (i - 1) + 1):(rx * i)
-            w = λᵖ[a, b, 1]
-            w >= λᵖᵐⁱⁿ || continue
-            Σλᵖ += w
-            Σlogℓ += w * log(ℓᵐ[a, b, 1])
-            Σd += w * d[a, b, 1]
-            Σh += w * h[a, b, 1]
-            urban += 1
-        end
-        urban_fraction[i, j] = urban / (rx * ry)
-        built = Σλᵖ > 0
-        roughness[i, j] = built ? exp(Σlogℓ / Σλᵖ) : bare_roughness
-        displacement[i, j] = built ? Σd / Σλᵖ : bare_displacement
-        mean_height[i, j] = built ? Σh / Σλᵖ : 0
-    end
+    roughness      = ifelse.(urban, exp.(block_sum(w .* log.(interior(ℓᵐ, :, :, 1)), refinement) ./ Σw), bare_roughness)
+    displacement   = ifelse.(urban, block_sum(w .* interior(d, :, :, 1), refinement) ./ Σw, bare_displacement)
+    mean_height    = ifelse.(urban, block_sum(w .* interior(h, :, :, 1), refinement) ./ Σw, 0)
+    urban_fraction = block_sum(w .> 0, refinement) ./ refinement^2
 
     fields = map((roughness, displacement, urban_fraction, mean_height)) do data
         field = Field{Center, Center, Nothing}(grid)
@@ -553,53 +555,6 @@ function binned_urban_roughness(grid, volume, area, pixels, closure)
         return field
     end
     return NamedTuple{(:ℓᵐ, :d, :urban_fraction, :building_height)}(fields)
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Aerodynamic parameters of the built-up surface on `grid` from the native GHSL rasters,
-as the NamedTuple of `Field`s `(; ℓᵐ, d, urban_fraction, building_height)`: the momentum
-roughness length and zero-plane displacement (m), the built-up fraction of each cell, and
-the built-area-weighted mean building height (m).
-
-The rasters are read natively in windows of `window_degrees` (longitude, latitude) and
-binned onto an evaluation lattice `refinement` times finer than `grid`, near the
-neighborhood scale at which the morphometric regressions hold: the plan-area index is
-the pixel mean of the built fraction, and the building height is the built-area-weighted
-pixel mean (building volume over built area). `closure` maps both to `(ℓᵐ, d)` on the
-lattice, and the lattice values reduce to each grid cell over its built lattice cells
-weighted by built area — so a dense urban core sets its cell's roughness rather than
-being diluted into the open land around it. A cell with no built lattice cell takes the
-closure's bare-soil limit.
-"""
-function Lands.urban_roughness(grid, height_dataset::GHSBuiltH, built_dataset::GHSBuiltS;
-                               closure = MorphometricRoughness(eltype(grid)),
-                               refinement = 10,
-                               window_degrees = (10, 8))
-    Nx, Ny, _ = size(grid)
-    nx, ny = refinement * Nx, refinement * Ny
-    volume = zeros(nx, ny)
-    area = zeros(nx, ny)
-    pixels = zeros(Int, nx, ny)
-
-    domain = BoundingBox(grid)
-    λ₁, λ₂ = domain.longitude
-    φ₁, φ₂ = domain.latitude
-    λedges = range(λ₁, λ₂; length = ceil(Int, (λ₂ - λ₁) / window_degrees[1]) + 1)
-    φedges = range(φ₁, φ₂; length = ceil(Int, (φ₂ - φ₁) / window_degrees[2]) + 1)
-
-    for n in 1:(length(φedges) - 1), m in 1:(length(λedges) - 1)
-        window = BoundingBox(longitude = (λedges[m], λedges[m + 1]),
-                             latitude  = (φedges[n], φedges[n + 1]))
-        building_height = Field(Metadatum(:building_height; dataset = height_dataset, region = window), CPU())
-        built_up_fraction = Field(Metadatum(:built_up_fraction; dataset = built_dataset, region = window), CPU())
-        bin_built_pixels!(volume, area, pixels, building_height, built_up_fraction, window, domain)
-        building_height = built_up_fraction = nothing
-        GC.gc()
-    end
-
-    return binned_urban_roughness(grid, volume, area, pixels, closure)
 end
 
 end # module GHSL

--- a/src/DataWrangling/GHSL/GHSL.jl
+++ b/src/DataWrangling/GHSL/GHSL.jl
@@ -1,6 +1,6 @@
 module GHSL
 
-export GHSBuiltH, GHSBuiltS, GHSBuiltSResolution, GHSBuiltS10m, GHSBuiltS100m
+export GHSBuiltH, GHSBuiltS, GHSBuiltSResolution, GHSBuiltS10m, GHSBuiltS100m, GHSBuilt
 
 using Downloads: Downloads
 using Oceananigans: Bounded, Center, CPU, Face, Field, Flat, LatitudeLongitudeGrid, interior
@@ -13,7 +13,7 @@ using NumericalEarth.Lands: Lands
 using ..DataWrangling: DataWrangling, AbstractStaticDataset, Metadatum,
                        metadata_path, native_grid, BoundingBox, bounding_box_suffix, tile_indices
 
-using DocStringExtensions: TYPEDSIGNATURES
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 
 import Oceananigans
 
@@ -133,6 +133,32 @@ Base.summary(::GHSBuiltH) = "GHSBuiltH()"
 Base.summary(dataset::GHSBuiltS) =
     string("GHSBuiltS(resolution = ", dataset.resolution, ", epoch = ", dataset.epoch, ")")
 Base.show(io::IO, dataset::AbstractGHSLDataset) = print(io, summary(dataset))
+
+"""
+$(TYPEDEF)
+
+The GHSL built-up pair that [`building_morphometry`](@ref) reads together: the built-up
+`surface` ([`GHSBuiltS`](@ref)) and the building `height` ([`GHSBuiltH`](@ref)).
+
+```jldoctest
+julia> using NumericalEarth
+
+julia> GHSBuilt()
+GHSBuilt(GHSBuiltS(resolution = GHSBuiltS100m, epoch = 2020), GHSBuiltH())
+
+julia> GHSBuilt(surface = GHSBuiltS(resolution = GHSBuiltS10m))
+GHSBuilt(GHSBuiltS(resolution = GHSBuiltS10m, epoch = 2018), GHSBuiltH())
+```
+"""
+struct GHSBuilt
+    surface :: GHSBuiltS
+    height  :: GHSBuiltH
+end
+
+GHSBuilt(; surface = GHSBuiltS(), height = GHSBuiltH()) = GHSBuilt(surface, height)
+
+Base.summary(dataset::GHSBuilt) = string("GHSBuilt(", summary(dataset.surface), ", ", summary(dataset.height), ")")
+Base.show(io::IO, dataset::GHSBuilt) = print(io, summary(dataset))
 
 const GHSBuiltHMetadatum = Metadatum{<:GHSBuiltH}
 const GHSBuiltSMetadatum = Metadatum{<:GHSBuiltS}
@@ -455,20 +481,23 @@ ghsl_tiles_to_netcdf(metadatum, nc_path) =
 $(TYPEDSIGNATURES)
 
 Plan-area index and built-area-weighted mean building height (m) on `grid` from the GHSL
-built-up fraction and building-height rasters, as the NamedTuple of `Field`s
+built-up surface and building-height rasters of `dataset`, as the NamedTuple of `Field`s
 `(; plan_area_index, mean_building_height)`: the pixel mean of the built fraction and the
 building volume over the built area of each cell, no-data pixels counting as unbuilt. The
-rasters are read in windows of at most `window_degrees` a side.
+rasters are read in windows of at most `maximum_raster_cells` native pixels.
 """
-function Lands.building_morphometry(grid, height_dataset::GHSBuiltH, built_dataset::GHSBuiltS; window_degrees = 5)
+function Lands.building_morphometry(grid, dataset::GHSBuilt; maximum_raster_cells = 100_000_000)
     Nx, Ny, _ = size(grid)
     λᶠ = λnodes(grid, Face())
     φᶠ = φnodes(grid, Face())
     λᵖ = Field{Center, Center, Nothing}(grid)
     h  = Field{Center, Center, Nothing}(grid)
 
-    windows_x = min(ceil(Int, (λᶠ[end] - λᶠ[1]) / window_degrees), Nx)
-    windows_y = min(ceil(Int, (φᶠ[end] - φᶠ[1]) / window_degrees), Ny)
+    Nλ, Nφ, _ = size(dataset.surface, :built_up_fraction)
+    pixels = (λᶠ[end] - λᶠ[1]) * Nλ / 360 * (φᶠ[end] - φᶠ[1]) * Nφ / 180
+    windows = ceil(Int, sqrt(pixels / maximum_raster_cells))
+    windows_x = min(windows, Nx)
+    windows_y = min(windows, Ny)
     for n in 1:windows_y, m in 1:windows_x
         I = tile_indices(Nx, windows_x, m)
         J = tile_indices(Ny, windows_y, n)
@@ -479,8 +508,8 @@ function Lands.building_morphometry(grid, height_dataset::GHSBuiltH, built_datas
                                             latitude  = φᶠ[first(J):last(J) + 1],
                                             topology = (Bounded, Bounded, Flat))
 
-        built_fraction  = Field(Metadatum(:built_up_fraction; dataset = built_dataset, region = window), CPU())
-        building_height = Field(Metadatum(:building_height; dataset = height_dataset, region = window), CPU())
+        built_fraction  = Field(Metadatum(:built_up_fraction; dataset = dataset.surface, region = window), CPU())
+        building_height = Field(Metadatum(:building_height; dataset = dataset.height, region = window), CPU())
         replace!(interior(built_fraction), NaN => 0)
         replace!(interior(building_height), NaN => 0)
         if built_fraction.grid != building_height.grid  # the 10 m built-up product

--- a/src/DataWrangling/GHSL/GHSL.jl
+++ b/src/DataWrangling/GHSL/GHSL.jl
@@ -3,12 +3,12 @@ module GHSL
 export GHSBuiltH, GHSBuiltS, GHSBuiltSResolution, GHSBuiltS10m, GHSBuiltS100m
 
 using Downloads: Downloads
-using Oceananigans: Bounded, Center, CPU, Face, Field, Flat, LatitudeLongitudeGrid, interior, set!
+using Oceananigans: Bounded, Center, CPU, Face, Field, Flat, LatitudeLongitudeGrid, interior
 using Oceananigans.Fields: regrid!
 using Oceananigans.DistributedComputations: @root
 using Oceananigans.Grids: x_domain, y_domain, λnodes, φnodes
 
-using NumericalEarth.Lands: Lands, MorphometricRoughness, aerodynamic_parameters, urban_roughness
+using NumericalEarth.Lands: Lands
 
 using ..DataWrangling: DataWrangling, AbstractStaticDataset, Metadatum,
                        metadata_path, native_grid, BoundingBox, bounding_box_suffix, tile_indices
@@ -448,49 +448,24 @@ ghsl_tiles_to_netcdf(metadatum, nc_path) =
           "Load it with `using ArchGDAL`.")
 
 #####
-##### Urban roughness on a model grid: conservative pixel means on a neighborhood-scale
-##### lattice, the morphometric closure evaluated there, reduced to the grid over the
-##### urban lattice cells.
+##### Building morphometry on a model grid: conservative pixel means of the rasters.
 #####
-
-# Sums over the `refinement × refinement` blocks of a lattice array.
-block_sum(a, refinement) =
-    dropdims(sum(reshape(a, refinement, size(a, 1) ÷ refinement, refinement, size(a, 2) ÷ refinement); dims = (1, 3)); dims = (1, 3))
 
 """
 $(TYPEDSIGNATURES)
 
-Momentum roughness length `ℓᵐ` and zero-plane displacement `d` (m) of the built-up
-surface on `grid` from the GHSL building-height and built-up rasters, with the
-`urban_fraction` of each cell and its built-area-weighted mean `building_height` (m),
-as a NamedTuple of `Field`s `(; ℓᵐ, d, urban_fraction, building_height)`.
-
-The rasters are averaged conservatively onto a lattice `refinement` times finer than
-`grid`: the plan-area index `λᵖ` is the pixel mean of the built fraction and the
-building height the built-area-weighted pixel mean, no-data pixels counting as unbuilt.
-`closure` maps both to `(ℓᵐ, d)` on the lattice. Each grid cell then takes the
-built-area-weighted log-mean `ℓᵐ`, mean `d` and mean height of its urban lattice cells,
-those with `λᵖ` at least the closure's `minimum_built_fraction`, and `urban_fraction`
-is their share of the cell; a cell without urban lattice cells takes the closure's
-bare-soil limit. The rasters are read in windows of at most `window_degrees` a side.
+Plan-area index and built-area-weighted mean building height (m) on `grid` from the GHSL
+built-up fraction and building-height rasters, as the NamedTuple of `Field`s
+`(; plan_area_index, mean_building_height)`: the pixel mean of the built fraction and the
+building volume over the built area of each cell, no-data pixels counting as unbuilt. The
+rasters are read in windows of at most `window_degrees` a side.
 """
-function Lands.urban_roughness(grid, height_dataset::GHSBuiltH, built_dataset::GHSBuiltS;
-                               closure = MorphometricRoughness(eltype(grid)),
-                               refinement = 10,
-                               window_degrees = 5)
-    FT = eltype(grid)
+function Lands.building_morphometry(grid, height_dataset::GHSBuiltH, built_dataset::GHSBuiltS; window_degrees = 5)
     Nx, Ny, _ = size(grid)
     λᶠ = λnodes(grid, Face())
     φᶠ = φnodes(grid, Face())
-
-    lattice_faces(faces) = [[faces[i] + (faces[i + 1] - faces[i]) * k / refinement
-                             for i in 1:length(faces) - 1 for k in 0:refinement - 1]; faces[end]]
-    λ = lattice_faces(λᶠ)
-    φ = lattice_faces(φᶠ)
-    lattice = LatitudeLongitudeGrid(CPU(), FT; size = (refinement * Nx, refinement * Ny),
-                                    longitude = λ, latitude = φ, topology = (Bounded, Bounded, Flat))
-    λᵖ = Field{Center, Center, Nothing}(lattice)
-    h  = Field{Center, Center, Nothing}(lattice)
+    λᵖ = Field{Center, Center, Nothing}(grid)
+    h  = Field{Center, Center, Nothing}(grid)
 
     windows_x = min(ceil(Int, (λᶠ[end] - λᶠ[1]) / window_degrees), Nx)
     windows_y = min(ceil(Int, (φᶠ[end] - φᶠ[1]) / window_degrees), Ny)
@@ -499,12 +474,10 @@ function Lands.urban_roughness(grid, height_dataset::GHSBuiltH, built_dataset::G
         J = tile_indices(Ny, windows_y, n)
         window = BoundingBox(longitude = (λᶠ[first(I)], λᶠ[last(I) + 1]),
                              latitude  = (φᶠ[first(J)], φᶠ[last(J) + 1]))
-        a = (refinement * (first(I) - 1) + 1):(refinement * last(I))
-        b = (refinement * (first(J) - 1) + 1):(refinement * last(J))
-        window_lattice = LatitudeLongitudeGrid(CPU(), FT; size = (length(a), length(b)),
-                                               longitude = λ[first(a):last(a) + 1],
-                                               latitude  = φ[first(b):last(b) + 1],
-                                               topology = (Bounded, Bounded, Flat))
+        window_grid = LatitudeLongitudeGrid(CPU(), eltype(grid); size = (length(I), length(J)),
+                                            longitude = λᶠ[first(I):last(I) + 1],
+                                            latitude  = φᶠ[first(J):last(J) + 1],
+                                            topology = (Bounded, Bounded, Flat))
 
         built_fraction  = Field(Metadatum(:built_up_fraction; dataset = built_dataset, region = window), CPU())
         building_height = Field(Metadatum(:building_height; dataset = height_dataset, region = window), CPU())
@@ -516,35 +489,16 @@ function Lands.urban_roughness(grid, height_dataset::GHSBuiltH, built_dataset::G
         end
         interior(building_height) .*= interior(built_fraction)  # building volume per pixel area
 
-        window_fraction = Field{Center, Center, Nothing}(window_lattice)
-        window_volume   = Field{Center, Center, Nothing}(window_lattice)
+        window_fraction = Field{Center, Center, Nothing}(window_grid)
+        window_volume   = Field{Center, Center, Nothing}(window_grid)
         regrid!(window_fraction, built_fraction)
         regrid!(window_volume, building_height)
-        interior(λᵖ, a, b, 1) .= interior(window_fraction, :, :, 1)
-        interior(h,  a, b, 1) .= interior(window_volume, :, :, 1)
+        interior(λᵖ, I, J, 1) .= interior(window_fraction, :, :, 1)
+        interior(h,  I, J, 1) .= interior(window_volume, :, :, 1)
     end
     interior(h) .= ifelse.(interior(λᵖ) .> 0, interior(h) ./ interior(λᵖ), 0)
 
-    ℓᵐ, d = urban_roughness(h, λᵖ; closure)
-
-    # Built-area weights of the urban lattice cells
-    w = interior(λᵖ, :, :, 1)
-    w = ifelse.(w .>= closure.minimum_built_fraction, w, 0)
-    Σw = block_sum(w, refinement)
-    urban = Σw .> 0
-    bare_roughness, bare_displacement = aerodynamic_parameters(closure, 0, 0)
-
-    roughness      = ifelse.(urban, exp.(block_sum(w .* log.(interior(ℓᵐ, :, :, 1)), refinement) ./ Σw), bare_roughness)
-    displacement   = ifelse.(urban, block_sum(w .* interior(d, :, :, 1), refinement) ./ Σw, bare_displacement)
-    mean_height    = ifelse.(urban, block_sum(w .* interior(h, :, :, 1), refinement) ./ Σw, 0)
-    urban_fraction = block_sum(w .> 0, refinement) ./ refinement^2
-
-    fields = map((roughness, displacement, urban_fraction, mean_height)) do data
-        field = Field{Center, Center, Nothing}(grid)
-        set!(field, data)
-        return field
-    end
-    return NamedTuple{(:ℓᵐ, :d, :urban_fraction, :building_height)}(fields)
+    return (; plan_area_index = λᵖ, mean_building_height = h)
 end
 
 end # module GHSL

--- a/src/DataWrangling/GHSL/GHSL.jl
+++ b/src/DataWrangling/GHSL/GHSL.jl
@@ -3,12 +3,16 @@ module GHSL
 export GHSBuiltH, GHSBuiltS, GHSBuiltSResolution, GHSBuiltS10m, GHSBuiltS100m
 
 using Downloads: Downloads
-using Oceananigans: Center, CPU
+using Oceananigans: Bounded, Center, CPU, Field, Flat, LatitudeLongitudeGrid, interior, set!
 using Oceananigans.DistributedComputations: @root
 using Oceananigans.Grids: x_domain, y_domain, λnodes, φnodes
 
+using NumericalEarth.Lands: Lands, MorphometricRoughness, aerodynamic_parameters, urban_roughness
+
 using ..DataWrangling: DataWrangling, AbstractStaticDataset, Metadatum,
                        metadata_path, native_grid, BoundingBox, bounding_box_suffix
+
+using DocStringExtensions: TYPEDSIGNATURES
 
 import Oceananigans
 
@@ -441,5 +445,161 @@ ghsl_tiles_to_netcdf(metadatum, nc_path) =
     error("Reading the $(summary(metadatum.dataset)) Mollweide GeoTIFF tiles requires " *
           "the ArchGDAL package (for the ESRI:54009 → EPSG:4326 reprojection). " *
           "Load it with `using ArchGDAL`.")
+
+#####
+##### Urban roughness on a model grid: bin the native pixels onto a neighborhood-scale
+##### evaluation lattice, apply the morphometric closure there, reduce with built-area
+##### weighting.
+#####
+
+"""
+$(TYPEDSIGNATURES)
+
+Accumulate the native `building_height` and `built_up_fraction` rasters onto the
+evaluation lattice dividing `domain` into `size(pixels)` cells: `pixels` counts each
+lattice cell's raster pixels of known built fraction, `area` sums their built fraction,
+and `volume` sums their built fraction times height (a pixel of unknown height adds area
+but no volume). Only pixels whose centers fall in `window` — half-open in both
+coordinates, so abutting windows never double count — are binned.
+"""
+function bin_built_pixels!(volume, area, pixels, building_height, built_up_fraction, window, domain)
+    size(building_height) == size(built_up_fraction) ||
+        throw(ArgumentError("the building-height and built-up-fraction rasters differ in size, " *
+                            "$(size(building_height)) vs $(size(built_up_fraction))"))
+
+    λ₁, λ₂ = domain.longitude
+    φ₁, φ₂ = domain.latitude
+    Δλ = (λ₂ - λ₁) / size(pixels, 1)
+    Δφ = (φ₂ - φ₁) / size(pixels, 2)
+
+    λ = λnodes(built_up_fraction.grid, Center())
+    φ = φnodes(built_up_fraction.grid, Center())
+    heights = interior(building_height, :, :, 1)
+    fractions = interior(built_up_fraction, :, :, 1)
+
+    for b in eachindex(φ), a in eachindex(λ)
+        window.longitude[1] <= λ[a] < window.longitude[2] &&
+            window.latitude[1] <= φ[b] < window.latitude[2] || continue
+        λᵖ = fractions[a, b]
+        isfinite(λᵖ) || continue
+        i = floor(Int, (λ[a] - λ₁) / Δλ) + 1
+        j = floor(Int, (φ[b] - φ₁) / Δφ) + 1
+        pixels[i, j] += 1
+        area[i, j] += λᵖ
+        isfinite(heights[a, b]) && (volume[i, j] += λᵖ * heights[a, b])
+    end
+    return nothing
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Aerodynamic parameters on `grid` from the binned `volume` (Σ λᵖh), `area` (Σ λᵖ) and
+`pixels` accumulators of its evaluation lattice: `closure` maps each lattice cell's
+plan-area index `area / pixels` and built-area-weighted height `volume / area` to
+`(ℓᵐ, d)`, which then reduce to each grid cell over its built lattice cells (plan-area
+index at least the closure's `minimum_built_fraction`), weighted by built area — the
+log-mean `ℓᵐ` and the mean `d` and building height. A grid cell with no built lattice
+cell takes the closure's bare-soil limit. Returns the NamedTuple of `Field`s
+`(; ℓᵐ, d, urban_fraction, building_height)`, where `urban_fraction` is the built
+share of each cell's lattice.
+"""
+function binned_urban_roughness(grid, volume, area, pixels, closure)
+    FT = eltype(grid)
+    nx, ny = size(pixels)
+    domain = BoundingBox(grid)
+    lattice = LatitudeLongitudeGrid(CPU(), FT; size = (nx, ny),
+                                    longitude = domain.longitude, latitude = domain.latitude,
+                                    topology = (Bounded, Bounded, Flat))
+
+    h  = Field{Center, Center, Nothing}(lattice)
+    λᵖ = Field{Center, Center, Nothing}(lattice)
+    interior(h, :, :, 1)  .= ifelse.(area .> 0, volume ./ area, 0)
+    interior(λᵖ, :, :, 1) .= ifelse.(pixels .> 0, area ./ pixels, NaN)
+    ℓᵐ, d = urban_roughness(h, λᵖ; closure)
+
+    Nx, Ny, _ = size(grid)
+    rx, ry = nx ÷ Nx, ny ÷ Ny
+    λᵖᵐⁱⁿ = closure.minimum_built_fraction
+    bare_roughness, bare_displacement = aerodynamic_parameters(closure, 0, 0)
+
+    roughness = zeros(FT, Nx, Ny)
+    displacement = zeros(FT, Nx, Ny)
+    urban_fraction = zeros(FT, Nx, Ny)
+    mean_height = zeros(FT, Nx, Ny)
+
+    for j in 1:Ny, i in 1:Nx
+        Σλᵖ = Σlogℓ = Σd = Σh = zero(FT)
+        urban = 0
+        for b in (ry * (j - 1) + 1):(ry * j), a in (rx * (i - 1) + 1):(rx * i)
+            w = λᵖ[a, b, 1]
+            w >= λᵖᵐⁱⁿ || continue
+            Σλᵖ += w
+            Σlogℓ += w * log(ℓᵐ[a, b, 1])
+            Σd += w * d[a, b, 1]
+            Σh += w * h[a, b, 1]
+            urban += 1
+        end
+        urban_fraction[i, j] = urban / (rx * ry)
+        built = Σλᵖ > 0
+        roughness[i, j] = built ? exp(Σlogℓ / Σλᵖ) : bare_roughness
+        displacement[i, j] = built ? Σd / Σλᵖ : bare_displacement
+        mean_height[i, j] = built ? Σh / Σλᵖ : 0
+    end
+
+    fields = map((roughness, displacement, urban_fraction, mean_height)) do data
+        field = Field{Center, Center, Nothing}(grid)
+        set!(field, data)
+        return field
+    end
+    return NamedTuple{(:ℓᵐ, :d, :urban_fraction, :building_height)}(fields)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Aerodynamic parameters of the built-up surface on `grid` from the native GHSL rasters,
+as the NamedTuple of `Field`s `(; ℓᵐ, d, urban_fraction, building_height)`: the momentum
+roughness length and zero-plane displacement (m), the built-up fraction of each cell, and
+the built-area-weighted mean building height (m).
+
+The rasters are read natively in windows of `window_degrees` (longitude, latitude) and
+binned onto an evaluation lattice `refinement` times finer than `grid`, near the
+neighborhood scale at which the morphometric regressions hold: the plan-area index is
+the pixel mean of the built fraction, and the building height is the built-area-weighted
+pixel mean (building volume over built area). `closure` maps both to `(ℓᵐ, d)` on the
+lattice, and the lattice values reduce to each grid cell over its built lattice cells
+weighted by built area — so a dense urban core sets its cell's roughness rather than
+being diluted into the open land around it. A cell with no built lattice cell takes the
+closure's bare-soil limit.
+"""
+function Lands.urban_roughness(grid, height_dataset::GHSBuiltH, built_dataset::GHSBuiltS;
+                               closure = MorphometricRoughness(eltype(grid)),
+                               refinement = 10,
+                               window_degrees = (10, 8))
+    Nx, Ny, _ = size(grid)
+    nx, ny = refinement * Nx, refinement * Ny
+    volume = zeros(nx, ny)
+    area = zeros(nx, ny)
+    pixels = zeros(Int, nx, ny)
+
+    domain = BoundingBox(grid)
+    λ₁, λ₂ = domain.longitude
+    φ₁, φ₂ = domain.latitude
+    λedges = range(λ₁, λ₂; length = ceil(Int, (λ₂ - λ₁) / window_degrees[1]) + 1)
+    φedges = range(φ₁, φ₂; length = ceil(Int, (φ₂ - φ₁) / window_degrees[2]) + 1)
+
+    for n in 1:(length(φedges) - 1), m in 1:(length(λedges) - 1)
+        window = BoundingBox(longitude = (λedges[m], λedges[m + 1]),
+                             latitude  = (φedges[n], φedges[n + 1]))
+        building_height = Field(Metadatum(:building_height; dataset = height_dataset, region = window), CPU())
+        built_up_fraction = Field(Metadatum(:built_up_fraction; dataset = built_dataset, region = window), CPU())
+        bin_built_pixels!(volume, area, pixels, building_height, built_up_fraction, window, domain)
+        building_height = built_up_fraction = nothing
+        GC.gc()
+    end
+
+    return binned_urban_roughness(grid, volume, area, pixels, closure)
+end
 
 end # module GHSL

--- a/src/DataWrangling/GloBFP3D/GloBFP3D.jl
+++ b/src/DataWrangling/GloBFP3D/GloBFP3D.jl
@@ -1,6 +1,6 @@
 module GloBFP3D
 
-export GlobalBuildingFootprints3D, building_morphometry
+export GlobalBuildingFootprints3D
 
 using Downloads: Downloads
 using Oceananigans: Center, Face
@@ -8,8 +8,12 @@ using Oceananigans.Fields: Field, set!
 using Oceananigans.Grids: LatitudeLongitudeGrid, λnodes, φnodes
 using Oceananigans.DistributedComputations: @root
 
+using NumericalEarth.Lands: Lands
+
 using ..DataWrangling: DataWrangling, AbstractStaticDataset, Metadatum, metadata_path,
                        BoundingBox, bounding_box_suffix, latitude_summary, native_region_grid
+
+using DocStringExtensions: TYPEDSIGNATURES
 
 import Oceananigans
 
@@ -287,12 +291,11 @@ function morphometry_latitude_bands(target_grid, region, Δ, maximum_raster_cell
 end
 
 """
-    building_morphometry(target_grid; dataset = GlobalBuildingFootprints3D(), region,
-                         maximum_raster_cells = 400_000_000)
+$(TYPEDSIGNATURES)
 
 Per-cell building morphometry on `target_grid` (a `LatitudeLongitudeGrid`, coarser than the
 `dataset` rasterization resolution), aggregated from the fine 3D-GloBFP building-height raster
-over `region`. Returns a NamedTuple of `Field`s:
+over `region`, by default the extent of `target_grid`. Returns a NamedTuple of `Field`s:
 
 - `plan_area_index` `λᵖ` — fraction of fine cells that are built.
 - `mean_building_height` `h` — mean height over the built fine cells.
@@ -309,8 +312,8 @@ deleted once reduced (the downloaded footprint tiles stay cached).
 
 Downloading and rasterizing the footprints requires `using ArchGDAL`.
 """
-function building_morphometry(target_grid::LatitudeLongitudeGrid; dataset = GlobalBuildingFootprints3D(),
-                              region, maximum_raster_cells = 400_000_000)
+function Lands.building_morphometry(target_grid::LatitudeLongitudeGrid, dataset::GlobalBuildingFootprints3D;
+                                    region = BoundingBox(target_grid), maximum_raster_cells = 400_000_000)
     metadatum = Metadatum(:building_height; dataset, region)
     DataWrangling.validate_dataset_coverage(nothing, metadatum)
 

--- a/src/DataWrangling/GloBFP3D/GloBFP3D.jl
+++ b/src/DataWrangling/GloBFP3D/GloBFP3D.jl
@@ -295,7 +295,7 @@ $(TYPEDSIGNATURES)
 
 Per-cell building morphometry on `target_grid` (a `LatitudeLongitudeGrid`, coarser than the
 `dataset` rasterization resolution), aggregated from the fine 3D-GloBFP building-height raster
-over `region`, by default the extent of `target_grid`. Returns a NamedTuple of `Field`s:
+over the extent of `target_grid`. Returns a NamedTuple of `Field`s:
 
 - `plan_area_index` `λᵖ` — fraction of fine cells that are built.
 - `mean_building_height` `h` — mean height over the built fine cells.
@@ -305,7 +305,7 @@ over `region`, by default the extent of `target_grid`. Returns a NamedTuple of `
 - `frontal_area_index` `λᶠ` — windward wall area from height steps, direction-averaged:
   `(Σₓ|δh|·dy + Σᵧ|δh|·dx) / (4·A)`, with `A` the cell area.
 
-A `region` whose native raster exceeds `maximum_raster_cells` (default `400_000_000` cells,
+A grid whose native raster exceeds `maximum_raster_cells` (default `400_000_000` cells,
 3.2 GB of `Float64`) is reduced in latitude bands sized to the limit, reproducing the single
 pass exactly while memory stays bounded regardless of the region size; band raster files are
 deleted once reduced (the downloaded footprint tiles stay cached).
@@ -313,7 +313,8 @@ deleted once reduced (the downloaded footprint tiles stay cached).
 Downloading and rasterizing the footprints requires `using ArchGDAL`.
 """
 function Lands.building_morphometry(target_grid::LatitudeLongitudeGrid, dataset::GlobalBuildingFootprints3D;
-                                    region = BoundingBox(target_grid), maximum_raster_cells = 400_000_000)
+                                    maximum_raster_cells = 400_000_000)
+    region = BoundingBox(target_grid)
     metadatum = Metadatum(:building_height; dataset, region)
     DataWrangling.validate_dataset_coverage(nothing, metadatum)
 

--- a/src/Lands/Lands.jl
+++ b/src/Lands/Lands.jl
@@ -22,7 +22,7 @@ export AbstractLand,
        AbstractUrbanRoughness, MorphometricRoughness,
        IsotropicFrontalArea, EmpiricalFrontalArea,
        UniformHeight, VariableHeight,
-       urban_roughness, compute_aerodynamic_roughness!, aerodynamic_parameters,
+       urban_roughness, compute_aerodynamic_roughness!, aerodynamic_parameters, building_morphometry,
        # Atmosphere-facing accessors
        surface_temperature, surface_saturation
 

--- a/src/Lands/roughness/urban_roughness_field.jl
+++ b/src/Lands/roughness/urban_roughness_field.jl
@@ -1,3 +1,8 @@
+using Oceananigans.Architectures: CPU
+using Oceananigans.Fields: interior, set!
+using Oceananigans.Grids: LatitudeLongitudeGrid, Bounded, Flat, λnodes, φnodes
+using Oceananigans.Operators: Δxᶜᶜᶜ, Δyᶜᶜᶜ
+
 #####
 ##### On-grid evaluation of the urban roughness closures: (λᵖ, h) → (ℓᵐ, d) fields.
 #####
@@ -37,7 +42,7 @@ of `h`) from a mean building-height field `h` and a plan-area index field `λᵖ
 under `closure` (default [`MorphometricRoughness`](@ref)). Where `λᵖ → 0` the result
 reduces to a bare-soil roughness.
 """
-function urban_roughness(h, λᵖ; closure = MorphometricRoughness(eltype(h.grid)))
+function urban_roughness(h::AbstractField, λᵖ; closure = MorphometricRoughness(eltype(h.grid)))
     grid = h.grid
     ℓᵐ = Field{Center, Center, Nothing}(grid)
     d  = Field{Center, Center, Nothing}(grid)
@@ -92,7 +97,7 @@ closure (default [`MorphometricRoughness`](@ref)) is fed the measured height het
 in place of its frontal-area estimator and `σʰ`/`hᵐᵃˣ` regressions. Where `λᵖ → 0` the
 result reduces to a bare-soil roughness.
 """
-function urban_roughness(h, λᵖ, σʰ, hᵐᵃˣ, λᶠ; closure = MorphometricRoughness(eltype(h.grid)))
+function urban_roughness(h::AbstractField, λᵖ, σʰ, hᵐᵃˣ, λᶠ; closure = MorphometricRoughness(eltype(h.grid)))
     grid = h.grid
     ℓᵐ = Field{Center, Center, Nothing}(grid)
     d  = Field{Center, Center, Nothing}(grid)
@@ -101,4 +106,81 @@ function urban_roughness(h, λᵖ, σʰ, hᵐᵃˣ, λᶠ; closure = Morphometri
                     frontal_area_index = λᶠ)
     compute_aerodynamic_roughness!(ℓᵐ, d, closure, properties, grid)
     return ℓᵐ, d
+end
+
+#####
+##### Neighborhood-scale evaluation from building datasets: dataset → lattice morphometry →
+##### closure → built-area-weighted reduction to the grid.
+#####
+
+"""
+$(TYPEDSIGNATURES)
+
+Per-cell building morphometry on `grid` from building `datasets`, as a NamedTuple of `Field`s
+named after the closure inputs: `plan_area_index` and `mean_building_height` (m), and, where
+the dataset measures them, `building_height_deviation` (m), `maximum_building_height` (m) and
+`frontal_area_index`. Dataset modules add methods for their products.
+"""
+function building_morphometry end
+
+# Sums over the `rx × ry` blocks of a lattice array.
+block_sum(a, rx, ry) =
+    dropdims(sum(reshape(a, rx, size(a, 1) ÷ rx, ry, size(a, 2) ÷ ry); dims = (1, 3)); dims = (1, 3))
+
+"""
+$(TYPEDSIGNATURES)
+
+Momentum roughness length and zero-plane displacement (m) of the built-up surface on `grid`
+from building `datasets`, as the NamedTuple of `Field`s
+`(; momentum_roughness_length, zero_plane_displacement, urban_fraction, building_height)`.
+
+The closure is evaluated on a lattice of cells about `neighborhood` (m) wide subdividing each
+grid cell, on the morphometry that [`building_morphometry`](@ref) supplies there. Each grid cell
+then takes the built-area-weighted log-mean roughness length, mean displacement and mean
+height of its urban lattice cells, those with plan-area index at least the closure's
+`minimum_built_fraction`; `urban_fraction` is their share of the cell, and a cell without urban
+lattice cells takes the closure's bare-soil limit. A grid cell narrower than `neighborhood` is
+its own lattice cell. Remaining keyword arguments pass to `building_morphometry`.
+"""
+function urban_roughness(grid, datasets...; closure = MorphometricRoughness(eltype(grid)),
+                         neighborhood = 1000, kw...)
+    FT = eltype(grid)
+    Nx, Ny, _ = size(grid)
+    center = (Nx ÷ 2 + 1, Ny ÷ 2 + 1, 1)
+    rx = max(1, round(Int, Δxᶜᶜᶜ(center..., grid) / neighborhood))
+    ry = max(1, round(Int, Δyᶜᶜᶜ(center..., grid) / neighborhood))
+
+    lattice_faces(faces, r) = [[faces[i] + (faces[i + 1] - faces[i]) * k / r
+                                for i in 1:length(faces) - 1 for k in 0:r - 1]; faces[end]]
+    lattice = LatitudeLongitudeGrid(CPU(), FT; size = (rx * Nx, ry * Ny),
+                                    longitude = lattice_faces(λnodes(grid, Face()), rx),
+                                    latitude  = lattice_faces(φnodes(grid, Face()), ry),
+                                    topology = (Bounded, Bounded, Flat))
+
+    properties = building_morphometry(lattice, datasets...; kw...)
+    measured = (:plan_area_index, :mean_building_height,
+                :building_height_deviation, :maximum_building_height, :frontal_area_index)
+    closure_inputs = hasproperty(properties, :frontal_area_index) ? properties[measured] : properties[measured[1:2]]
+    ℓᵐ = Field{Center, Center, Nothing}(lattice)
+    d  = Field{Center, Center, Nothing}(lattice)
+    compute_aerodynamic_roughness!(ℓᵐ, d, closure, closure_inputs, lattice)
+
+    # Built-area weights of the urban lattice cells
+    λᵖ = interior(properties.plan_area_index, :, :, 1)
+    w  = ifelse.(λᵖ .>= closure.minimum_built_fraction, λᵖ, 0)
+    Σw = block_sum(w, rx, ry)
+    urban = Σw .> 0
+    bare_roughness, bare_displacement = aerodynamic_parameters(closure, 0, 0)
+
+    roughness      = ifelse.(urban, exp.(block_sum(w .* log.(interior(ℓᵐ, :, :, 1)), rx, ry) ./ Σw), bare_roughness)
+    displacement   = ifelse.(urban, block_sum(w .* interior(d, :, :, 1), rx, ry) ./ Σw, bare_displacement)
+    mean_height    = ifelse.(urban, block_sum(w .* interior(properties.mean_building_height, :, :, 1), rx, ry) ./ Σw, 0)
+    urban_fraction = block_sum(w .> 0, rx, ry) ./ (rx * ry)
+
+    fields = map((roughness, displacement, urban_fraction, mean_height)) do data
+        field = Field{Center, Center, Nothing}(grid)
+        set!(field, data)
+        return field
+    end
+    return NamedTuple{(:momentum_roughness_length, :zero_plane_displacement, :urban_fraction, :building_height)}(fields)
 end

--- a/src/Lands/roughness/urban_roughness_field.jl
+++ b/src/Lands/roughness/urban_roughness_field.jl
@@ -116,7 +116,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Per-cell building morphometry on `grid` from building `datasets`, as a NamedTuple of `Field`s
+Per-cell building morphometry on `grid` from a building `dataset`, as a NamedTuple of `Field`s
 named after the closure inputs: `plan_area_index` and `mean_building_height` (m), and, where
 the dataset measures them, `building_height_deviation` (m), `maximum_building_height` (m) and
 `frontal_area_index`. Dataset modules add methods for their products.
@@ -131,7 +131,7 @@ block_sum(a, rx, ry) =
 $(TYPEDSIGNATURES)
 
 Momentum roughness length and zero-plane displacement (m) of the built-up surface on `grid`
-from building `datasets`, as the NamedTuple of `Field`s
+from a building `dataset`, as the NamedTuple of `Field`s
 `(; momentum_roughness_length, zero_plane_displacement, urban_fraction, building_height)`.
 
 The closure is evaluated on a lattice of cells about `neighborhood` (m) wide subdividing each
@@ -142,7 +142,7 @@ height of its urban lattice cells, those with plan-area index at least the closu
 lattice cells takes the closure's bare-soil limit. A grid cell narrower than `neighborhood` is
 its own lattice cell. Remaining keyword arguments pass to `building_morphometry`.
 """
-function urban_roughness(grid, datasets...; closure = MorphometricRoughness(eltype(grid)),
+function urban_roughness(grid, dataset; closure = MorphometricRoughness(eltype(grid)),
                          neighborhood = 1000, kw...)
     FT = eltype(grid)
     Nx, Ny, _ = size(grid)
@@ -157,7 +157,7 @@ function urban_roughness(grid, datasets...; closure = MorphometricRoughness(elty
                                     latitude  = lattice_faces(φnodes(grid, Face()), ry),
                                     topology = (Bounded, Bounded, Flat))
 
-    properties = building_morphometry(lattice, datasets...; kw...)
+    properties = building_morphometry(lattice, dataset; kw...)
     measured = (:plan_area_index, :mean_building_height,
                 :building_height_deviation, :maximum_building_height, :frontal_area_index)
     closure_inputs = hasproperty(properties, :frontal_area_index) ? properties[measured] : properties[measured[1:2]]

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -107,7 +107,7 @@ export
     AbstractUrbanRoughness, MorphometricRoughness,
     IsotropicFrontalArea, EmpiricalFrontalArea,
     UniformHeight, VariableHeight,
-    urban_roughness, compute_aerodynamic_roughness!, aerodynamic_parameters,
+    urban_roughness, compute_aerodynamic_roughness!, aerodynamic_parameters, building_morphometry,
     surface_temperature,
     regrid_bathymetry,
     regrid_topography,

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -137,7 +137,7 @@ export
     ORCAGrid,
     OpenLandMapSoilDB,
     GlobalBuildingFootprints3D, building_morphometry,
-    GHSBuiltH, GHSBuiltS, GHSBuiltSResolution, GHSBuiltS10m, GHSBuiltS100m,
+    GHSBuiltH, GHSBuiltS, GHSBuiltSResolution, GHSBuiltS10m, GHSBuiltS100m, GHSBuilt,
     first_date, last_date, all_dates,
     LinearlyTaperedPolarMask,
     DatasetRestoring,

--- a/test/test_ghsl.jl
+++ b/test/test_ghsl.jl
@@ -257,13 +257,13 @@ function write_ghsl_raster(metadatum, values)
 end
 
 @testset "GHSL urban roughness on a grid" begin
-    # A 2 × 2 grid whose 4× lattice cells hold 24 × 24 native pixels each, aligned with the
-    # pixel faces so the conservative means are exact.
+    # A 2 × 2 grid near the equator whose 2.4 km lattice cells hold 24 × 24 native pixels
+    # each, aligned with the pixel faces so the conservative means are exact.
     Nλ, Nφ, _ = size(GHSBuiltH(), :building_height)
     Δλ, Δφ = 360 / Nλ, 180 / Nφ
     refinement, pixels = 4, 24
     λ₁ = -180 + 200_000Δλ
-    φ₁ = -90 + 150_000Δφ
+    φ₁ = -90 + 100_000Δφ
     grid = LatitudeLongitudeGrid(CPU(); size = (2, 2),
                                  longitude = (λ₁, λ₁ + 2refinement * pixels * Δλ),
                                  latitude  = (φ₁, φ₁ + 2refinement * pixels * Δφ),
@@ -297,43 +297,43 @@ end
         write_ghsl_raster(Metadatum(:building_height; dataset = GHSBuiltH(), region), building_height)
 
         closure = MorphometricRoughness()
-        fields = urban_roughness(grid, GHSBuiltH(), GHSBuiltS(); closure, refinement)
-        @test keys(fields) == (:ℓᵐ, :d, :urban_fraction, :building_height)
+        fields = urban_roughness(grid, GHSBuiltH(), GHSBuiltS(); closure, neighborhood = 2400)
+        @test keys(fields) == (:momentum_roughness_length, :zero_plane_displacement, :urban_fraction, :building_height)
 
         # The core alone sets its cell's roughness.
         core_roughness, core_displacement = aerodynamic_parameters(closure, 0.5, 20.0)
-        @test fields.ℓᵐ[1, 1, 1] ≈ core_roughness rtol = 1e-4
-        @test fields.d[1, 1, 1] ≈ core_displacement rtol = 1e-4
+        @test fields.momentum_roughness_length[1, 1, 1] ≈ core_roughness rtol = 1e-4
+        @test fields.zero_plane_displacement[1, 1, 1] ≈ core_displacement rtol = 1e-4
         @test fields.building_height[1, 1, 1] ≈ 20 rtol = 1e-4
         @test fields.urban_fraction[1, 1, 1] == 1 / 16
 
-        @test fields.ℓᵐ[2, 2, 1] ≈ core_roughness rtol = 1e-4
-        @test fields.d[2, 2, 1] ≈ core_displacement rtol = 1e-4
+        @test fields.momentum_roughness_length[2, 2, 1] ≈ core_roughness rtol = 1e-4
+        @test fields.zero_plane_displacement[2, 2, 1] ≈ core_displacement rtol = 1e-4
         @test fields.building_height[2, 2, 1] ≈ 20 rtol = 1e-4
         @test fields.urban_fraction[2, 2, 1] == 1
 
         # Built-area-weighted height, (0.2 · 10 + 0.6 · 30) / 0.8, at plan-area index 0.4.
         mixed_roughness, mixed_displacement = aerodynamic_parameters(closure, 0.4, 25.0)
         @test fields.building_height[1, 2, 1] ≈ 25 rtol = 1e-4
-        @test fields.ℓᵐ[1, 2, 1] ≈ mixed_roughness rtol = 1e-4
-        @test fields.d[1, 2, 1] ≈ mixed_displacement rtol = 1e-4
+        @test fields.momentum_roughness_length[1, 2, 1] ≈ mixed_roughness rtol = 1e-4
+        @test fields.zero_plane_displacement[1, 2, 1] ≈ mixed_displacement rtol = 1e-4
         @test fields.urban_fraction[1, 2, 1] == 1 / 16
 
         # No-data pixels count as unbuilt.
         bare_roughness, _ = aerodynamic_parameters(closure, 0, 0)
-        @test fields.ℓᵐ[2, 1, 1] == bare_roughness
-        @test fields.d[2, 1, 1] == 0
+        @test fields.momentum_roughness_length[2, 1, 1] == bare_roughness
+        @test fields.zero_plane_displacement[2, 1, 1] == 0
         @test fields.urban_fraction[2, 1, 1] == 0
         @test fields.building_height[2, 1, 1] == 0
 
         # The 10 m built-up product regrids onto the 100 m height pixels.
         fine = GHSBuiltS(resolution = GHSBuiltS10m)
         write_ghsl_raster(Metadatum(:built_up_fraction; dataset = fine, region), built_fraction)
-        fields = urban_roughness(grid, GHSBuiltH(), fine; closure, refinement)
-        @test fields.ℓᵐ[2, 2, 1] ≈ core_roughness rtol = 1e-4
+        fields = urban_roughness(grid, GHSBuiltH(), fine; closure, neighborhood = 2400)
+        @test fields.momentum_roughness_length[2, 2, 1] ≈ core_roughness rtol = 1e-4
         @test fields.building_height[1, 1, 1] ≈ 20 rtol = 1e-4
         @test fields.urban_fraction[1, 1, 1] == 1 / 16
-        @test fields.ℓᵐ[2, 1, 1] == bare_roughness
+        @test fields.momentum_roughness_length[2, 1, 1] == bare_roughness
     finally
         setglobal!(GHSL, :download_GHSL_cache, default_cache)
     end

--- a/test/test_ghsl.jl
+++ b/test/test_ghsl.jl
@@ -297,7 +297,7 @@ end
         write_ghsl_raster(Metadatum(:building_height; dataset = GHSBuiltH(), region), building_height)
 
         closure = MorphometricRoughness()
-        fields = urban_roughness(grid, GHSBuiltH(), GHSBuiltS(); closure, neighborhood = 2400)
+        fields = urban_roughness(grid, GHSBuilt(); closure, neighborhood = 2400)
         @test keys(fields) == (:momentum_roughness_length, :zero_plane_displacement, :urban_fraction, :building_height)
 
         # The core alone sets its cell's roughness.
@@ -329,7 +329,7 @@ end
         # The 10 m built-up product regrids onto the 100 m height pixels.
         fine = GHSBuiltS(resolution = GHSBuiltS10m)
         write_ghsl_raster(Metadatum(:built_up_fraction; dataset = fine, region), built_fraction)
-        fields = urban_roughness(grid, GHSBuiltH(), fine; closure, neighborhood = 2400)
+        fields = urban_roughness(grid, GHSBuilt(surface = fine); closure, neighborhood = 2400)
         @test fields.momentum_roughness_length[2, 2, 1] ≈ core_roughness rtol = 1e-4
         @test fields.building_height[1, 1, 1] ≈ 20 rtol = 1e-4
         @test fields.urban_fraction[1, 1, 1] == 1 / 16

--- a/test/test_ghsl.jl
+++ b/test/test_ghsl.jl
@@ -6,7 +6,8 @@ using NumericalEarth.DataWrangling.GHSL: ghsl_tile_index, ghsl_tiles_in_bbox,
                                          longitude_latitude_to_mollweide,
                                          mask_building_height, built_surface_to_fraction,
                                          dataset_prefix, native_resolution, ghsl_tiles_to_netcdf,
-                                         ghsl_regional_raster
+                                         ghsl_regional_raster, bin_built_pixels!, binned_urban_roughness
+using NumericalEarth.Lands: MorphometricRoughness, aerodynamic_parameters
 using NumericalEarth.DataWrangling: BoundingBox, Metadatum, native_grid,
                                     longitude_interfaces, latitude_interfaces,
                                     dataset_variable_name, validate_dataset_coverage,
@@ -234,6 +235,100 @@ end
         @test raster.region.latitude[2]  ≥ region.latitude[2]
         @test ghsl_tiles_in_bbox(region) ⊆ ghsl_tiles_in_bbox(raster.region)
     end
+end
+
+#####
+##### Native-pixel binning and built-area-weighted reduction to a model grid.
+#####
+
+@testset "GHSL binning onto the evaluation lattice" begin
+    domain = BoundingBox(longitude = (0, 1), latitude = (0, 1))
+    raster_grid = LatitudeLongitudeGrid(CPU(); size = (40, 40),
+                                        longitude = (0, 1), latitude = (0, 1),
+                                        topology = (Bounded, Bounded, Flat))
+    height = Field{Center, Center, Nothing}(raster_grid)
+    built = Field{Center, Center, Nothing}(raster_grid)
+
+    # 10 × 10 pixels per cell of the 4 × 4 lattice. Lattice cell (1, 1) is uniformly
+    # built; cell (2, 1) mixes two densities, so its height must be built-area-weighted,
+    # (0.2·10 + 0.6·30) / 0.8 = 25, not the plain pixel mean 20.
+    interior(built, 1:10, 1:10, 1) .= 0.5
+    interior(height, 1:10, 1:10, 1) .= 20
+    interior(built, 11:15, 1:10, 1) .= 0.2
+    interior(height, 11:15, 1:10, 1) .= 10
+    interior(built, 16:20, 1:10, 1) .= 0.6
+    interior(height, 16:20, 1:10, 1) .= 30
+
+    # In lattice cell (3, 1): an unknown height adds area but no volume, and an unknown
+    # built fraction drops its pixel.
+    built[21, 1, 1] = 0.4
+    height[21, 1, 1] = NaN
+    built[22, 1, 1] = NaN
+
+    volume = zeros(4, 4)
+    area = zeros(4, 4)
+    pixels = zeros(Int, 4, 4)
+    bin_built_pixels!(volume, area, pixels, height, built, domain, domain)
+
+    @test pixels[1, 1] == 100
+    @test area[1, 1] ≈ 50
+    @test volume[1, 1] ≈ 1000
+    @test volume[2, 1] / area[2, 1] ≈ 25
+    @test pixels[3, 1] == 99
+    @test area[3, 1] ≈ 0.4
+    @test volume[3, 1] == 0
+    @test pixels[4, 4] == 100
+    @test area[4, 4] == 0
+
+    # Two abutting half-open windows bin every pixel exactly once.
+    split_volume = zeros(4, 4)
+    split_area = zeros(4, 4)
+    split_pixels = zeros(Int, 4, 4)
+    for window in (BoundingBox(longitude = (0, 0.5), latitude = (0, 1)),
+                   BoundingBox(longitude = (0.5, 1), latitude = (0, 1)))
+        bin_built_pixels!(split_volume, split_area, split_pixels, height, built, window, domain)
+    end
+    @test split_pixels == pixels
+    @test split_area == area
+    @test split_volume == volume
+end
+
+@testset "GHSL reduction: a dense core sets its cell's roughness" begin
+    grid = LatitudeLongitudeGrid(CPU(); size = (2, 2),
+                                 longitude = (0, 2), latitude = (0, 2),
+                                 topology = (Bounded, Bounded, Flat))
+    closure = MorphometricRoughness(eltype(grid))
+
+    # A 4× finer lattice: grid cell (1, 1) holds a single dense 20 m core among 15 empty
+    # lattice cells; grid cell (2, 2) is uniformly built at the same density and height.
+    volume = zeros(8, 8)
+    area = zeros(8, 8)
+    pixels = ones(Int, 8, 8)
+    area[2, 2] = 0.5
+    volume[2, 2] = 10
+    area[5:8, 5:8] .= 0.5
+    volume[5:8, 5:8] .= 10
+
+    core_roughness, core_displacement = aerodynamic_parameters(closure, 0.5, 20.0)
+    fields = binned_urban_roughness(grid, volume, area, pixels, closure)
+    @test keys(fields) == (:ℓᵐ, :d, :urban_fraction, :building_height)
+
+    # The core sets the cell's parameters — a plain cell mean would dilute h to 1.25 m.
+    @test fields.ℓᵐ[1, 1, 1] ≈ core_roughness
+    @test fields.d[1, 1, 1] ≈ core_displacement
+    @test fields.building_height[1, 1, 1] ≈ 20
+    @test fields.urban_fraction[1, 1, 1] ≈ 1 / 16
+
+    # A uniformly built cell matches the direct closure evaluation.
+    @test fields.ℓᵐ[2, 2, 1] ≈ core_roughness
+    @test fields.d[2, 2, 1] ≈ core_displacement
+    @test fields.urban_fraction[2, 2, 1] == 1
+
+    # Cells with no built lattice cell reduce to the closure's bare-soil limit.
+    @test fields.ℓᵐ[1, 2, 1] == closure.bare_soil_roughness
+    @test fields.d[1, 2, 1] == 0
+    @test fields.urban_fraction[1, 2, 1] == 0
+    @test fields.building_height[1, 2, 1] == 0
 end
 
 #####

--- a/test/test_ghsl.jl
+++ b/test/test_ghsl.jl
@@ -6,13 +6,15 @@ using NumericalEarth.DataWrangling.GHSL: ghsl_tile_index, ghsl_tiles_in_bbox,
                                          longitude_latitude_to_mollweide,
                                          mask_building_height, built_surface_to_fraction,
                                          dataset_prefix, native_resolution, ghsl_tiles_to_netcdf,
-                                         ghsl_regional_raster, bin_built_pixels!, binned_urban_roughness
-using NumericalEarth.Lands: MorphometricRoughness, aerodynamic_parameters
+                                         ghsl_regional_raster
+using NumericalEarth.Lands: MorphometricRoughness, aerodynamic_parameters, urban_roughness
 using NumericalEarth.DataWrangling: BoundingBox, Metadatum, native_grid,
                                     longitude_interfaces, latitude_interfaces,
                                     dataset_variable_name, validate_dataset_coverage,
-                                    metadata_filename, available_variables,
+                                    metadata_filename, metadata_path, available_variables,
                                     is_three_dimensional, default_inpainting
+
+using NCDatasets: NCDataset, defDim, defVar
 
 using Oceananigans.Fields: location
 using Oceananigans.Grids: x_domain, y_domain, λnodes, φnodes
@@ -238,97 +240,103 @@ end
 end
 
 #####
-##### Native-pixel binning and built-area-weighted reduction to a model grid.
+##### Urban roughness on a model grid, from synthetic rasters in the GHSL cache layout.
 #####
 
-@testset "GHSL binning onto the evaluation lattice" begin
-    domain = BoundingBox(longitude = (0, 1), latitude = (0, 1))
-    raster_grid = LatitudeLongitudeGrid(CPU(); size = (40, 40),
-                                        longitude = (0, 1), latitude = (0, 1),
-                                        topology = (Bounded, Bounded, Flat))
-    height = Field{Center, Center, Nothing}(raster_grid)
-    built = Field{Center, Center, Nothing}(raster_grid)
-
-    # 10 × 10 pixels per cell of the 4 × 4 lattice. Lattice cell (1, 1) is uniformly
-    # built; cell (2, 1) mixes two densities, so its height must be built-area-weighted,
-    # (0.2·10 + 0.6·30) / 0.8 = 25, not the plain pixel mean 20.
-    interior(built, 1:10, 1:10, 1) .= 0.5
-    interior(height, 1:10, 1:10, 1) .= 20
-    interior(built, 11:15, 1:10, 1) .= 0.2
-    interior(height, 11:15, 1:10, 1) .= 10
-    interior(built, 16:20, 1:10, 1) .= 0.6
-    interior(height, 16:20, 1:10, 1) .= 30
-
-    # In lattice cell (3, 1): an unknown height adds area but no volume, and an unknown
-    # built fraction drops its pixel.
-    built[21, 1, 1] = 0.4
-    height[21, 1, 1] = NaN
-    built[22, 1, 1] = NaN
-
-    volume = zeros(4, 4)
-    area = zeros(4, 4)
-    pixels = zeros(Int, 4, 4)
-    bin_built_pixels!(volume, area, pixels, height, built, domain, domain)
-
-    @test pixels[1, 1] == 100
-    @test area[1, 1] ≈ 50
-    @test volume[1, 1] ≈ 1000
-    @test volume[2, 1] / area[2, 1] ≈ 25
-    @test pixels[3, 1] == 99
-    @test area[3, 1] ≈ 0.4
-    @test volume[3, 1] == 0
-    @test pixels[4, 4] == 100
-    @test area[4, 4] == 0
-
-    # Two abutting half-open windows bin every pixel exactly once.
-    split_volume = zeros(4, 4)
-    split_area = zeros(4, 4)
-    split_pixels = zeros(Int, 4, 4)
-    for window in (BoundingBox(longitude = (0, 0.5), latitude = (0, 1)),
-                   BoundingBox(longitude = (0.5, 1), latitude = (0, 1)))
-        bin_built_pixels!(split_volume, split_area, split_pixels, height, built, window, domain)
+function write_ghsl_raster(metadatum, values)
+    raster = ghsl_regional_raster(metadatum)
+    NCDataset(metadata_path(metadatum), "c") do ds
+        defDim(ds, "lon", raster.Nx)
+        defDim(ds, "lat", raster.Ny)
+        defVar(ds, "lon", Float64, ("lon",))[:] = raster.longitude
+        defVar(ds, "lat", Float64, ("lat",))[:] = raster.latitude
+        defVar(ds, dataset_variable_name(metadatum), Float64, ("lon", "lat"))[:, :] =
+            [values(λ, φ) for λ in raster.longitude, φ in raster.latitude]
     end
-    @test split_pixels == pixels
-    @test split_area == area
-    @test split_volume == volume
+    return nothing
 end
 
-@testset "GHSL reduction: a dense core sets its cell's roughness" begin
+@testset "GHSL urban roughness on a grid" begin
+    # A 2 × 2 grid whose 4× lattice cells hold 24 × 24 native pixels each, aligned with the
+    # pixel faces so the conservative means are exact.
+    Nλ, Nφ, _ = size(GHSBuiltH(), :building_height)
+    Δλ, Δφ = 360 / Nλ, 180 / Nφ
+    refinement, pixels = 4, 24
+    λ₁ = -180 + 200_000Δλ
+    φ₁ = -90 + 150_000Δφ
     grid = LatitudeLongitudeGrid(CPU(); size = (2, 2),
-                                 longitude = (0, 2), latitude = (0, 2),
+                                 longitude = (λ₁, λ₁ + 2refinement * pixels * Δλ),
+                                 latitude  = (φ₁, φ₁ + 2refinement * pixels * Δφ),
                                  topology = (Bounded, Bounded, Flat))
-    closure = MorphometricRoughness(eltype(grid))
+    lattice_cell(λ, φ) = (floor(Int, (λ - λ₁) / (pixels * Δλ)) + 1,
+                          floor(Int, (φ - φ₁) / (pixels * Δφ)) + 1)
+    odd_column(λ) = isodd(floor(Int, (λ - λ₁) / Δλ))
 
-    # A 4× finer lattice: grid cell (1, 1) holds a single dense 20 m core among 15 empty
-    # lattice cells; grid cell (2, 2) is uniformly built at the same density and height.
-    volume = zeros(8, 8)
-    area = zeros(8, 8)
-    pixels = ones(Int, 8, 8)
-    area[2, 2] = 0.5
-    volume[2, 2] = 10
-    area[5:8, 5:8] .= 0.5
-    volume[5:8, 5:8] .= 10
+    # Lattice cell (2, 2) is a dense core in an otherwise empty grid cell (1, 1); grid cell
+    # (2, 2) is uniformly built; lattice cell (2, 6) alternates two densities by pixel
+    # column; grid cell (2, 1) is no-data.
+    function built_fraction(λ, φ)
+        a, b = lattice_cell(λ, φ)
+        (a, b) == (2, 2) && return 0.5
+        (a, b) == (2, 6) && return odd_column(λ) ? 0.2 : 0.6
+        a > 4 && return b > 4 ? 0.5 : NaN
+        return 0.0
+    end
+    function building_height(λ, φ)
+        a, b = lattice_cell(λ, φ)
+        (a, b) == (2, 6) && return odd_column(λ) ? 10.0 : 30.0
+        a > 4 && b <= 4 && return NaN
+        return 20.0
+    end
 
-    core_roughness, core_displacement = aerodynamic_parameters(closure, 0.5, 20.0)
-    fields = binned_urban_roughness(grid, volume, area, pixels, closure)
-    @test keys(fields) == (:ℓᵐ, :d, :urban_fraction, :building_height)
+    default_cache = GHSL.download_GHSL_cache
+    setglobal!(GHSL, :download_GHSL_cache, mktempdir())
+    try
+        region = BoundingBox(grid)
+        write_ghsl_raster(Metadatum(:built_up_fraction; dataset = GHSBuiltS(), region), built_fraction)
+        write_ghsl_raster(Metadatum(:building_height; dataset = GHSBuiltH(), region), building_height)
 
-    # The core sets the cell's parameters — a plain cell mean would dilute h to 1.25 m.
-    @test fields.ℓᵐ[1, 1, 1] ≈ core_roughness
-    @test fields.d[1, 1, 1] ≈ core_displacement
-    @test fields.building_height[1, 1, 1] ≈ 20
-    @test fields.urban_fraction[1, 1, 1] ≈ 1 / 16
+        closure = MorphometricRoughness()
+        fields = urban_roughness(grid, GHSBuiltH(), GHSBuiltS(); closure, refinement)
+        @test keys(fields) == (:ℓᵐ, :d, :urban_fraction, :building_height)
 
-    # A uniformly built cell matches the direct closure evaluation.
-    @test fields.ℓᵐ[2, 2, 1] ≈ core_roughness
-    @test fields.d[2, 2, 1] ≈ core_displacement
-    @test fields.urban_fraction[2, 2, 1] == 1
+        # The core alone sets its cell's roughness.
+        core_roughness, core_displacement = aerodynamic_parameters(closure, 0.5, 20.0)
+        @test fields.ℓᵐ[1, 1, 1] ≈ core_roughness rtol = 1e-4
+        @test fields.d[1, 1, 1] ≈ core_displacement rtol = 1e-4
+        @test fields.building_height[1, 1, 1] ≈ 20 rtol = 1e-4
+        @test fields.urban_fraction[1, 1, 1] == 1 / 16
 
-    # Cells with no built lattice cell reduce to the closure's bare-soil limit.
-    @test fields.ℓᵐ[1, 2, 1] == closure.bare_soil_roughness
-    @test fields.d[1, 2, 1] == 0
-    @test fields.urban_fraction[1, 2, 1] == 0
-    @test fields.building_height[1, 2, 1] == 0
+        @test fields.ℓᵐ[2, 2, 1] ≈ core_roughness rtol = 1e-4
+        @test fields.d[2, 2, 1] ≈ core_displacement rtol = 1e-4
+        @test fields.building_height[2, 2, 1] ≈ 20 rtol = 1e-4
+        @test fields.urban_fraction[2, 2, 1] == 1
+
+        # Built-area-weighted height, (0.2 · 10 + 0.6 · 30) / 0.8, at plan-area index 0.4.
+        mixed_roughness, mixed_displacement = aerodynamic_parameters(closure, 0.4, 25.0)
+        @test fields.building_height[1, 2, 1] ≈ 25 rtol = 1e-4
+        @test fields.ℓᵐ[1, 2, 1] ≈ mixed_roughness rtol = 1e-4
+        @test fields.d[1, 2, 1] ≈ mixed_displacement rtol = 1e-4
+        @test fields.urban_fraction[1, 2, 1] == 1 / 16
+
+        # No-data pixels count as unbuilt.
+        bare_roughness, _ = aerodynamic_parameters(closure, 0, 0)
+        @test fields.ℓᵐ[2, 1, 1] == bare_roughness
+        @test fields.d[2, 1, 1] == 0
+        @test fields.urban_fraction[2, 1, 1] == 0
+        @test fields.building_height[2, 1, 1] == 0
+
+        # The 10 m built-up product regrids onto the 100 m height pixels.
+        fine = GHSBuiltS(resolution = GHSBuiltS10m)
+        write_ghsl_raster(Metadatum(:built_up_fraction; dataset = fine, region), built_fraction)
+        fields = urban_roughness(grid, GHSBuiltH(), fine; closure, refinement)
+        @test fields.ℓᵐ[2, 2, 1] ≈ core_roughness rtol = 1e-4
+        @test fields.building_height[1, 1, 1] ≈ 20 rtol = 1e-4
+        @test fields.urban_fraction[1, 1, 1] == 1 / 16
+        @test fields.ℓᵐ[2, 1, 1] == bare_roughness
+    finally
+        setglobal!(GHSL, :download_GHSL_cache, default_cache)
+    end
 end
 
 #####

--- a/test/test_globfp3d.jl
+++ b/test/test_globfp3d.jl
@@ -134,7 +134,7 @@ end
     target = LatitudeLongitudeGrid(CPU(), Float64; size = (4, 4),
                                    longitude = (-74.02, -73.93), latitude = (40.70, 40.82),
                                    topology = (Bounded, Bounded, Flat))
-    @test_throws "must be used with a bounded region" building_morphometry(target; dataset, region = BoundingBox())
+    @test_throws "must be used with a bounded region" building_morphometry(target, dataset; region = BoundingBox())
 end
 
 @testset "GloBFP3D native aggregation grid" begin

--- a/test/test_globfp3d.jl
+++ b/test/test_globfp3d.jl
@@ -134,7 +134,7 @@ end
     target = LatitudeLongitudeGrid(CPU(), Float64; size = (4, 4),
                                    longitude = (-74.02, -73.93), latitude = (40.70, 40.82),
                                    topology = (Bounded, Bounded, Flat))
-    @test_throws "must be used with a bounded region" building_morphometry(target, dataset; region = BoundingBox())
+    @test_throws "must be used with a bounded region" validate_dataset_coverage(nothing, Metadatum(:building_height; dataset))
 end
 
 @testset "GloBFP3D native aggregation grid" begin

--- a/test/test_globfp3d_downloading.jl
+++ b/test/test_globfp3d_downloading.jl
@@ -22,7 +22,7 @@ using NumericalEarth.DataWrangling.GloBFP3D: globfp3d_native_cell_size
     target_grid = LatitudeLongitudeGrid(CPU(), Float64; size = (4, 4),
                                         longitude = region.longitude, latitude = region.latitude,
                                         topology = (Bounded, Bounded, Flat))
-    morphometry = building_morphometry(target_grid, dataset; region)
+    morphometry = building_morphometry(target_grid, dataset)
 
     λᵖ   = Array(interior(morphometry.plan_area_index, :, :, 1))
     h    = Array(interior(morphometry.mean_building_height, :, :, 1))
@@ -42,7 +42,7 @@ using NumericalEarth.DataWrangling.GloBFP3D: globfp3d_native_cell_size
     maximum_raster_cells = raster.Nx * (raster.Ny ÷ 4)
     @test raster.Nx * raster.Ny > maximum_raster_cells    # the limit really forces bands
 
-    banded = building_morphometry(target_grid, dataset; region, maximum_raster_cells)
+    banded = building_morphometry(target_grid, dataset; maximum_raster_cells)
     for name in keys(morphometry)
         @test Array(interior(banded[name], :, :, 1)) == Array(interior(morphometry[name], :, :, 1))
     end
@@ -57,5 +57,5 @@ end
                                         longitude = region.longitude, latitude = region.latitude,
                                         topology = (Bounded, Bounded, Flat))
 
-    @test_throws ErrorException building_morphometry(target_grid, dataset; region)
+    @test_throws ErrorException building_morphometry(target_grid, dataset)
 end

--- a/test/test_globfp3d_downloading.jl
+++ b/test/test_globfp3d_downloading.jl
@@ -22,7 +22,7 @@ using NumericalEarth.DataWrangling.GloBFP3D: globfp3d_native_cell_size
     target_grid = LatitudeLongitudeGrid(CPU(), Float64; size = (4, 4),
                                         longitude = region.longitude, latitude = region.latitude,
                                         topology = (Bounded, Bounded, Flat))
-    morphometry = building_morphometry(target_grid; dataset, region)
+    morphometry = building_morphometry(target_grid, dataset; region)
 
     λᵖ   = Array(interior(morphometry.plan_area_index, :, :, 1))
     h    = Array(interior(morphometry.mean_building_height, :, :, 1))
@@ -42,7 +42,7 @@ using NumericalEarth.DataWrangling.GloBFP3D: globfp3d_native_cell_size
     maximum_raster_cells = raster.Nx * (raster.Ny ÷ 4)
     @test raster.Nx * raster.Ny > maximum_raster_cells    # the limit really forces bands
 
-    banded = building_morphometry(target_grid; dataset, region, maximum_raster_cells)
+    banded = building_morphometry(target_grid, dataset; region, maximum_raster_cells)
     for name in keys(morphometry)
         @test Array(interior(banded[name], :, :, 1)) == Array(interior(morphometry[name], :, :, 1))
     end
@@ -57,5 +57,5 @@ end
                                         longitude = region.longitude, latitude = region.latitude,
                                         topology = (Bounded, Bounded, Flat))
 
-    @test_throws ErrorException building_morphometry(target_grid; dataset, region)
+    @test_throws ErrorException building_morphometry(target_grid, dataset; region)
 end

--- a/test/test_urban_roughness.jl
+++ b/test/test_urban_roughness.jl
@@ -352,3 +352,31 @@ end
     @test all(≈(ℓᵐref), interior(ℓᵐ))
     @test all(≈(dref), interior(d))
 end
+
+#####
+##### Dataset-level evaluation: a dataset supplying measured morphometry selects the measured closure.
+#####
+
+struct UniformBuildings end
+
+function NumericalEarth.Lands.building_morphometry(grid, ::UniformBuildings)
+    uniform(value) = set!(Field{Center, Center, Nothing}(grid), value)
+    return (; plan_area_index = uniform(0.4), mean_building_height = uniform(25.0),
+              building_height_deviation = uniform(8.0), maximum_building_height = uniform(60.0),
+              frontal_area_index = uniform(0.3), gross_building_height = uniform(10.0))
+end
+
+@testset "Dataset-level urban roughness from measured morphometry" begin
+    grid = LatitudeLongitudeGrid(CPU(), Float64; size = (2, 2),
+                                 longitude = (0, 0.2), latitude = (0, 0.2),
+                                 topology = (Bounded, Bounded, Flat))
+    closure = MorphometricRoughness()
+    fields = urban_roughness(grid, UniformBuildings(); closure, neighborhood = 5000)
+    @test keys(fields) == (:momentum_roughness_length, :zero_plane_displacement, :urban_fraction, :building_height)
+
+    ℓᵐ, d = aerodynamic_parameters(closure, 0.4, 25.0, 8.0, 60.0, 0.3)
+    @test all(interior(fields.momentum_roughness_length, :, :, 1) .≈ ℓᵐ)
+    @test all(interior(fields.zero_plane_displacement, :, :, 1) .≈ d)
+    @test all(interior(fields.urban_fraction, :, :, 1) .== 1)
+    @test all(interior(fields.building_height, :, :, 1) .≈ 25)
+end


### PR DESCRIPTION
`urban_roughness(grid, dataset)` evaluates the morphometric closure on ~1 km lattice cells inside each grid cell rather than on grid-cell means of the rasters, which dilute a city into bare soil on coarse grids (a 12 km metropolitan cell averages to λᵖ ≈ 0.03 and 1 m buildings).

- `building_morphometry(grid, dataset; maximum_raster_cells)`: the dataset hook, declared in `Lands`, returning a NamedTuple of `Field`s named after the closure inputs (`plan_area_index`, `mean_building_height`, and where measured `building_height_deviation`, `maximum_building_height`, `frontal_area_index`). GloBFP3D's method moves onto it and takes its region from the grid. GHSL adds one for `GHSBuilt(; surface = GHSBuiltS(), height = GHSBuiltH())`: conservative pixel means with Oceananigans' `regrid!`, no-data counted as unbuilt, read in windows sized to `maximum_raster_cells`.
- `urban_roughness(grid, dataset; closure, neighborhood = 1000)`: lattice at about `neighborhood` m from the grid faces, closure per lattice cell (the measured variant when `frontal_area_index` is supplied), built-area-weighted reduction over the urban lattice cells (`λᵖ ≥ minimum_built_fraction`). Returns `(; momentum_roughness_length, zero_plane_displacement, urban_fraction, building_height)`; a cell without urban lattice cells takes the closure's bare-soil limit.

```julia
using NumericalEarth, Oceananigans, ArchGDAL

grid = LatitudeLongitudeGrid(size = (4, 4), longitude = (-74.1, -73.7), latitude = (40.6, 40.9),
                             topology = (Bounded, Bounded, Flat))
roughness = urban_roughness(grid, GHSBuilt())
roughness.momentum_roughness_length
```

Breaking: `building_morphometry(target_grid; dataset, region)` becomes `building_morphometry(target_grid, dataset)`.

Refs #611; the bilinear `Field(m, grid)` path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
