### PR TITLE
Build the nesting parent on the child architecture, not the partitioned one

### DIFF
--- a/ext/NumericalEarthBreezeExt/breeze_nested_atmosphere.jl
+++ b/ext/NumericalEarthBreezeExt/breeze_nested_atmosphere.jl
@@ -32,7 +32,7 @@ using Oceananigans:
     set!
 
 using Oceananigans.Architectures: architecture
-using Oceananigans.DistributedComputations: all_reduce
+using Oceananigans.DistributedComputations: all_reduce, child_architecture
 using Oceananigans.Coriolis: SphericalCoriolis
 using Oceananigans.Fields: AbstractField, interior, interpolate!
 using Oceananigans.Forcings: Relaxation
@@ -387,8 +387,10 @@ function NumericalEarth.NestedModels.nested_atmosphere_model(child_grid, parent_
     kw...)
 
     parent_region = BoundingBox(child_grid; padding = parent_padding)
+    # The parent must cover each rank's subdomain plus halo, so it is not partitioned with the
+    # child. `child_architecture` is the identity on a serial grid. Live parent: #634.
     parent_atmosphere = PrescribedAtmosphere(parent_region, dates, parent_dataset;
-                                             architecture = architecture(child_grid), dir,
+                                             architecture = child_architecture(child_grid), dir,
                                              time_indices_in_memory = parent_time_indices_in_memory)
 
     if isnothing(surface_pressure)


### PR DESCRIPTION

On a `Distributed` child, `nested_atmosphere_model` builds the parent `PrescribedAtmosphere` with the
child's own `Partition`. Each rank then holds only the parent quadrant matching its subdomain — not
the subdomain **plus halo** that the lateral boundary conditions and the Davies relaxation
interpolate over.

Build the parent on `child_architecture` instead, so every rank holds the whole window. A no-op on
serial. Partitioning buys nothing here: a partitioned parent needs a halo wide enough for the
child's reach, and on a 21-cell reanalysis window over 4 ranks that leaves every rank holding all 21
anyway, plus halo exchange. This touches the dataset constructor only; a nest whose parent is a live
model is built through `nested_atmosphere_model(parent_atmosphere, child_grid; …)`, where the
arithmetic reverses and partitioning is worth it.

<details>
<summary>Reproducer (4 ranks, CPU)</summary>

```julia
using MPI; MPI.Init()
using NumericalEarth, Oceananigans, Breeze, CopernicusClimateDataStore
using Oceananigans.Grids: λnodes
using Dates: DateTime

arch = Distributed(CPU(); partition = Partition(4, 1))

grid = LatitudeLongitudeGrid(arch; longitude = (-100, -96), latitude = (35, 39),
                             z = (0, 10e3), size = (32, 32, 16), halo = (5, 5, 5),
                             topology = (Bounded, Bounded, Bounded))

model = nested_atmosphere_model(grid, ERA5HourlyPressureLevels();
                                dates = (DateTime(2011, 5, 20, 0), DateTime(2011, 5, 20, 1)))

pg = model.parent.grid
@show arch.local_rank, size(pg), extrema(λnodes(pg, Center()))
```

`mpiexec -n 4 julia --project repro.jl`. Needs CDS credentials; the download is a 4x4 degree window
at two hourly steps.

Before — each rank holds a 1 degree slice, and ranks 0, 1 and 3 do not even cover their own
subdomain:

```
rank 0  size = (5, 22, 37)  λ = (-100.5, -99.5)    child λ = (-99.9375, -99.0625)
rank 1  size = (5, 22, 37)  λ = (-99.25,  -98.25)  child λ = (-98.9375, -98.0625)
rank 2  size = (5, 22, 37)  λ = (-98.0,   -97.0)   child λ = (-97.9375, -97.0625)
rank 3  size = (6, 22, 37)  λ = (-96.75,  -95.5)   child λ = (-96.9375, -96.0625)
```

After — every rank holds the full padded window:

```
rank 0..3  size = (21, 22, 37)  λ = (-100.5, -95.5)
```
</details>

Note this is not caught at construction in the case above: `validate_source_bracket` compares
`xnodes`/`ynodes`, which on a `LatitudeLongitudeGrid` are latitude-weighted meters
(`R * deg2rad(λ) * cos(φ)`) rather than longitude, and the parent's wider, unpartitioned latitude
range masks the missing longitude. All four ranks pass the check and the run completes with a
silently truncated parent. That guard weakness is reported separately.

Verified on 4×A100, `Partition(4, 1)`, 300 iterations. Rationale, the call-site-versus-constructor
choice, and the blockers this does *not* remove are in the commit message.

Nesting under a *live* parent across ranks is a different problem — it needs a parent halo
sized from the child rather than an unpartitioned parent — and is tracked in #634.