### PR TITLE
Measure the terrain blend frame in global indices

### DIFF
--- a/src/NestedModels/parent_terrain.jl
+++ b/src/NestedModels/parent_terrain.jl
@@ -9,14 +9,30 @@
 
 using KernelAbstractions: @kernel, @index
 using Oceananigans.Architectures: architecture
+using Oceananigans.DistributedComputations: DistributedGrid, concatenate_local_sizes
 using Oceananigans.Utils: launch!
 
-@kernel function _blend_parent_terrain!(elevation, parent_elevation, width, Nx, Ny)
+@kernel function _blend_parent_terrain!(elevation, parent_elevation, width, i₀, j₀, Nx, Ny)
     i, j = @index(Global, NTuple)
+    I = i + i₀
+    J = j + j₀
     @inbounds begin
-        w = clamp(min(i - 1, Nx - i, j - 1, Ny - j) / width, 0, 1)
+        w = clamp(min(I - 1, Nx - I, J - 1, Ny - J) / width, 0, 1)
         elevation[i, j, 1] = w * elevation[i, j, 1] + (1 - w) * parent_elevation[i, j, 1]
     end
+end
+
+# Offset of this rank's first cell within the global domain, and the global horizontal size. The
+# blend frame follows the *domain* edge, so both must be global: `size(grid)` is rank-local under a
+# `Partition`, and using it would ring every rank's own subdomain instead.
+blend_frame(grid) = (0, 0, size(grid, 1), size(grid, 2))
+
+function blend_frame(grid::DistributedGrid)
+    arch = architecture(grid)
+    nx = concatenate_local_sizes(size(grid), arch, 1)
+    ny = concatenate_local_sizes(size(grid), arch, 2)
+    rx, ry = arch.local_index[1], arch.local_index[2]
+    return sum(nx[1:rx-1]), sum(ny[1:ry-1]), sum(nx), sum(ny)
 end
 
 """
@@ -26,11 +42,14 @@ Blend the child `elevation` (a two-dimensional field) toward `parent_elevation` 
 surface elevation on the same grid) over the outermost `width` cells: the blend weight ramps
 linearly from the parent's elevation at the boundary to the child's `width` cells inward, so the
 terrain at the open boundaries matches the orography the parent state was produced with.
+
+Distance to the boundary is measured in global indices, so under a `Partition` only the ranks
+holding a true domain edge blend, and interior rank seams are left untouched.
 """
 function blend_parent_terrain!(elevation, parent_elevation; width)
     grid = elevation.grid
-    Nx, Ny, _ = size(grid)
+    i₀, j₀, Nx, Ny = blend_frame(grid)
     launch!(architecture(grid), grid, :xy, _blend_parent_terrain!,
-            elevation, parent_elevation, convert(eltype(grid), width), Nx, Ny)
+            elevation, parent_elevation, convert(eltype(grid), width), i₀, j₀, Nx, Ny)
     return elevation
 end

--- a/test/test_distributed_utils.jl
+++ b/test/test_distributed_utils.jl
@@ -106,7 +106,7 @@ end
 end
 
 @testset "Distributed terrain blending" begin
-    Nx, Ny = 150, 90 # 150 over 4 ranks splits 37/37/37/39: a uniform rank offset would be wrong
+    Nx, Ny = 150, 90 # over 4 ranks these split 37/37/37/39 and 22/22/22/24: uneven in both directions
     width = 6
 
     child_terrain(x, y) = 1000 + 2x + 3y
@@ -126,8 +126,9 @@ end
     reference = Array(interior(blended_elevation(CPU()), :, :, 1))
 
     # Rank-local sizes would blend a frame around each rank's own subdomain, banding parent orography
-    # along every interior seam: three bands in x under Partition(4, 1), a cross under Partition(2, 2).
-    for partition in (Partition(4, 1), Partition(2, 2))
+    # along every interior seam: bands in x under Partition(4, 1), in y under Partition(1, 4), and a
+    # cross under Partition(2, 2), which is the only case with an even split in both directions.
+    for partition in (Partition(4, 1), Partition(1, 4), Partition(2, 2))
         blended = blended_elevation(Distributed(CPU(); partition))
         @test Array(interior(blended, :, :, 1)) == reference
     end

--- a/test/test_distributed_utils.jl
+++ b/test/test_distributed_utils.jl
@@ -7,8 +7,9 @@ using CFTime
 using Dates
 using NCDatasets
 using NumericalEarth.DataWrangling: metadata_path
+using NumericalEarth.NestedModels: blend_parent_terrain!
 using Oceananigans.DistributedComputations
-using Oceananigans.DistributedComputations: reconstruct_global_grid
+using Oceananigans.DistributedComputations: reconstruct_global_grid, reconstruct_global_field
 
 # We start by building a fake bathymetry on rank 0 and save it to file
 rm("./trivial_bathymetry.nc", force=true)
@@ -101,6 +102,34 @@ end
         begin
             @test interior(global_height, irange, jrange, 1) == interior(local_height, :, :, 1)
         end
+    end
+end
+
+@testset "Distributed terrain blending" begin
+    Nx, Ny = 150, 90 # 150 over 4 ranks splits 37/37/37/39: a uniform rank offset would be wrong
+    width = 6
+
+    child_terrain(x, y) = 1000 + 2x + 3y
+    parent_terrain(x, y) = 500 - x + y / 2
+
+    function blended_elevation(arch)
+        grid = RectilinearGrid(arch; size = (Nx, Ny, 1), x = (0, Nx), y = (0, Ny), z = (0, 1),
+                               topology = (Bounded, Bounded, Bounded))
+        elevation = Field{Center, Center, Nothing}(grid)
+        parent_surface = Field{Center, Center, Nothing}(grid)
+        set!(elevation, child_terrain)
+        set!(parent_surface, parent_terrain)
+        blend_parent_terrain!(elevation, parent_surface; width)
+        return reconstruct_global_field(elevation)
+    end
+
+    reference = Array(interior(blended_elevation(CPU()), :, :, 1))
+
+    # Rank-local sizes would blend a frame around each rank's own subdomain, banding parent orography
+    # along every interior seam: three bands in x under Partition(4, 1), a cross under Partition(2, 2).
+    for partition in (Partition(4, 1), Partition(2, 2))
+        blended = blended_elevation(Distributed(CPU(); partition))
+        @test Array(interior(blended, :, :, 1)) == reference
     end
 end
 

--- a/test/test_nested_simulation.jl
+++ b/test/test_nested_simulation.jl
@@ -1,7 +1,8 @@
 include("runtests_setup.jl")
 
 using NumericalEarth
-using NumericalEarth.NestedModels: parent_boundary_conditions, nested_atmosphere_model
+using NumericalEarth.NestedModels: parent_boundary_conditions, nested_atmosphere_model,
+                                   blend_parent_terrain!, blend_frame
 using Oceananigans
 using Oceananigans: prognostic_fields
 using Oceananigans.OutputReaders: interpolating_time_indices, memory_index
@@ -696,4 +697,39 @@ end
     Δxf = minimum_xspacing(fine,   Center(), Center(), Center())
     @test isapprox(wc * Δxc, 60_000; rtol = 0.2)
     @test isapprox(wf * Δxf, 60_000; rtol = 0.2)
+end
+
+# The blend frame follows the *domain* edge. Serial half of the regression; the distributed half —
+# that a `Partition` does not ring each rank's own subdomain — is in `test_distributed_utils.jl`.
+@testset "blend_parent_terrain!: the blend frame is the domain frame" begin
+    grid = RectilinearGrid(size = (24, 18, 1), x = (0, 24), y = (0, 18), z = (0, 1),
+                           topology = (Bounded, Bounded, Bounded))
+    Nx, Ny = size(grid, 1), size(grid, 2)
+    width = 3
+
+    elevation = Field{Center, Center, Nothing}(grid)
+    parent_surface = Field{Center, Center, Nothing}(grid)
+    set!(elevation, (x, y) -> 1000 + 2x + 3y)
+    set!(parent_surface, (x, y) -> 500 - x + y / 2)
+    child_terrain = Array(interior(elevation, :, :, 1))
+    parent_terrain = Array(interior(parent_surface, :, :, 1))
+
+    # serial fallback: no rank offset, and the global size is the local size
+    @test blend_frame(grid) == (0, 0, Nx, Ny)
+
+    blend_parent_terrain!(elevation, parent_surface; width)
+    blended = Array(interior(elevation, :, :, 1))
+
+    # the weight ramps with the global-index distance to the nearest domain edge
+    w = [clamp(min(i - 1, Nx - i, j - 1, Ny - j) / width, 0, 1) for i in 1:Nx, j in 1:Ny]
+    @test blended == w .* child_terrain .+ (1 .- w) .* parent_terrain
+
+    # the domain edge is pure parent orography
+    @test blended[1, :] == parent_terrain[1, :]
+    @test blended[Nx, :] == parent_terrain[Nx, :]
+    @test blended[:, 1] == parent_terrain[:, 1]
+    @test blended[:, Ny] == parent_terrain[:, Ny]
+
+    # everything `width` cells or more from every edge is untouched
+    @test blended[width+1:Nx-width, width+1:Ny-width] == child_terrain[width+1:Nx-width, width+1:Ny-width]
 end


### PR DESCRIPTION
Closes #637.

`blend_frame` returns the rank's offset within the global domain and the global horizontal size:
`(0, 0, size(grid, 1), size(grid, 2))` for a serial grid, and for a `DistributedGrid` the
`concatenate_local_sizes` cumulative sum, mirroring the offset idiom in
`src/DistributedComputations/partition_assemble.jl` upstream. The kernel adds that offset before
measuring the distance to the edge. Dispatch rather than a branch, and the serial arithmetic is
unchanged.

Verified on a 150×90 grid with `width = 6`: the fixed serial result is identical to the previous
kernel on all 13500 cells, and `Partition(4, 1)` and `Partition(2, 2)` each reproduce the serial
result exactly. `Nx = 150` splits unevenly as 37/37/37/39, so this also covers the case a uniform
offset would get wrong on the last rank.

Two notes for reviewers:

- `concatenate_local_sizes` is a collective, so `blend_parent_terrain!` is now collective too and
  must not be called from inside a rank-conditional block. Its one caller,
  `materialize_nested_terrain!`, is on an unconditional path.
- **The distributed regression added here does not run in CI.** The distributed job in
  `.github/workflows/ci.yml` is commented out and `test/runtests.jl` drops
  `test_distributed_utils` from the auto-discovered suite, so it runs only under `mpiexecjl -n 4`
  by hand. It fails 2/2 on every rank against the unfixed kernel. Re-enabling that job is a separate
  change, but without it this class of bug has no guard.

Tests added: in `test/test_nested_simulation.jl`, that the serial `blend_frame` is `(0, 0, Nx, Ny)`,
that the result matches a host-side ramp built from global-index distances, that the four domain
edges are pure parent orography, and that the interior is untouched. In
`test/test_distributed_utils.jl`, that `Partition(4, 1)` and `Partition(2, 2)` gathered with
`reconstruct_global_field` equal the serial result, mirroring that file's existing MPI harness.

Suite results: `test_nested_simulation.jl` 288 pass (281 before), `test_breeze_coupling.jl` 42 pass
plus 2 pre-existing `@test_broken`. Two testsets in `test_distributed_utils.jl` were already failing
on `main` and are unrelated — `"Distributed ECCO download"` (missing Earthdata credentials) and
`"Distributed Bathymetry interpolation"` (`MethodError: joinpath(::String, ::Nothing)`, reported
separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
