### PR TITLE
Land MCD12Q1 class fractions and the majority class on a model grid

### DIFF
--- a/src/DataWrangling/MODISLand/MODISLand.jl
+++ b/src/DataWrangling/MODISLand/MODISLand.jl
@@ -20,7 +20,7 @@ using Statistics: mean
 using ..DataWrangling: DataWrangling, Metadata, Metadatum, BoundingBox,
                        metadata_path, default_download_directory,
                        native_cell_range, native_convention_longitude,
-                       cmr_granules, write_atomically
+                       cmr_granules, write_atomically, class_fractions, majority_class!
 
 import Oceananigans
 

--- a/src/DataWrangling/MODISLand/MODISLand.jl
+++ b/src/DataWrangling/MODISLand/MODISLand.jl
@@ -12,7 +12,9 @@ using Dates: Dates, DateTime, Day, dayofyear
 using Downloads: Downloads
 using NCDatasets: NCDataset, defDim, defVar
 using Oceananigans: Center
+using Oceananigans.Architectures: child_architecture
 using Oceananigans.DistributedComputations: @root
+using Oceananigans.Fields: Field, interior, regrid!
 using Statistics: mean
 
 using ..DataWrangling: DataWrangling, Metadata, Metadatum, BoundingBox,

--- a/src/DataWrangling/MODISLand/datasets.jl
+++ b/src/DataWrangling/MODISLand/datasets.jl
@@ -111,10 +111,8 @@ enumerated classification quality, 0 being good classified land), and `:land_wat
 keyed on it. `:LAI` is the stratification the MCD15 retrieval itself uses, which makes it
 the closer match when the class field is there to pool leaf-area donors.
 
-Class codes are **not** interpolable: read them on the product's own grid, where
-`Field(metadatum)` lands them, and take [`class_fractions`](@ref)`(grid, dataset)` if a
-model grid is wanted. A bilinear regrid averages urban (13) against water (17) into
-permanent snow (15).
+On a model grid, `Field(metadatum, grid)` lands the class covering the largest area of
+each cell, and [`class_fractions`](@ref) returns every class's area fraction beside it.
 
 Granules are HDF-EOS2 tiles discovered through NASA's Common Metadata Repository, so a
 lon/lat [`BoundingBox`](@ref) is required, `ArchGDAL` must be loaded, and a NASA Earthdata
@@ -363,37 +361,43 @@ end
                     region = BoundingBox(grid),
                     dir = default_download_directory(dataset))
 
-Land the MCD12Q1 class map of `date` on `grid` as per-class area fractions:
-`(; fractions, majority_class)`, where `fractions` holds one fraction `Field` per legend
-class name and `majority_class` is the `Field` of the class code covering the largest
-fraction of each cell (ties resolve to the lower code).
-
-The class map is read on its native lattice over `region`, no-data cells are counted as
-water, and each class's indicator rides the conservative `regrid!`, so every cell's
-fractions sum to one.
+The MCD12Q1 class map of `date`'s year on `grid` as `(; fractions, majority_class)`: one
+area-fraction `Field` per legend class name, regridded conservatively from the native
+lattice over `region` with no-data counted as water, and the `Field` of the class code
+covering the largest fraction of each cell, ties resolving to the lower code and `NaN`
+outside `region`.
 """
 function DataWrangling.class_fractions(grid, dataset::MCD12Q1;
                                        date,
                                        region = BoundingBox(grid),
                                        dir = default_download_directory(dataset))
     metadatum = Metadatum(:landcover_class; dataset, region, date, dir)
-    classes = Field(metadatum, child_architecture(grid))
-    codes = interior(classes)
-    codes .= ifelse.(isfinite.(codes), codes, landcover_class_names(dataset).water)
-
-    indicator = Field{Center, Center, Nothing}(classes.grid)
-    majority_class = Field{Center, Center, Nothing}(grid)
-    largest_fraction = Field{Center, Center, Nothing}(grid)
-
-    fractions = map(landcover_class_names(dataset)) do code
-        interior(indicator) .= codes .== code
-        fraction = Field{Center, Center, Nothing}(grid)
-        regrid!(fraction, indicator)
-        interior(majority_class) .= ifelse.(interior(fraction) .> interior(largest_fraction),
-                                            code, interior(majority_class))
-        interior(largest_fraction) .= max.(interior(largest_fraction), interior(fraction))
-        return fraction
-    end
-
+    fractions = class_fractions(grid, Field(metadatum, child_architecture(grid)), dataset)
+    majority_class = majority_class!(Field{Center, Center, Nothing}(grid), fractions,
+                                     landcover_class_names(dataset))
     return (; fractions, majority_class)
+end
+
+"""
+    class_fractions(grid, classes::Field, dataset::MCD12Q1)
+
+The area fraction of each legend class of `dataset` on `grid`, regridded conservatively
+from the class map `classes` on its native lattice with no-data counted as water.
+"""
+function DataWrangling.class_fractions(grid, classes::Field, dataset::MCD12Q1)
+    class_names = landcover_class_names(dataset)
+    codes = interior(classes)
+    water = convert(eltype(codes), class_names.water)
+    indicator = Field{Center, Center, Nothing}(classes.grid)
+    return map(class_names) do code
+        interior(indicator) .= ifelse.(isfinite.(codes), codes, water) .== code
+        regrid!(Field{Center, Center, Nothing}(grid), indicator)
+    end
+end
+
+function DataWrangling.interpolate_physical!(target, classes, metadatum::Metadatum{<:MCD12Q1})
+    metadatum.name === :landcover_class ||
+        return DataWrangling.interpolate_physical!(target, classes)
+    fractions = class_fractions(target.grid, classes, metadatum.dataset)
+    return majority_class!(target, fractions, landcover_class_names(metadatum.dataset))
 end

--- a/src/DataWrangling/MODISLand/datasets.jl
+++ b/src/DataWrangling/MODISLand/datasets.jl
@@ -112,8 +112,9 @@ keyed on it. `:LAI` is the stratification the MCD15 retrieval itself uses, which
 the closer match when the class field is there to pool leaf-area donors.
 
 Class codes are **not** interpolable: read them on the product's own grid, where
-`Field(metadatum)` lands them, and take [`class_fraction`](@ref) if a model grid is wanted.
-A bilinear regrid averages urban (13) against water (17) into permanent snow (15).
+`Field(metadatum)` lands them, and take [`class_fractions`](@ref)`(grid, dataset)` if a
+model grid is wanted. A bilinear regrid averages urban (13) against water (17) into
+permanent snow (15).
 
 Granules are HDF-EOS2 tiles discovered through NASA's Common Metadata Repository, so a
 lon/lat [`BoundingBox`](@ref) is required, `ArchGDAL` must be loaded, and a NASA Earthdata
@@ -351,4 +352,48 @@ function DataWrangling.validate_dataset_coverage(grid, metadata::MODISLandMetada
               "                        region = BoundingBox(longitude = (λ₁, λ₂), latitude = (φ₁, φ₂)))")
     end
     return nothing
+end
+
+#####
+##### The class map on a model grid
+#####
+
+"""
+    class_fractions(grid, dataset::MCD12Q1; date,
+                    region = BoundingBox(grid),
+                    dir = default_download_directory(dataset))
+
+Land the MCD12Q1 class map of `date` on `grid` as per-class area fractions:
+`(; fractions, majority_class)`, where `fractions` holds one fraction `Field` per legend
+class name and `majority_class` is the `Field` of the class code covering the largest
+fraction of each cell (ties resolve to the lower code).
+
+The class map is read on its native lattice over `region`, no-data cells are counted as
+water, and each class's indicator rides the conservative `regrid!`, so every cell's
+fractions sum to one.
+"""
+function DataWrangling.class_fractions(grid, dataset::MCD12Q1;
+                                       date,
+                                       region = BoundingBox(grid),
+                                       dir = default_download_directory(dataset))
+    metadatum = Metadatum(:landcover_class; dataset, region, date, dir)
+    classes = Field(metadatum, child_architecture(grid))
+    codes = interior(classes)
+    codes .= ifelse.(isfinite.(codes), codes, landcover_class_names(dataset).water)
+
+    indicator = Field{Center, Center, Nothing}(classes.grid)
+    majority_class = Field{Center, Center, Nothing}(grid)
+    largest_fraction = Field{Center, Center, Nothing}(grid)
+
+    fractions = map(landcover_class_names(dataset)) do code
+        interior(indicator) .= codes .== code
+        fraction = Field{Center, Center, Nothing}(grid)
+        regrid!(fraction, indicator)
+        interior(majority_class) .= ifelse.(interior(fraction) .> interior(largest_fraction),
+                                            code, interior(majority_class))
+        interior(largest_fraction) .= max.(interior(largest_fraction), interior(fraction))
+        return fraction
+    end
+
+    return (; fractions, majority_class)
 end

--- a/src/DataWrangling/WorldCover/WorldCover.jl
+++ b/src/DataWrangling/WorldCover/WorldCover.jl
@@ -3,16 +3,13 @@ module WorldCover
 export ESAWorldCover, WorldCoverVersion, WorldCoverV100, WorldCoverV200
 
 using Downloads: Downloads
-using KernelAbstractions: @kernel, @index
 using Oceananigans: Center, location
 using Oceananigans.Architectures: architecture, child_architecture
-using Oceananigans.BoundaryConditions: fill_halo_regions!
 using Oceananigans.DistributedComputations: @root
 using Oceananigans.Fields: Field, regrid!
-using Oceananigans.Utils: launch!
 
 using ..DataWrangling: DataWrangling, AbstractStaticDataset, Metadatum,
-                       metadata_path, BoundingBox, Dataset
+                       metadata_path, BoundingBox, Dataset, majority_class!
 
 import Oceananigans
 
@@ -422,74 +419,21 @@ Oceananigans.Fields.location(::ESAWorldCoverMetadatum) = (Center, Center, Center
 #####
 ##### Regridding onto a model grid
 #####
-##### The fraction products ride Oceananigans' conservative (area-weighted)
-##### `regrid!`, so each target cell carries the true area fraction of every class
-##### and the fractions still sum to one. The categorical `:landcover_class` is the argmax of
-##### those fractions — the class covering the most area of the target cell.
-##### Bilinear interpolation of the codes would instead invent intermediate,
-##### non-legend classes. Both extend the shared `interpolate_physical!` regrid
-##### hook, dispatched on the metadatum.
-#####
 
 function DataWrangling.interpolate_physical!(target, native, metadata::ESAWorldCoverMetadatum)
-    if metadata.name === :landcover_class
-        majority_class_regrid!(target, metadata)
-    else
-        regrid!(target, native)
-    end
-    return target
-end
+    metadata.name === :landcover_class || return regrid!(target, native)
 
-# Majority class of each target cell: the class holding the largest conservatively
-# regridded area fraction. This keeps the class consistent with the fraction
-# fields and confined to the legend. Refining rather than coarsening needs no
-# special case — the conservative regrid then reduces to the containing native
-# cell, whose majority class the target inherits. Ties resolve to the lower code,
-# matching `majority_class`, because the classes accumulate in ascending order.
-function majority_class_regrid!(target, metadata)
     grid = target.grid
     arch = child_architecture(architecture(grid))
     LX, LY, LZ = location(metadata)
 
-    fraction = Field{LX, LY, LZ}(grid)
-    largest_fraction = Field{LX, LY, LZ}(grid)
-    total_fraction = Field{LX, LY, LZ}(grid)
-
-    fill!(target, 0)
-    fill!(largest_fraction, 0)
-    fill!(total_fraction, 0)
-
-    for (name, code) in zip(ESA_WORLDCOVER_FRACTION_VARIABLE_NAMES, ESA_WORLDCOVER_CLASS_CODES)
+    fractions = map(ESA_WORLDCOVER_FRACTION_VARIABLE_NAMES) do name
         fraction_metadatum = Metadatum(name; dataset = metadata.dataset,
                                        region = metadata.region, dir = metadata.dir)
-        regrid!(fraction, Field(fraction_metadatum, arch))
-        launch!(arch, grid, :xyz, _accumulate_majority_class!,
-                target, largest_fraction, total_fraction, fraction, code)
+        regrid!(Field{LX, LY, LZ}(grid), Field(fraction_metadatum, arch))
     end
 
-    launch!(arch, grid, :xyz, _mask_uncovered_class!, target, total_fraction)
-    fill_halo_regions!(target)
-    return target
-end
-
-@kernel function _accumulate_majority_class!(target, largest_fraction, total_fraction, fraction, code)
-    i, j, k = @index(Global, NTuple)
-    @inbounds begin
-        f = fraction[i, j, k]
-        larger = f > largest_fraction[i, j, k]
-        largest_fraction[i, j, k] = ifelse(larger, f, largest_fraction[i, j, k])
-        target[i, j, k] = ifelse(larger, convert(eltype(target), code), target[i, j, k])
-        total_fraction[i, j, k] += f
-    end
-end
-
-# Cells outside the product's coverage have no valid pixels, so every fraction is
-# zero and no class holds a majority.
-@kernel function _mask_uncovered_class!(target, total_fraction)
-    i, j, k = @index(Global, NTuple)
-    FT = eltype(target)
-    @inbounds covered = total_fraction[i, j, k] > convert(FT, 1//2)
-    @inbounds target[i, j, k] = ifelse(covered, target[i, j, k], convert(FT, NaN))
+    return majority_class!(target, fractions, ESA_WORLDCOVER_CLASS_CODES)
 end
 
 #####

--- a/src/DataWrangling/class_fractions.jl
+++ b/src/DataWrangling/class_fractions.jl
@@ -50,3 +50,52 @@ function class_fractions(codes, classes, factor)
 
     return fractions
 end
+
+#####
+##### The majority class of regridded fractions
+#####
+
+"""
+    majority_class!(majority_class, fractions, codes)
+
+Set each cell of `majority_class` to the entry of `codes` whose `Field` in `fractions`
+covers the largest fraction of it, ties going to the earlier entry. Cells whose fractions
+sum below one half are `NaN`.
+"""
+function majority_class!(majority_class, fractions, codes)
+    grid = majority_class.grid
+    arch = child_architecture(architecture(grid))
+    LX, LY, LZ = location(majority_class)
+    largest_fraction = Field{LX, LY, LZ}(grid)
+    total_fraction = Field{LX, LY, LZ}(grid)
+
+    fill!(majority_class, 0)
+    for (fraction, code) in zip(fractions, codes)
+        launch!(arch, grid, :xyz, _accumulate_majority_class!,
+                majority_class, largest_fraction, total_fraction, fraction, code)
+    end
+
+    launch!(arch, grid, :xyz, _mask_uncovered_class!, majority_class, total_fraction)
+    fill_halo_regions!(majority_class)
+    return majority_class
+end
+
+@kernel function _accumulate_majority_class!(target, largest_fraction, total_fraction, fraction, code)
+    i, j, k = @index(Global, NTuple)
+    @inbounds begin
+        f = fraction[i, j, k]
+        larger = f > largest_fraction[i, j, k]
+        largest_fraction[i, j, k] = ifelse(larger, f, largest_fraction[i, j, k])
+        target[i, j, k] = ifelse(larger, convert(eltype(target), code), target[i, j, k])
+        total_fraction[i, j, k] += f
+    end
+end
+
+# Cells outside the product's coverage have no valid pixels, so every fraction is
+# zero and no class holds a majority.
+@kernel function _mask_uncovered_class!(target, total_fraction)
+    i, j, k = @index(Global, NTuple)
+    FT = eltype(target)
+    @inbounds covered = total_fraction[i, j, k] > convert(FT, 1//2)
+    @inbounds target[i, j, k] = ifelse(covered, target[i, j, k], convert(FT, NaN))
+end

--- a/test/test_modis_land.jl
+++ b/test/test_modis_land.jl
@@ -742,6 +742,7 @@ end
         majority = landed(majority_class)
         @test all(majority[1, :] .== igbp_class_names.grassland)
         @test all(majority[2, :] .== igbp_class_names.water)
+        @test landed(Field(metadatum, grid)) == majority
     end
 end
 

--- a/test/test_modis_land.jl
+++ b/test/test_modis_land.jl
@@ -699,6 +699,52 @@ end
     end
 end
 
+@testset "MODIS class fractions on a model grid" begin
+    mktempdir() do dir
+        region = BoundingBox(longitude = (-92.5, -92.4), latitude = (36.5, 36.6))
+        date = DateTime(2015)
+        dataset = MCD12Q1()
+        metadatum = Metadatum(:landcover_class; dataset, region, date, dir)
+        lattice = regional_lattice(metadatum)
+
+        # Longitude stripes, uniform in latitude, splitting each of the two target cells
+        # 7:5 so the fractions are exact column counts: grassland then cropland west of
+        # -92.45, fill (read as no-data, counted as water) then urban east of it.
+        function stripe_class(λ)
+            λ < -92.5 + 7Δᵛ  && return 0x0a  # grassland
+            λ < -92.45       && return 0x0c  # cropland
+            λ < -92.45 + 7Δᵛ && return 0xff  # fill
+            return 0x0d                      # urban
+        end
+
+        class_at = Dict((i, j) => stripe_class(lattice.west + (i - 1/2) * Δᵛ)
+                        for i in 1:lattice.Nx, j in 1:lattice.Ny)
+        write_synthetic_landcover_file(joinpath(dir, metadatum.filename), lattice, dataset;
+                                       class_at)
+
+        grid = LatitudeLongitudeGrid(CPU(); size = (2, 2),
+                                     longitude = (-92.5, -92.4), latitude = (36.5, 36.6),
+                                     topology = (Bounded, Bounded, Flat))
+
+        (; fractions, majority_class) = class_fractions(grid, dataset; date, region, dir)
+        @test keys(fractions) == keys(igbp_class_names)
+
+        landed(field) = Array(interior(field, :, :, 1))
+        @test all(isapprox.(landed(fractions.grassland)[1, :], 7/12, atol = 1e-3))
+        @test all(isapprox.(landed(fractions.cropland)[1, :],  5/12, atol = 1e-3))
+        @test all(isapprox.(landed(fractions.water)[2, :],     7/12, atol = 1e-3))
+        @test all(isapprox.(landed(fractions.urban)[2, :],     5/12, atol = 1e-3))
+        @test all(iszero, landed(fractions.mixed_forest))
+
+        total = sum(landed(fraction) for fraction in fractions)
+        @test all(isapprox.(total, 1, atol = 1e-3))
+
+        majority = landed(majority_class)
+        @test all(majority[1, :] .== igbp_class_names.grassland)
+        @test all(majority[2, :] .== igbp_class_names.water)
+    end
+end
+
 @testset "MODIS class-keyed temporal tolerance" begin
     # A month-long bridge is nearly exact over an evergreen canopy and fabricates a green-up
     # ramp over a crop, so the two cannot share a tolerance.


### PR DESCRIPTION
Regridding the MCD12Q1 class map onto a model grid previously meant hand-rolling one indicator field per class, and `Field(metadatum, grid)` interpolated the codes bilinearly (#650).

- `Field(Metadatum(:landcover_class; …), grid)` and `set!` land the class covering the largest area of each cell, through the `interpolate_physical!` hook WorldCover already uses
- `class_fractions(grid, dataset::MCD12Q1; date, region = BoundingBox(grid), dir)` returns `(; fractions, majority_class)`: one conservatively regridded area-fraction `Field` per legend class (no-data counted as water) and their per-cell argmax, ties to the lower code, `NaN` outside `region`
- the argmax accumulation moves from WorldCover into `DataWrangling.majority_class!`, shared by both datasets
