### PR TITLE
Stream ESA WorldCover aggregation in bounded chunks

### DIFF
--- a/ext/NumericalEarthArchGDALExt/NumericalEarthArchGDALExt.jl
+++ b/ext/NumericalEarthArchGDALExt/NumericalEarthArchGDALExt.jl
@@ -13,7 +13,7 @@ using Oceananigans.Grids: λnodes, φnodes
 using NumericalEarth.DataWrangling: BoundingBox, native_grid, native_region_grid,
                                     dataset_variable_name, bounding_box_intersects,
                                     cmr_granules, earthdata_download_cached,
-                                    figshare_article_url
+                                    figshare_article_url, tile_indices, default_tile_bytes
 using NumericalEarth.DataWrangling.ASTERGED: asterged_short_name, asterged_version,
                                              asterged_decode_emissivity, asterged_decode_uncertainty,
                                              broadband_map, place_tile!,
@@ -26,11 +26,12 @@ using NumericalEarth.DataWrangling.GHSL: GHSBuiltS, GHSLMetadatum, native_resolu
                                          ghsl_tile_url, ghsl_tile_tif_name, ghsl_tiles_in_bbox,
                                          ghsl_regional_raster, built_surface_to_fraction,
                                          mask_building_height
-                                         built_surface_to_fraction, mask_building_height
 using NumericalEarth.DataWrangling.WorldCover: ESAWorldCoverMetadatum, version_year, version_string,
                                                worldcover_window, aggregate_landcover,
                                                class_fraction_variable_name,
-                                               ESA_WORLDCOVER_NATIVE_STEP
+                                               ESA_WORLDCOVER_CLASS_NAMES,
+                                               ESA_WORLDCOVER_NATIVE_STEP,
+                                               ESA_WORLDCOVER_PIXELS_PER_DEGREE
 
 include("gdal_utils.jl")
 include("ibcao.jl")

--- a/ext/NumericalEarthArchGDALExt/worldcover.jl
+++ b/ext/NumericalEarthArchGDALExt/worldcover.jl
@@ -2,10 +2,11 @@
 ##### ESA WorldCover: anonymous COG tiles → regional NetCDF
 #####
 ##### The `Map` band is a UInt8 land-cover class code (no-data = 0). Class codes
-##### must never be averaged, so we read the raw 10 m pixels windowed to the bbox
-##### with nearest resampling (which only clips/aligns — it never invents an
-##### intermediate code), then aggregate onto the coarse lat/lon grid by an
-##### integer factor using `aggregate_landcover`. This keeps the categorical
+##### must never be averaged, so the mosaic of 3° tiles is read at its native
+##### 10 m resolution with nearest resampling (which only clips/aligns — it never
+##### invents an intermediate code), one bounded chunk at a time; each chunk is
+##### counted onto the coarse lat/lon lattice with `aggregate_landcover` and
+##### written to the NetCDF before the next is read. This keeps the categorical
 ##### field on its native EPSG:4326 grid — no reprojection.
 #####
 
@@ -28,17 +29,11 @@ function worldcover_tile_label(longitude, latitude)
                   ew, lpad(abs(Int(tile_longitude)), 3, '0'))
 end
 
-# The SW corners of every 3° tile intersecting the bbox.
-function worldcover_tiles(longitude_bounds, latitude_bounds)
-    λ₁, λ₂ = longitude_bounds
-    φ₁, φ₂ = latitude_bounds
-    tiles = String[]
-    for tile_latitude in (3 * fld(φ₁, 3)):3:(3 * fld(φ₂, 3))
-        for tile_longitude in (3 * fld(λ₁, 3)):3:(3 * fld(λ₂, 3))
-            push!(tiles, worldcover_tile_label(tile_longitude, tile_latitude))
-        end
-    end
-    return tiles
+# Labels of every 3° tile overlapping the native-pixel window.
+function worldcover_tiles(i₁, i₂, j₁, j₂)
+    tile_span = 3 * ESA_WORLDCOVER_PIXELS_PER_DEGREE
+    return [worldcover_tile_label(λ, φ) for φ in 3 * fld(j₁, tile_span) : 3 : 3 * fld(j₂ - 1, tile_span)
+                                        for λ in 3 * fld(i₁, tile_span) : 3 : 3 * fld(i₂ - 1, tile_span)]
 end
 
 function NumericalEarth.DataWrangling.WorldCover.worldcover_cog_to_netcdf(metadatum::ESAWorldCoverMetadatum, nc_path)
@@ -46,27 +41,18 @@ function NumericalEarth.DataWrangling.WorldCover.worldcover_cog_to_netcdf(metada
 
     dataset = metadatum.dataset
     region  = metadatum.region
+    factor  = dataset.aggregation_factor
 
-    factor = dataset.aggregation_factor
-    native_step = ESA_WORLDCOVER_NATIVE_STEP
-
-    i₁, i₂, j₁, j₂ = worldcover_window(region.longitude, region.latitude, factor)
-    west  = i₁ * native_step
-    east  = i₂ * native_step
-    south = j₁ * native_step
-    north = j₂ * native_step
-
-    tile_urls = [worldcover_tile_url(dataset, tile)
-                 for tile in worldcover_tiles(region.longitude, region.latitude)]
+    window = worldcover_window(region.longitude, region.latitude, factor)
+    tile_urls = [worldcover_tile_url(dataset, tile) for tile in worldcover_tiles(window...)]
 
     # Read the anonymous, unsigned public bucket; `environment` restores any prior
     # AWS/GDAL config afterwards, so a signed `/vsis3` read elsewhere in the same
     # session is not left with signing disabled.
-    pixels = ArchGDAL.environment(globalconfig = ["AWS_NO_SIGN_REQUEST" => "YES",
-                                                  "AWS_REGION" => "eu-central-1"]) do
+    ArchGDAL.environment(globalconfig = ["AWS_NO_SIGN_REQUEST" => "YES",
+                                         "AWS_REGION" => "eu-central-1"]) do
         # ESA WorldCover only publishes tiles that contain land; a 3° cell that is
-        # entirely ocean (or outside coverage) has no tile, so skip a URL that
-        # fails to open instead of aborting the whole read.
+        # entirely ocean has no tile and reads as no-data.
         sources = ArchGDAL.IDataset[]
         for url in tile_urls
             try
@@ -76,40 +62,35 @@ function NumericalEarth.DataWrangling.WorldCover.worldcover_cog_to_netcdf(metada
             end
         end
         isempty(sources) && error("No ESA WorldCover tiles are published for the region " *
-                                  "longitude $(region.longitude), latitude $(region.latitude); " *
-                                  "it may be entirely ocean or outside the product's coverage " *
-                                  "(land only, 60°S–84°N).")
+                                  "longitude $(region.longitude), latitude $(region.latitude)")
 
-        # Build a VRT mosaic over the available tiles, then read the raw pixels on
-        # the snapped window at native resolution with nearest resampling.
         try
-            ArchGDAL.gdalbuildvrt(sources) do mosaic
-                ArchGDAL.gdalwarp([mosaic],
-                    ["-te", string(west), string(south), string(east), string(north),
-                     "-tr", string(native_step), string(native_step),
-                     "-r",  "near",
-                     "-ot", "Byte"]) do windowed
-                    # (Nx, Ny) with y north-to-south (GDAL convention).
-                    data = UInt8.(ArchGDAL.read(windowed, 1))
-                    reverse(data, dims = 2)  # flip to south-to-north
-                end
-            end
+            aggregate_worldcover_tiles(sources, window, factor, nc_path)
         finally
             foreach(ArchGDAL.destroy, sources)
         end
     end
 
-    # Aggregate onto the coarse lat/lon grid by the integer factor in one pass.
-    aggregated  = aggregate_landcover(pixels, factor)
-    class_field = aggregated.landcover_class
-    vegetation  = aggregated.vegetation_fraction
+    return nothing
+end
 
-    nx, ny = size(class_field)
+# Count the mosaic of `sources` over the native-pixel `window` onto the `factor`-pixel
+# lattice and write every product to `nc_path`, holding at most `tile_bytes` of pixels at a time.
+function aggregate_worldcover_tiles(sources, window, factor, nc_path; tile_bytes = default_tile_bytes)
+    i₁, i₂, j₁, j₂ = window
+    native_step = ESA_WORLDCOVER_NATIVE_STEP
+    nx = (i₂ - i₁) ÷ factor
+    ny = (j₂ - j₁) ÷ factor
     Δ = factor * native_step
-    longitude = range(west  + Δ / 2, step = Δ, length = nx)
-    latitude  = range(south + Δ / 2, step = Δ, length = ny)
+    longitude = range(i₁ * native_step + Δ / 2, step = Δ, length = nx)
+    latitude  = range(j₁ * native_step + Δ / 2, step = Δ, length = ny)
 
-    NCDataset(nc_path, "c") do ds
+    chunks = ceil(Int, sqrt((i₂ - i₁) * (j₂ - j₁) / tile_bytes))
+    chunks_x = min(chunks, nx)
+    chunks_y = min(chunks, ny)
+
+    staging = tempname(dirname(nc_path))
+    NCDataset(staging, "c") do ds
         defDim(ds, "lon", nx)
         defDim(ds, "lat", ny)
 
@@ -123,21 +104,41 @@ function NumericalEarth.DataWrangling.WorldCover.worldcover_cog_to_netcdf(metada
         class_variable = defVar(ds, "landcover_class", Float32, ("lon", "lat");
                                 attrib = ["long_name" => "majority land-cover class code",
                                           "missing_value" => 0])
-        class_variable[:, :] = Float32.(class_field)
-
         vegetation_variable = defVar(ds, "vegetation_fraction", Float32, ("lon", "lat");
                                      attrib = ["long_name" => "vegetated area fraction",
                                                "units" => "1"])
-        vegetation_variable[:, :] = Float32.(vegetation)
+        fraction_variables = map(keys(ESA_WORLDCOVER_CLASS_NAMES)) do name
+            defVar(ds, string(class_fraction_variable_name(name)), Float32, ("lon", "lat");
+                   attrib = ["long_name" => string(name, " area fraction"), "units" => "1"])
+        end
 
-        for (name, fraction) in pairs(aggregated.class_fractions)
-            band = string(class_fraction_variable_name(name))
-            fraction_variable = defVar(ds, band, Float32, ("lon", "lat");
-                                       attrib = ["long_name" => string(name, " area fraction"),
-                                                 "units" => "1"])
-            fraction_variable[:, :] = Float32.(fraction)
+        ArchGDAL.gdalbuildvrt(sources) do mosaic
+            for chunk_j in 1:chunks_y, chunk_i in 1:chunks_x
+                cells_i = tile_indices(nx, chunks_x, chunk_i)
+                cells_j = tile_indices(ny, chunks_y, chunk_j)
+                west  = (i₁ + factor * (first(cells_i) - 1)) * native_step
+                east  = (i₁ + factor * last(cells_i)) * native_step
+                south = (j₁ + factor * (first(cells_j) - 1)) * native_step
+                north = (j₁ + factor * last(cells_j)) * native_step
+
+                pixels = ArchGDAL.gdalwarp([mosaic],
+                    ["-te", string(west), string(south), string(east), string(north),
+                     "-tr", string(native_step), string(native_step),
+                     "-r",  "near",
+                     "-ot", "Byte"]) do windowed
+                    reverse!(ArchGDAL.read(windowed, 1), dims = 2)  # GDAL rows run north to south
+                end
+
+                aggregated = aggregate_landcover(pixels, factor)
+                class_variable[cells_i, cells_j]      = Float32.(aggregated.landcover_class)
+                vegetation_variable[cells_i, cells_j] = Float32.(aggregated.vegetation_fraction)
+                for (variable, fraction) in zip(fraction_variables, aggregated.class_fractions)
+                    variable[cells_i, cells_j] = Float32.(fraction)
+                end
+            end
         end
     end
+    mv(staging, nc_path; force = true)
 
     return nothing
 end

--- a/test/test_esaworldcover.jl
+++ b/test/test_esaworldcover.jl
@@ -1,5 +1,8 @@
 include("runtests_setup.jl")
 
+using ArchGDAL
+using NCDatasets: NCDataset
+
 using NumericalEarth: ESAWorldCover, WorldCoverVersion, WorldCoverV100, WorldCoverV200
 using NumericalEarth.DataWrangling.WorldCover: class_counts, majority_class,
                                                class_fractions, vegetation_fraction,
@@ -11,6 +14,7 @@ using NumericalEarth.DataWrangling.WorldCover: class_counts, majority_class,
                                                ESA_WORLDCOVER_FRACTION_VARIABLE_NAMES,
                                                ESA_WORLDCOVER_VEGETATED_CLASSES,
                                                ESA_WORLDCOVER_NATIVE_STEP,
+                                               ESA_WORLDCOVER_PIXELS_PER_DEGREE,
                                                version_year, version_string
 using Oceananigans.Grids: λnodes, φnodes
 using NumericalEarth.DataWrangling: longitude_interfaces, latitude_interfaces, native_grid,
@@ -284,4 +288,64 @@ end
         @test all(λ -> any(fλ -> abs(fλ - λ) < ε, file_λ), λc)
         @test all(φ -> any(fφ -> abs(fφ - φ) < ε, file_φ), φc)
     end
+end
+
+@testset "chunked aggregation matches the one-pass aggregation" begin
+    ext = Base.get_extension(NumericalEarth, :NumericalEarthArchGDALExt)
+    factor = 4
+    Δ = ESA_WORLDCOVER_NATIVE_STEP
+    i₀ = 5 * ESA_WORLDCOVER_PIXELS_PER_DEGREE
+    j₀ = 52 * ESA_WORLDCOVER_PIXELS_PER_DEGREE
+
+    # A GeoTIFF on the global 10 m lattice with its SW pixel corner at pixel (i, j);
+    # `codes` run west to east and south to north.
+    function synthetic_tile(i, j, codes)
+        path = tempname() * ".tif"
+        nx, ny = size(codes)
+        ArchGDAL.create(path; driver = ArchGDAL.getdriver("GTiff"),
+                        width = nx, height = ny, nbands = 1, dtype = UInt8) do dataset
+            ArchGDAL.setgeotransform!(dataset, [i * Δ, Δ, 0.0, (j + ny) * Δ, 0.0, -Δ])
+            ArchGDAL.setproj!(dataset, ArchGDAL.toWKT(ArchGDAL.importEPSG(4326)))
+            ArchGDAL.write!(ArchGDAL.getband(dataset, 1), reverse(codes, dims = 2))
+        end
+        return path
+    end
+
+    # Two tiles meeting inside the window: the west one cycles through the legend with a
+    # no-data corner, the east one covers only the southern half, so the northeast quarter
+    # of the window has no source and reads as no-data.
+    codes = collect(ESA_WORLDCOVER_CLASS_CODES)
+    west = UInt8.(codes[mod1.((1:24) .+ (1:48)', 11)])
+    west[1:3, 1:3] .= 0
+    east = fill(UInt8(40), 24, 24)
+    raster = zeros(UInt8, 48, 48)
+    raster[1:24, :] = west
+    raster[25:48, 1:24] = east
+
+    region = BoundingBox(longitude = ((i₀ + 6) * Δ, (i₀ + 42) * Δ),
+                         latitude  = ((j₀ + 6) * Δ, (j₀ + 42) * Δ))
+    window = worldcover_window(region.longitude, region.latitude, factor)
+    @test window == (i₀, i₀ + 48, j₀, j₀ + 48)
+
+    sources = [ArchGDAL.read(synthetic_tile(i₀, j₀, west)),
+               ArchGDAL.read(synthetic_tile(i₀ + 24, j₀, east))]
+    expected = aggregate_landcover(raster, factor)
+
+    for tile_bytes in (10^6, 300, 1)  # one chunk, 3 × 3 chunks, one coarse cell per chunk
+        nc_path = tempname() * ".nc"
+        ext.aggregate_worldcover_tiles(sources, window, factor, nc_path; tile_bytes)
+        NCDataset(nc_path) do ds
+            @test ds["lon"][:] ≈ (i₀ .+ factor .* (0.5:11.5)) .* Δ
+            @test ds["landcover_class"].var[:, :] == Float32.(expected.landcover_class)
+            @test ds["vegetation_fraction"].var[:, :] == Float32.(expected.vegetation_fraction)
+            for (name, fraction) in pairs(expected.class_fractions)
+                @test ds[string(class_fraction_variable_name(name))].var[:, :] == Float32.(fraction)
+            end
+        end
+    end
+    foreach(ArchGDAL.destroy, sources)
+
+    # The quarter with no published tile is no-data: class 0 and zero fractions.
+    @test all(iszero, expected.landcover_class[7:12, 7:12])
+    @test all(iszero, expected.vegetation_fraction[7:12, 7:12])
 end


### PR DESCRIPTION
Reading an `ESAWorldCover` window materialized the whole 10 m raster in one warp, ~340 GB for a continental region. The tile mosaic is now warped in lattice-aligned chunks of at most `default_tile_bytes`, each aggregated with `aggregate_landcover` and written to the NetCDF before the next is read, so nothing window-sized is resident. Tiles are selected from the padded window, so an edge tile is never skipped.

Nothing user-facing changes: the chunking happens inside `download(metadatum)`, behind the usual `Metadatum` and `Field` calls. The region must be a `BoundingBox`, and `ArchGDAL` must be loaded. For a continental window choose an `aggregation_factor` that keeps the aggregated lattice small (`120` → ~1 km).

```julia
using NumericalEarth, Oceananigans, ArchGDAL

grid = LatitudeLongitudeGrid(size = (40, 40), longitude = (4.8, 5.0), latitude = (52.3, 52.5),
                             topology = (Bounded, Bounded, Flat))
dataset = ESAWorldCover(aggregation_factor = 12)
region  = BoundingBox(grid)

vegetation = Field(Metadatum(:vegetation_fraction; dataset, region), grid)  # regridded onto `grid`
landcover  = Field(Metadatum(:landcover_class; dataset, region), CPU())     # on the aggregated lattice
```

Test: two synthetic tiles aggregated at 1, 9 and 144 chunks match the one-pass aggregation exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
