### PR TITLE
Limit infiltration to the remaining pore volume in VariablySaturatedHydrology

### DIFF
--- a/src/Lands/hydrology/runoff_models.jl
+++ b/src/Lands/hydrology/runoff_models.jl
@@ -6,7 +6,8 @@
 ##### * `Rˢᶠᶜ`: surface runoff — rejected liquid input. Returned together with
 #####   the actual surface liquid flux `Jˡˢ` because they are coupled (the
 #####   infiltration-capacity model splits incoming precipitation between the
-#####   two).
+#####   two). The hydrology adds saturation excess (input the remaining pore
+#####   volume cannot hold) to `Rˢᶠᶜ` outside the closure.
 ##### * `Rˡᵃᵗ`: lateral / subsurface runoff — true storage export. Carries
 #####   internal energy with it.
 #####
@@ -24,7 +25,8 @@
 """
     NoRunoff()
 
-No runoff. All precipitation infiltrates (`Jˡˢ = −Pˡ`), no subsurface export.
+No runoff from the closure. All precipitation infiltrates (`Jˡˢ = −Pˡ`) up to
+the pore volume the column has left; no subsurface export.
 """
 struct NoRunoff end
 

--- a/src/Lands/hydrology/variably_saturated_hydrology.jl
+++ b/src/Lands/hydrology/variably_saturated_hydrology.jl
@@ -10,7 +10,9 @@
 ##### where every term is positive-upward (`Jˡˢ = −Pˡ + Rˢᶠᶜ`). The
 ##### conservative storage variable is the *augmented* liquid fraction
 ##### `ϑˡ = θˡ + max(Π,0)/hˢˢ`, so `Mˡᵃ > Mˡᵃ⁺` is admitted and corresponds to
-##### saturated positive-pressure storage (`Π > 0`).
+##### saturated positive-pressure storage (`Π > 0`), reachable only through an
+##### upward deep liquid flux or dew since infiltration is limited to the
+##### remaining pore volume.
 #####
 ##### Diagnostics published every step:
 #####   * `deep_liquid_flux`        (Jˡᵇ, positive upward)
@@ -154,13 +156,19 @@ end
     return clamp((θˡ - θʳ) / Δ, zero(FT), one(FT))
 end
 
-@inline function diagnostic_pressure_head(h, M, θˡ, 𝒮, i, j)
+@inline function saturated_water_storage(h, M, i, j)
     FT  = typeof(M)
     ν   = convert(FT, property_value(h.porosity, i, j))
+    hˡᵃ = convert(FT, property_value(h.slab_depth, i, j))
+    return convert(FT, h.liquid_density) * ν * hˡᵃ
+end
+
+@inline function diagnostic_pressure_head(h, M, θˡ, 𝒮, i, j)
+    FT  = typeof(M)
     ρˡ  = convert(FT, h.liquid_density)
     hˡᵃ = convert(FT, property_value(h.slab_depth, i, j))
     hˢˢ = convert(FT, property_value(h.storage_height, i, j))
-    Mˡᵃ⁺ = ρˡ * ν * hˡᵃ
+    Mˡᵃ⁺ = saturated_water_storage(h, M, i, j)
     # Unsaturated branch: Π = Π_m(𝒮). Saturated branch: Π = (M − M⁺) hˢˢ/(ρˡ hˡᵃ).
     return ifelse(M < Mˡᵃ⁺,
                   pressure_head(h.retention_curve, 𝒮),
@@ -214,6 +222,13 @@ saturation(h::VariablySaturatedHydrology, land) = land.saturation
     Jˡs, Rsfc = surface_liquid_flux_and_runoff(h.runoff, Plij, Mij, θˡ, 𝒮, Π, K, i, j)
     Jˡb       = deep_liquid_flux(h.deep_liquid_flux, Mij, θˡ, 𝒮, Π, K, Πᵈ, time)
     Rlat      = subsurface_runoff(h.runoff, Mij, Π, K)
+
+    # Infiltration cannot exceed the pore volume the column has left; the surplus
+    # is saturation-excess runoff.
+    pore_limited_flux = -max(saturated_water_storage(h, Mij, i, j) - Mij, 0) / Δt
+    saturation_excess = max(pore_limited_flux - Jˡs, 0)
+    Jˡs  += saturation_excess
+    Rsfc += saturation_excess
 
     dMdt = Jˡb - Jˡs - Jvij - Rlat
 

--- a/test/test_variably_saturated_hydrology.jl
+++ b/test/test_variably_saturated_hydrology.jl
@@ -136,5 +136,28 @@ end
         time_step!(land_drain, 100.0)
         # Expect M to decrease by 100 * 1e-3 = 0.1
         @test only(Array(interior(land_drain.water_storage))) ≈ 399.9 atol = 1e-3
+
+        # Rain on a column at pore capacity runs off: M stays at M⁺ less one step
+        # of drainage, and the runoff is the rain minus the drainage ρˡ K₀ = 1e-3.
+        hydrology_saturating = VariablySaturatedHydrology(eltype(grid);
+            slab_depth = 1.0,
+            porosity = 0.4,
+            storage_height = 1000,
+            retention_curve = VanGenuchtenRetention(α = 1.0, n = 2.0),
+            hydraulic_conductivity = VanGenuchtenConductivity(K_saturated = 1e-6, n = 2.0),
+            deep_liquid_flux = FreeDrainageFlux(),
+            runoff = InfiltrationCapacityRunoff(infiltration_capacity = 7.0),
+        )
+        land_saturating = SlabLand(grid; hydrology = hydrology_saturating)
+        set!(land_saturating; M = 399.0)
+        fill!(land_saturating.fluxes.vapor_flux, 0)
+        fill!(land_saturating.fluxes.liquid_precipitation_flux, 5.0)  # below capacity 7
+        for _ in 1:20
+            time_step!(land_saturating, 1.0)
+        end
+        M = only(Array(interior(land_saturating.water_storage)))
+        @test M ≤ 400.0
+        @test M ≈ 400.0 - 1e-3 atol = 1e-2
+        @test only(Array(interior(land_saturating.diagnostics.surface_runoff))) ≈ 5.0 - 1e-3 atol = 1e-2
     end
 end


### PR DESCRIPTION
`VariablySaturatedHydrology` now rejects surface liquid input the column has no pore volume left for and books it as surface runoff, so rain cannot push `M` past `ρˡ ν hˡᵃ` with any runoff closure or bottom boundary. Closes #625.

- The limit sits in the time-step kernel after the closure's rate cap, so `NoRunoff` and `InfiltrationCapacityRunoff` are unchanged and both get it.
- The space offered to rain is `M⁺ − M` at the start of the step. What drainage and evaporation free up during the step is offered on the next one, and an upward deep liquid flux or dew can still carry `M` above `M⁺`.

```julia
hydrology = VariablySaturatedHydrology(slab_depth = 1.0, porosity = 0.4, storage_height = 1000,
                                       retention_curve = VanGenuchtenRetention(α = 1.0, n = 2.0),
                                       hydraulic_conductivity = VanGenuchtenConductivity(K_saturated = 1e-6, n = 2.0),
                                       deep_liquid_flux = FreeDrainageFlux(),
                                       runoff = InfiltrationCapacityRunoff(infiltration_capacity = 7.0))
# Pˡ = 5 kg m⁻² s⁻¹ on a column at M = 399: M now holds at 400 − ρˡ K₀ Δt and
# surface_runoff → Pˡ − ρˡ K₀. Before, M grew by ~5 kg m⁻² per second without bound.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
