### PR TITLE
Add `tall_canopy_fraction_field` for the ETH canopy-height product

### DIFF
--- a/ext/NumericalEarthArchGDALExt/NumericalEarthArchGDALExt.jl
+++ b/ext/NumericalEarthArchGDALExt/NumericalEarthArchGDALExt.jl
@@ -8,9 +8,9 @@ using Downloads: Downloads
 using NetworkOptions: NetworkOptions
 using NumericalEarth: NumericalEarth
 
-using Oceananigans: Center, CPU
+using Oceananigans: Bounded, Center, CPU, Face, Flat, LatitudeLongitudeGrid
 using Oceananigans.Architectures: architecture, on_architecture
-using Oceananigans.Fields: Field, interior
+using Oceananigans.Fields: Field, interior, regrid!
 using Oceananigans.Grids: λnodes, φnodes
 
 using NumericalEarth.DataWrangling: BoundingBox, native_grid, native_region_grid,

--- a/ext/NumericalEarthArchGDALExt/ethcanopy.jl
+++ b/ext/NumericalEarthArchGDALExt/ethcanopy.jl
@@ -139,85 +139,72 @@ function canopy_field(grid, data)
     return h
 end
 
-# ~1 km lattice for multi-tile reads: 0.01° divides the 3° tiles exactly, so no lattice cell
-# straddles a tile seam and adjacent tiles mosaic without blending.
-const canopy_lattice_step = 0.01
-
-# Aggregate the tile `sources` onto the shared coarse lattice covering `region` (bounds
-# snapped outward to the lattice lines), returning the lattice grid and the masked cell-mean
-# heights on it; areas no source covers stay NaN.
-function canopy_lattice(sources, region; resampling = "average")
-    # 1e-9 absorbs float dust so bounds already on a lattice line do not snap a cell further
-    iλ₁ = floor(Int, region.longitude[1] / canopy_lattice_step + 1e-9)
-    iλ₂ =  ceil(Int, region.longitude[2] / canopy_lattice_step - 1e-9)
-    iφ₁ = floor(Int, region.latitude[1]  / canopy_lattice_step + 1e-9)
-    iφ₂ =  ceil(Int, region.latitude[2]  / canopy_lattice_step - 1e-9)
-    longitude = (iλ₁, iλ₂) .* canopy_lattice_step
-    latitude  = (iφ₁, iφ₂) .* canopy_lattice_step
-    Nλ = iλ₂ - iλ₁
-    Nφ = iφ₂ - iφ₁
-
-    warped = warp_canopy_onto_grid(sources, longitude, latitude, Nλ, Nφ; resampling, nodata = 255)
-    lattice = LatitudeLongitudeGrid(CPU(); size = (Nλ, Nφ), longitude, latitude,
-                                    topology = (Bounded, Bounded, Flat))
-    return lattice, mask_eth.(warped.data, 255)
-end
-
-# Area-weighted mean of the valid lattice cells under each grid cell — conservative regrid
-# of the values and of their validity — so cells the lattice never covers come out NaN (0/0).
-function landed_canopy_field(grid, lattice, data)
-    values = Field{Center, Center, Nothing}(lattice)
-    valid  = Field{Center, Center, Nothing}(lattice)
-    interior(values, :, :, 1) .= ifelse.(isnan.(data), 0, data)
-    interior(valid,  :, :, 1) .= isfinite.(data)
-
-    # Flat CPU twin of `grid`: the conservative regrid pairs like topologies and architectures.
-    twin = LatitudeLongitudeGrid(CPU(); size = (size(grid, 1), size(grid, 2)),
-                                 longitude = Array(λnodes(grid, Face())),
-                                 latitude  = Array(φnodes(grid, Face())),
-                                 topology  = (Bounded, Bounded, Flat))
-    landed = Field{Center, Center, Nothing}(twin)
-    weight = Field{Center, Center, Nothing}(twin)
-    regrid!(landed, values)
-    regrid!(weight, valid)
-
-    return canopy_field(grid, interior(landed, :, :, 1) ./ interior(weight, :, :, 1))
-end
-
 # Area-averaged read straight onto a model grid, coarse-graining the native pixels within
-# each cell without going through a regional NetCDF. Grids the ~1 km lattice cannot resolve
-# are windowed in one mosaic straight onto their cells; coarser grids go through the lattice.
+# each cell without going through a regional NetCDF.
 function NumericalEarth.DataWrangling.ETHSentinel2Canopy.canopy_height_field(grid, ::ETHSentinel2CanopyHeight;
                                                                             name = :canopy_height,
                                                                             resampling = "average")
     region = BoundingBox(grid)
     sources = eth_tile_urls(region, name)
 
-    λ₁, λ₂ = region.longitude
-    φ₁, φ₂ = region.latitude
-    if (λ₂ - λ₁) / size(grid, 1) < canopy_lattice_step || (φ₂ - φ₁) / size(grid, 2) < canopy_lattice_step
-        warped = with_gdal_config(eth_http_config()) do
-            warp_canopy_onto_grid(sources, region.longitude, region.latitude,
-                                  size(grid, 1), size(grid, 2); resampling, nodata = 255)
-        end
-        return canopy_field(grid, mask_eth.(warped.data, 255))
+    warped = with_gdal_config(eth_http_config()) do
+        warp_canopy_onto_grid(sources, region.longitude, region.latitude,
+                              size(grid, 1), size(grid, 2); resampling, nodata = 255)
     end
 
-    lattice, heights = with_gdal_config(eth_http_config()) do
-        canopy_lattice(sources, region; resampling)
-    end
-    return landed_canopy_field(grid, lattice, heights)
+    return canopy_field(grid, mask_eth.(warped.data, 255))
 end
 
-function NumericalEarth.DataWrangling.ETHSentinel2Canopy.tall_canopy_fraction_field(grid, ::ETHSentinel2CanopyHeight;
-                                                                                    threshold = 2)
+# Aggregation cells per grid-cell side, so the fraction resolves a hundredth of a cell.
+const canopy_subdivisions = 10
+
+# Fraction of each grid cell whose canopy stands at least `threshold` m tall: the tiles are
+# aggregated onto a lattice `canopy_subdivisions` times finer than the grid (never finer than
+# the product's own pixels), thresholded there, and landed by a conservative regrid of the
+# mask and of its validity, so cells no tile covers come out NaN (0/0).
+function canopy_fraction_field(grid, sources, threshold, native_step)
     region = BoundingBox(grid)
-    sources = eth_tile_urls(region, :canopy_height)
+    λ₁, λ₂ = region.longitude
+    φ₁, φ₂ = region.latitude
+    Δ = max(native_step, min((λ₂ - λ₁) / size(grid, 1), (φ₂ - φ₁) / size(grid, 2)) / canopy_subdivisions)
 
-    lattice, heights = with_gdal_config(eth_http_config()) do
-        canopy_lattice(sources, region)
+    # 1e-9 absorbs float dust so a bound already on a lattice line does not snap a cell further
+    iλ₁ = floor(Int, λ₁ / Δ + 1e-9)
+    iλ₂ =  ceil(Int, λ₂ / Δ - 1e-9)
+    iφ₁ = floor(Int, φ₁ / Δ + 1e-9)
+    iφ₂ =  ceil(Int, φ₂ / Δ - 1e-9)
+    longitude = (iλ₁, iλ₂) .* Δ
+    latitude  = (iφ₁, iφ₂) .* Δ
+    Nλ = iλ₂ - iλ₁
+    Nφ = iφ₂ - iφ₁
+
+    warped = with_gdal_config(eth_http_config()) do
+        warp_canopy_onto_grid(sources, longitude, latitude, Nλ, Nφ; nodata = 255)
     end
+    heights = mask_eth.(warped.data, 255)
 
-    tall = ifelse.(isnan.(heights), heights, Float32.(heights .>= threshold))
-    return landed_canopy_field(grid, lattice, tall)
+    lattice = LatitudeLongitudeGrid(CPU(); size = (Nλ, Nφ), longitude, latitude,
+                                    topology = (Bounded, Bounded, Flat))
+    tall  = Field{Center, Center, Nothing}(lattice)
+    valid = Field{Center, Center, Nothing}(lattice)
+    interior(tall,  :, :, 1) .= heights .≥ threshold
+    interior(valid, :, :, 1) .= isfinite.(heights)
+
+    # Flat CPU twin of `grid` to land the lattice on.
+    twin = LatitudeLongitudeGrid(CPU(); size = (size(grid, 1), size(grid, 2)),
+                                 longitude = Array(λnodes(grid, Face())),
+                                 latitude  = Array(φnodes(grid, Face())),
+                                 topology  = (Bounded, Bounded, Flat))
+    fraction = Field{Center, Center, Nothing}(twin)
+    weight   = Field{Center, Center, Nothing}(twin)
+    regrid!(fraction, tall)
+    regrid!(weight, valid)
+
+    return canopy_field(grid, interior(fraction, :, :, 1) ./ interior(weight, :, :, 1))
+end
+
+function NumericalEarth.DataWrangling.ETHSentinel2Canopy.tall_canopy_fraction_field(grid, dataset::ETHSentinel2CanopyHeight;
+                                                                                    threshold = 2)
+    sources = eth_tile_urls(BoundingBox(grid), :canopy_height)
+    return canopy_fraction_field(grid, sources, threshold, 360 / size(dataset, :canopy_height)[1])
 end

--- a/ext/NumericalEarthArchGDALExt/ethcanopy.jl
+++ b/ext/NumericalEarthArchGDALExt/ethcanopy.jl
@@ -139,18 +139,85 @@ function canopy_field(grid, data)
     return h
 end
 
+# ~1 km lattice for multi-tile reads: 0.01° divides the 3° tiles exactly, so no lattice cell
+# straddles a tile seam and adjacent tiles mosaic without blending.
+const canopy_lattice_step = 0.01
+
+# Aggregate the tile `sources` onto the shared coarse lattice covering `region` (bounds
+# snapped outward to the lattice lines), returning the lattice grid and the masked cell-mean
+# heights on it; areas no source covers stay NaN.
+function canopy_lattice(sources, region; resampling = "average")
+    # 1e-9 absorbs float dust so bounds already on a lattice line do not snap a cell further
+    iλ₁ = floor(Int, region.longitude[1] / canopy_lattice_step + 1e-9)
+    iλ₂ =  ceil(Int, region.longitude[2] / canopy_lattice_step - 1e-9)
+    iφ₁ = floor(Int, region.latitude[1]  / canopy_lattice_step + 1e-9)
+    iφ₂ =  ceil(Int, region.latitude[2]  / canopy_lattice_step - 1e-9)
+    longitude = (iλ₁, iλ₂) .* canopy_lattice_step
+    latitude  = (iφ₁, iφ₂) .* canopy_lattice_step
+    Nλ = iλ₂ - iλ₁
+    Nφ = iφ₂ - iφ₁
+
+    warped = warp_canopy_onto_grid(sources, longitude, latitude, Nλ, Nφ; resampling, nodata = 255)
+    lattice = LatitudeLongitudeGrid(CPU(); size = (Nλ, Nφ), longitude, latitude,
+                                    topology = (Bounded, Bounded, Flat))
+    return lattice, mask_eth.(warped.data, 255)
+end
+
+# Area-weighted mean of the valid lattice cells under each grid cell — conservative regrid
+# of the values and of their validity — so cells the lattice never covers come out NaN (0/0).
+function landed_canopy_field(grid, lattice, data)
+    values = Field{Center, Center, Nothing}(lattice)
+    valid  = Field{Center, Center, Nothing}(lattice)
+    interior(values, :, :, 1) .= ifelse.(isnan.(data), 0, data)
+    interior(valid,  :, :, 1) .= isfinite.(data)
+
+    # Flat CPU twin of `grid`: the conservative regrid pairs like topologies and architectures.
+    twin = LatitudeLongitudeGrid(CPU(); size = (size(grid, 1), size(grid, 2)),
+                                 longitude = Array(λnodes(grid, Face())),
+                                 latitude  = Array(φnodes(grid, Face())),
+                                 topology  = (Bounded, Bounded, Flat))
+    landed = Field{Center, Center, Nothing}(twin)
+    weight = Field{Center, Center, Nothing}(twin)
+    regrid!(landed, values)
+    regrid!(weight, valid)
+
+    return canopy_field(grid, interior(landed, :, :, 1) ./ interior(weight, :, :, 1))
+end
+
 # Area-averaged read straight onto a model grid, coarse-graining the native pixels within
-# each cell without going through a regional NetCDF.
+# each cell without going through a regional NetCDF. Grids the ~1 km lattice cannot resolve
+# are windowed in one mosaic straight onto their cells; coarser grids go through the lattice.
 function NumericalEarth.DataWrangling.ETHSentinel2Canopy.canopy_height_field(grid, ::ETHSentinel2CanopyHeight;
                                                                             name = :canopy_height,
                                                                             resampling = "average")
     region = BoundingBox(grid)
     sources = eth_tile_urls(region, name)
 
-    warped = with_gdal_config(eth_http_config()) do
-        warp_canopy_onto_grid(sources, region.longitude, region.latitude,
-                              size(grid, 1), size(grid, 2); resampling, nodata = 255)
+    λ₁, λ₂ = region.longitude
+    φ₁, φ₂ = region.latitude
+    if (λ₂ - λ₁) / size(grid, 1) < canopy_lattice_step || (φ₂ - φ₁) / size(grid, 2) < canopy_lattice_step
+        warped = with_gdal_config(eth_http_config()) do
+            warp_canopy_onto_grid(sources, region.longitude, region.latitude,
+                                  size(grid, 1), size(grid, 2); resampling, nodata = 255)
+        end
+        return canopy_field(grid, mask_eth.(warped.data, 255))
     end
 
-    return canopy_field(grid, mask_eth.(warped.data, 255))
+    lattice, heights = with_gdal_config(eth_http_config()) do
+        canopy_lattice(sources, region; resampling)
+    end
+    return landed_canopy_field(grid, lattice, heights)
+end
+
+function NumericalEarth.DataWrangling.ETHSentinel2Canopy.tall_canopy_fraction_field(grid, ::ETHSentinel2CanopyHeight;
+                                                                                    threshold = 2)
+    region = BoundingBox(grid)
+    sources = eth_tile_urls(region, :canopy_height)
+
+    lattice, heights = with_gdal_config(eth_http_config()) do
+        canopy_lattice(sources, region)
+    end
+
+    tall = ifelse.(isnan.(heights), heights, Float32.(heights .>= threshold))
+    return landed_canopy_field(grid, lattice, tall)
 end

--- a/src/DataWrangling/ETHSentinel2Canopy/ETHSentinel2Canopy.jl
+++ b/src/DataWrangling/ETHSentinel2Canopy/ETHSentinel2Canopy.jl
@@ -279,7 +279,7 @@ grid cell is subdivided into ten aggregation cells per side (never finer than th
 reaches `threshold`. Cells the product never covers are `NaN`. Requires the `ArchGDAL`
 package (`using ArchGDAL`).
 """
-tall_canopy_fraction_field(grid, dataset; kw...) =
+tall_canopy_fraction_field(grid, dataset::AbstractStaticDataset; kw...) =
     error("Reading a canopy-height Cloud-Optimized GeoTIFF onto a grid requires the " *
           "ArchGDAL package. Load it with `using ArchGDAL`.")
 

--- a/src/DataWrangling/ETHSentinel2Canopy/ETHSentinel2Canopy.jl
+++ b/src/DataWrangling/ETHSentinel2Canopy/ETHSentinel2Canopy.jl
@@ -1,6 +1,6 @@
 module ETHSentinel2Canopy
 
-export ETHSentinel2CanopyHeight, canopy_height_field
+export ETHSentinel2CanopyHeight, canopy_height_field, tall_canopy_fraction_field
 
 using Downloads: Downloads
 using Oceananigans: Center
@@ -34,7 +34,9 @@ raster distributed in 3°×3° tiles. Two layers per tile:
 
 Canopy height over non-forest is a legitimate value of `0` m (not missing), so
 these fields are **not inpainted** and zeros are kept — only the product's
-explicit no-data code is masked to `NaN`.
+explicit no-data code is masked to `NaN`. The retrieval reads several meters of
+canopy over cropland and grassland, so mask by land-cover class where tree
+heights are wanted.
 
 Because it is a global 10 m product, it is read in regional windows only:
 construct the `Metadatum` with a longitude/latitude `BoundingBox`. The windowed
@@ -254,17 +256,32 @@ canopy_height_cog_to_netcdf(metadatum, nc_path) =
 """
     canopy_height_field(grid, dataset; name = :canopy_height, resampling = "average")
 
-Read `dataset` canopy height directly onto `grid`, area-averaging (`-r average`, with the
-no-data byte excluded from each cell mean) the native COG pixels within each grid cell —
+Read `dataset` canopy height onto `grid`, area-averaging (`-r average`, with the no-data
+byte excluded from each cell mean) the native COG pixels within each grid cell —
 coarse-graining rather than point interpolation, the correct reduction from a 10 m raster
-onto a coarse model cell. Only the windowed COG blocks are read (anonymous `/vsicurl/`), so
-no full-resolution regional file is materialized.
+onto a coarse model cell. Grids finer than the ~1 km aggregation lattice are read in one
+windowed mosaic straight onto their cells; coarser grids — up to continental — go through
+the shared 0.01° lattice the intersecting 3° tiles are aggregated onto, landed with a
+conservative regrid. Only the windowed COG blocks are read (anonymous `/vsicurl/`), so no
+full-resolution regional file is materialized.
 
 Returns a `Field{Center, Center, Nothing}(grid)`: canopy height over non-forest is a valid
-`0`, tiles absent over ocean are skipped, and the product no-data code is masked to `NaN`.
+`0`, tiles absent over ocean are skipped, and cells the product never covers are `NaN`.
 Requires the `ArchGDAL` package (`using ArchGDAL`).
 """
 canopy_height_field(grid, dataset; kw...) =
+    error("Reading a canopy-height Cloud-Optimized GeoTIFF onto a grid requires the " *
+          "ArchGDAL package. Load it with `using ArchGDAL`.")
+
+"""
+    tall_canopy_fraction_field(grid, dataset; threshold = 2)
+
+Fraction of each grid cell standing under tall canopy: the share of the cell's ~1 km
+aggregation-lattice cells whose mean `dataset` canopy height is at least `threshold`
+meters. Cells the product never covers are `NaN`. Requires the `ArchGDAL` package
+(`using ArchGDAL`).
+"""
+tall_canopy_fraction_field(grid, dataset; kw...) =
     error("Reading a canopy-height Cloud-Optimized GeoTIFF onto a grid requires the " *
           "ArchGDAL package. Load it with `using ArchGDAL`.")
 

--- a/src/DataWrangling/ETHSentinel2Canopy/ETHSentinel2Canopy.jl
+++ b/src/DataWrangling/ETHSentinel2Canopy/ETHSentinel2Canopy.jl
@@ -253,9 +253,6 @@ canopy_height_cog_to_netcdf(metadatum, nc_path) =
     error("Reading the $(dataset_prefix(metadatum.dataset)) Cloud-Optimized GeoTIFF " *
           "requires the ArchGDAL package. Load it with `using ArchGDAL`.")
 
-const ARCHGDAL_REQUIRED = "Reading a canopy-height Cloud-Optimized GeoTIFF onto a grid " *
-                         "requires the ArchGDAL package. Load it with `using ArchGDAL`."
-
 """
     canopy_height_field(grid, dataset; name = :canopy_height, resampling = "average")
 
@@ -269,7 +266,9 @@ Returns a `Field{Center, Center, Nothing}(grid)`: canopy height over non-forest 
 `0`, tiles absent over ocean are skipped, and the product no-data code is masked to `NaN`.
 Requires the `ArchGDAL` package (`using ArchGDAL`).
 """
-canopy_height_field(grid, dataset; kw...) = error(ARCHGDAL_REQUIRED)
+canopy_height_field(grid, dataset; kw...) =
+    error("Reading a canopy-height Cloud-Optimized GeoTIFF onto a grid requires the " *
+          "ArchGDAL package. Load it with `using ArchGDAL`.")
 
 """
     tall_canopy_fraction_field(grid, dataset; threshold = 2)
@@ -280,6 +279,8 @@ grid cell is subdivided into ten aggregation cells per side (never finer than th
 reaches `threshold`. Cells the product never covers are `NaN`. Requires the `ArchGDAL`
 package (`using ArchGDAL`).
 """
-tall_canopy_fraction_field(grid, dataset; kw...) = error(ARCHGDAL_REQUIRED)
+tall_canopy_fraction_field(grid, dataset; kw...) =
+    error("Reading a canopy-height Cloud-Optimized GeoTIFF onto a grid requires the " *
+          "ArchGDAL package. Load it with `using ArchGDAL`.")
 
 end # module ETHSentinel2Canopy

--- a/src/DataWrangling/ETHSentinel2Canopy/ETHSentinel2Canopy.jl
+++ b/src/DataWrangling/ETHSentinel2Canopy/ETHSentinel2Canopy.jl
@@ -253,36 +253,33 @@ canopy_height_cog_to_netcdf(metadatum, nc_path) =
     error("Reading the $(dataset_prefix(metadatum.dataset)) Cloud-Optimized GeoTIFF " *
           "requires the ArchGDAL package. Load it with `using ArchGDAL`.")
 
+const ARCHGDAL_REQUIRED = "Reading a canopy-height Cloud-Optimized GeoTIFF onto a grid " *
+                         "requires the ArchGDAL package. Load it with `using ArchGDAL`."
+
 """
     canopy_height_field(grid, dataset; name = :canopy_height, resampling = "average")
 
-Read `dataset` canopy height onto `grid`, area-averaging (`-r average`, with the no-data
-byte excluded from each cell mean) the native COG pixels within each grid cell —
+Read `dataset` canopy height directly onto `grid`, area-averaging (`-r average`, with the
+no-data byte excluded from each cell mean) the native COG pixels within each grid cell —
 coarse-graining rather than point interpolation, the correct reduction from a 10 m raster
-onto a coarse model cell. Grids finer than the ~1 km aggregation lattice are read in one
-windowed mosaic straight onto their cells; coarser grids — up to continental — go through
-the shared 0.01° lattice the intersecting 3° tiles are aggregated onto, landed with a
-conservative regrid. Only the windowed COG blocks are read (anonymous `/vsicurl/`), so no
-full-resolution regional file is materialized.
+onto a coarse model cell. Only the windowed COG blocks are read (anonymous `/vsicurl/`), so
+no full-resolution regional file is materialized.
 
 Returns a `Field{Center, Center, Nothing}(grid)`: canopy height over non-forest is a valid
-`0`, tiles absent over ocean are skipped, and cells the product never covers are `NaN`.
+`0`, tiles absent over ocean are skipped, and the product no-data code is masked to `NaN`.
 Requires the `ArchGDAL` package (`using ArchGDAL`).
 """
-canopy_height_field(grid, dataset; kw...) =
-    error("Reading a canopy-height Cloud-Optimized GeoTIFF onto a grid requires the " *
-          "ArchGDAL package. Load it with `using ArchGDAL`.")
+canopy_height_field(grid, dataset; kw...) = error(ARCHGDAL_REQUIRED)
 
 """
     tall_canopy_fraction_field(grid, dataset; threshold = 2)
 
-Fraction of each grid cell standing under tall canopy: the share of the cell's ~1 km
-aggregation-lattice cells whose mean `dataset` canopy height is at least `threshold`
-meters. Cells the product never covers are `NaN`. Requires the `ArchGDAL` package
-(`using ArchGDAL`).
+Fraction of each grid cell standing under canopy at least `threshold` meters tall. Each
+grid cell is subdivided into ten aggregation cells per side (never finer than the product's
+10 m pixels), and the fraction is the share of those whose mean `dataset` canopy height
+reaches `threshold`. Cells the product never covers are `NaN`. Requires the `ArchGDAL`
+package (`using ArchGDAL`).
 """
-tall_canopy_fraction_field(grid, dataset; kw...) =
-    error("Reading a canopy-height Cloud-Optimized GeoTIFF onto a grid requires the " *
-          "ArchGDAL package. Load it with `using ArchGDAL`.")
+tall_canopy_fraction_field(grid, dataset; kw...) = error(ARCHGDAL_REQUIRED)
 
 end # module ETHSentinel2Canopy

--- a/src/DataWrangling/ETHSentinel2Canopy/ETHSentinel2Canopy.jl
+++ b/src/DataWrangling/ETHSentinel2Canopy/ETHSentinel2Canopy.jl
@@ -279,7 +279,7 @@ grid cell is subdivided into ten aggregation cells per side (never finer than th
 reaches `threshold`. Cells the product never covers are `NaN`. Requires the `ArchGDAL`
 package (`using ArchGDAL`).
 """
-tall_canopy_fraction_field(grid, dataset::AbstractStaticDataset; kw...) =
+tall_canopy_fraction_field(grid, dataset; kw...) =
     error("Reading a canopy-height Cloud-Optimized GeoTIFF onto a grid requires the " *
           "ArchGDAL package. Load it with `using ArchGDAL`.")
 

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -133,7 +133,7 @@ export
     ASTERGEDv3, ASTERGEDResolution, ASTERGEDHigh100m, ASTERGEDLow1km,
     CopernicusAlbedo, CopernicusAlbedoClimatology, build_monthly_climatology!,
     ESAWorldCover, WorldCoverVersion, WorldCoverV100, WorldCoverV200,
-    ETHSentinel2CanopyHeight, canopy_height_field,
+    ETHSentinel2CanopyHeight, canopy_height_field, tall_canopy_fraction_field,
     GLORYSDaily, GLORYSMonthly, GLORYSStatic,
     AVISOMetadata, AVISODaily, AVISOMonthly, AVISOMetadatum,
     RepeatYearJRA55, MultiYearJRA55,

--- a/test/test_ethsentinel2canopy.jl
+++ b/test/test_ethsentinel2canopy.jl
@@ -160,6 +160,7 @@ end
     if isnothing(Base.get_extension(NumericalEarth, :NumericalEarthArchGDALExt))
         @test_throws ErrorException canopy_height_cog_to_netcdf(meta, tempname() * ".nc")
         @test_throws ErrorException canopy_height_field(grid, ETHSentinel2CanopyHeight())
+        @test_throws ErrorException tall_canopy_fraction_field(grid, ETHSentinel2CanopyHeight())
     end
 end
 
@@ -213,4 +214,81 @@ end
     @test size(H) == (nx, ny, 1)
     @test H[1, 1, 1] ≈ 50                      # south
     @test isnan(H[1, ny, 1])                   # north-west gap
+end
+
+#####
+##### Multi-tile stitching onto the shared coarse lattice, on synthetic local tiles
+##### (no network): adjacent tiles mosaic without seams, no-data stays NaN, treeless
+##### pixels pull the cell mean down, and never-covered cells land as NaN.
+#####
+
+@testset "Stitched multi-tile lattice" begin
+    ext = Base.get_extension(NumericalEarth, :NumericalEarthArchGDALExt)
+    @test !isnothing(ext)
+
+    # Two adjacent 0.1° × 0.1° EPSG:4326 Byte tiles at 0.002° pixels (5×5 pixels per 0.01°
+    # lattice cell), meeting on the lattice line λ = 0.1 like the product's 3° tiles do.
+    Δ = 0.002
+    nx = ny = 50
+    function synthetic_tile(λ₀, band)
+        tif = tempname() * ".tif"
+        ArchGDAL.create(tif; driver = ArchGDAL.getdriver("GTiff"),
+                        width = nx, height = ny, nbands = 1, dtype = UInt8) do ds
+            ArchGDAL.setgeotransform!(ds, [λ₀, Δ, 0.0, 50.1, 0.0, -Δ])
+            ArchGDAL.setproj!(ds, ArchGDAL.toWKT(ArchGDAL.importEPSG(4326)))
+            ArchGDAL.write!(ArchGDAL.getband(ds, 1), band)
+        end
+        return tif
+    end
+
+    # West tile: 10 m canopy, with three patched lattice cells in row j = 9 (rows 6:10):
+    # (2, 9) all no-data, (3, 9) 25 m trees over a fifth of the cell and treeless elsewhere,
+    # (4, 9) fully treeless — valid zeros, not gaps.
+    west = fill(UInt8(10), nx, ny)
+    west[6:10, 6:10]  .= 255
+    west[11:15, 6:10] .= 0
+    west[11, 6:10]    .= 25
+    west[16:20, 6:10] .= 0
+    east = fill(UInt8(30), nx, ny)
+
+    sources = [synthetic_tile(0.0, west), synthetic_tile(0.1, east)]
+
+    # The region reaches to 0.3°E, one tile width past the published tiles.
+    region = BoundingBox(longitude = (0.0, 0.3), latitude = (50.0, 50.1))
+    lattice, heights = ext.canopy_lattice(sources, region)
+
+    @test size(heights) == (30, 10)
+    @test size(lattice) == (30, 10, 1)
+
+    # Seam-free: per-tile cell means change exactly at the tile boundary, nothing blends.
+    @test all(heights[10, :] .≈ 10)
+    @test all(heights[11, :] .≈ 30)
+    @test all(h -> isnan(h) || any(v -> abs(h - v) < 1e-4, (0, 5, 10, 30)), heights)
+
+    # No-data stays NaN; its valid neighbor is untouched; treeless pixels pull the mean down.
+    @test isnan(heights[2, 9])
+    @test heights[1, 9] ≈ 10
+    @test heights[3, 9] ≈ 5
+    @test heights[4, 9] ≈ 0 atol = 1e-4
+
+    # No tile covers λ > 0.2°: never-covered lattice cells stay NaN.
+    @test all(isnan, heights[21:30, :])
+
+    # Landing on a model grid: area-weighted mean of the valid lattice cells under each grid
+    # cell (the no-data cell is excluded, the treeless cells count); cells the product never
+    # covers stay NaN.
+    grid = LatitudeLongitudeGrid(CPU(); size = (3, 1), longitude = (0, 0.3), latitude = (50, 50.1),
+                                 topology = (Bounded, Bounded, Flat))
+    H = Array(interior(ext.landed_canopy_field(grid, lattice, heights), :, :, 1))
+    @test H[1] ≈ (97 * 10 + 5 + 0) / 99 atol = 0.01
+    @test H[2] ≈ 30
+    @test isnan(H[3])
+
+    # A thresholded lattice lands as the tall-canopy fraction: 98 of the west cell's 99
+    # valid lattice cells stand at least 2 m tall.
+    tall = ifelse.(isnan.(heights), heights, Float32.(heights .>= 2))
+    F = Array(interior(ext.landed_canopy_field(grid, lattice, tall), :, :, 1))
+    @test F[1] ≈ 98 / 99 atol = 0.001
+    @test F[2] ≈ 1
+    @test isnan(F[3])
 end

--- a/test/test_ethsentinel2canopy.jl
+++ b/test/test_ethsentinel2canopy.jl
@@ -217,33 +217,31 @@ end
 end
 
 #####
-##### Multi-tile stitching onto the shared coarse lattice, on synthetic local tiles
-##### (no network): adjacent tiles mosaic without seams, no-data stays NaN, treeless
-##### pixels pull the cell mean down, and never-covered cells land as NaN.
+##### Tall-canopy fraction over a synthetic two-tile mosaic (no network): the threshold
+##### selects, treeless and no-data pixels are told apart, adjacent tiles both contribute,
+##### and the aggregation lattice follows the grid down to the product's own pixel size.
 #####
 
-@testset "Stitched multi-tile lattice" begin
+@testset "Tall-canopy fraction" begin
     ext = Base.get_extension(NumericalEarth, :NumericalEarthArchGDALExt)
     @test !isnothing(ext)
 
-    # Two adjacent 0.1° × 0.1° EPSG:4326 Byte tiles at 0.002° pixels (5×5 pixels per 0.01°
-    # lattice cell), meeting on the lattice line λ = 0.1 like the product's 3° tiles do.
-    Δ = 0.002
+    # Two adjacent 0.1° × 0.1° EPSG:4326 Byte tiles at 0.002° pixels, meeting at λ = 0.1.
+    native_step = 0.002
     nx = ny = 50
     function synthetic_tile(λ₀, band)
         tif = tempname() * ".tif"
         ArchGDAL.create(tif; driver = ArchGDAL.getdriver("GTiff"),
                         width = nx, height = ny, nbands = 1, dtype = UInt8) do ds
-            ArchGDAL.setgeotransform!(ds, [λ₀, Δ, 0.0, 50.1, 0.0, -Δ])
+            ArchGDAL.setgeotransform!(ds, [λ₀, native_step, 0.0, 50.1, 0.0, -native_step])
             ArchGDAL.setproj!(ds, ArchGDAL.toWKT(ArchGDAL.importEPSG(4326)))
             ArchGDAL.write!(ArchGDAL.getband(ds, 1), band)
         end
         return tif
     end
 
-    # West tile: 10 m canopy, with three patched lattice cells in row j = 9 (rows 6:10):
-    # (2, 9) all no-data, (3, 9) 25 m trees over a fifth of the cell and treeless elsewhere,
-    # (4, 9) fully treeless — valid zeros, not gaps.
+    # West tile: 10 m canopy, with three patches across rows 6:10 — columns 6:10 no-data,
+    # columns 11:15 a single 25 m column beside treeless zeros, columns 16:20 all treeless.
     west = fill(UInt8(10), nx, ny)
     west[6:10, 6:10]  .= 255
     west[11:15, 6:10] .= 0
@@ -253,42 +251,30 @@ end
 
     sources = [synthetic_tile(0.0, west), synthetic_tile(0.1, east)]
 
-    # The region reaches to 0.3°E, one tile width past the published tiles.
-    region = BoundingBox(longitude = (0.0, 0.3), latitude = (50.0, 50.1))
-    lattice, heights = ext.canopy_lattice(sources, region)
-
-    @test size(heights) == (30, 10)
-    @test size(lattice) == (30, 10, 1)
-
-    # Seam-free: per-tile cell means change exactly at the tile boundary, nothing blends.
-    @test all(heights[10, :] .≈ 10)
-    @test all(heights[11, :] .≈ 30)
-    @test all(h -> isnan(h) || any(v -> abs(h - v) < 1e-4, (0, 5, 10, 30)), heights)
-
-    # No-data stays NaN; its valid neighbor is untouched; treeless pixels pull the mean down.
-    @test isnan(heights[2, 9])
-    @test heights[1, 9] ≈ 10
-    @test heights[3, 9] ≈ 5
-    @test heights[4, 9] ≈ 0 atol = 1e-4
-
-    # No tile covers λ > 0.2°: never-covered lattice cells stay NaN.
-    @test all(isnan, heights[21:30, :])
-
-    # Landing on a model grid: area-weighted mean of the valid lattice cells under each grid
-    # cell (the no-data cell is excluded, the treeless cells count); cells the product never
-    # covers stay NaN.
+    # Three 0.1° cells: the west tile, the east tile, and one the tiles never reach.
     grid = LatitudeLongitudeGrid(CPU(); size = (3, 1), longitude = (0, 0.3), latitude = (50, 50.1),
                                  topology = (Bounded, Bounded, Flat))
-    H = Array(interior(ext.landed_canopy_field(grid, lattice, heights), :, :, 1))
-    @test H[1] ≈ (97 * 10 + 5 + 0) / 99 atol = 0.01
-    @test H[2] ≈ 30
-    @test isnan(H[3])
 
-    # A thresholded lattice lands as the tall-canopy fraction: 98 of the west cell's 99
-    # valid lattice cells stand at least 2 m tall.
-    tall = ifelse.(isnan.(heights), heights, Float32.(heights .>= 2))
-    F = Array(interior(ext.landed_canopy_field(grid, lattice, tall), :, :, 1))
-    @test F[1] ≈ 98 / 99 atol = 0.001
+    # Aggregation cells are a tenth of a grid cell (0.01°): 99 of the west cell's 100 carry
+    # data, and the one whose mean the zeros pull under 2 m is the only one not tall.
+    F = Array(interior(ext.canopy_fraction_field(grid, sources, 2, native_step), :, :, 1))
+    @test F[1] ≈ 98 / 99 atol = 1e-3
     @test F[2] ≈ 1
     @test isnan(F[3])
+
+    # Nothing in the west tile reaches 20 m once averaged; the east tile is 30 m throughout.
+    T = Array(interior(ext.canopy_fraction_field(grid, sources, 20, native_step), :, :, 1))
+    @test T[1] ≈ 0 atol = 1e-6
+    @test T[2] ≈ 1
+    @test isnan(T[3])
+
+    # A grid finer than ten native pixels per cell floors the lattice at the pixel size, so
+    # the fraction becomes the exact share of tall pixels: the treeless patch spans 20 of
+    # the 250 pixels under cell 3 and all 25 under cell 4.
+    fine = LatitudeLongitudeGrid(CPU(); size = (30, 1), longitude = (0, 0.3), latitude = (50, 50.1),
+                                 topology = (Bounded, Bounded, Flat))
+    P = Array(interior(ext.canopy_fraction_field(fine, sources, 2, native_step), :, :, 1))
+    @test P[2] ≈ 1                             # the no-data patch shrinks the denominator only
+    @test P[3] ≈ 230 / 250 atol = 1e-3
+    @test P[4] ≈ 225 / 250 atol = 1e-3
 end

--- a/test/test_ethsentinel2canopy_downloading.jl
+++ b/test/test_ethsentinel2canopy_downloading.jl
@@ -40,11 +40,13 @@ const canopy_height = canopy_height_field(canopy_grid, ETHSentinel2CanopyHeight(
 end
 
 @testset "Tall-canopy fraction over closed forest" begin
-    fraction = tall_canopy_fraction_field(canopy_grid, ETHSentinel2CanopyHeight())
-    f = Array(interior(fraction, :, :, 1))
+    f = Array(interior(tall_canopy_fraction_field(canopy_grid, ETHSentinel2CanopyHeight()), :, :, 1))
+    tall = Array(interior(tall_canopy_fraction_field(canopy_grid, ETHSentinel2CanopyHeight();
+                                                     threshold = 40), :, :, 1))
 
-    # Closed evergreen canopy: every ~1 km lattice cell stands at least 2 m tall.
-    @test all(f .≈ 1)
+    @test all(f .≈ 1)                      # closed evergreen canopy: nothing stands under 2 m
+    @test all(0 .≤ tall .≤ 1)
+    @test all(tall .≤ f)                   # a taller threshold can only select less
 end
 
 @testset "Downloading the ETH regional canopy-height file" begin

--- a/test/test_ethsentinel2canopy_downloading.jl
+++ b/test/test_ethsentinel2canopy_downloading.jl
@@ -39,6 +39,14 @@ const canopy_height = canopy_height_field(canopy_grid, ETHSentinel2CanopyHeight(
     @test all(0 .< sd .< h)
 end
 
+@testset "Tall-canopy fraction over closed forest" begin
+    fraction = tall_canopy_fraction_field(canopy_grid, ETHSentinel2CanopyHeight())
+    f = Array(interior(fraction, :, :, 1))
+
+    # Closed evergreen canopy: every ~1 km lattice cell stands at least 2 m tall.
+    @test all(f .≈ 1)
+end
+
 @testset "Downloading the ETH regional canopy-height file" begin
     metadatum = Metadatum(:canopy_height; dataset = ETHSentinel2CanopyHeight(), region = canopy_region)
     filepath = metadata_path(metadatum)


### PR DESCRIPTION
`tall_canopy_fraction_field(grid, ETHSentinel2CanopyHeight(); threshold = 2)`: the fraction of each grid cell standing under canopy at least `threshold` m tall. A threshold cannot be recovered from a cell mean, so the intersecting 3° COG tiles are aggregated onto a lattice ten cells per grid-cell side — never finer than the product's own 10 m pixels — and the thresholded mask and its validity are landed on the grid by a conservative regrid. Cells no tile covers come out `NaN`.

- `canopy_height_field` is unchanged.
- Dataset docstring notes the product's high bias over cropland and grass.
- Synthetic-tile tests: the threshold selects, treeless and no-data pixels are told apart, and a grid finer than ten native pixels per cell floors the lattice at the pixel size (fraction then exact to the pixel).