### PR TITLE
Interpolate atmosphere→Breeze surface momentum stress onto velocity faces (#472)

### DIFF
--- a/ext/NumericalEarthBreezeExt/breeze_atmosphere_interface.jl
+++ b/ext/NumericalEarthBreezeExt/breeze_atmosphere_interface.jl
@@ -1,4 +1,5 @@
 using Oceananigans.Grids: Center
+using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ
 using Oceananigans.Fields: compute!
 using Breeze.AtmosphereModels: thermodynamic_density, dynamics_pressure,
                                specific_humidity, surface_precipitation_flux
@@ -178,16 +179,16 @@ NumericalEarth.EarthSystemModels.InterfaceComputations.net_fluxes(atmos::BreezeA
 ##### Assemble ESM similarity-theory fluxes into Breeze bottom BCs
 #####
 
-@kernel function _assemble_net_atmosphere_fluxes!(net, ao_fluxes)
+@kernel function _assemble_net_atmosphere_fluxes!(net, ao_fluxes, grid)
     i, j = @index(Global, NTuple)
     @inbounds begin
-        τx = ao_fluxes.x_momentum[i, j, 1]
-        τy = ao_fluxes.y_momentum[i, j, 1]
         Qc = ao_fluxes.sensible_heat[i, j, 1]
         Fv = ao_fluxes.water_vapor[i, j, 1]
 
-        net.ρu[i, j, 1]  = τx
-        net.ρv[i, j, 1]  = τy
+        # ρu/ρv are face-located, so interpolate the (Center, Center) surface stress
+        # onto their velocity faces. Heat and moisture stay at centers.
+        net.ρu[i, j, 1]  = ℑxᶠᵃᵃ(i, j, 1, grid, ao_fluxes.x_momentum)
+        net.ρv[i, j, 1]  = ℑyᵃᶠᵃ(i, j, 1, grid, ao_fluxes.y_momentum)
         net.ρe[i, j, 1]  = Qc   # sensible heat only; latent heat handled by moisture flux
         net.ρqᵛᵉ[i, j, 1] = Fv
     end
@@ -209,7 +210,7 @@ function NumericalEarth.EarthSystemModels.update_net_fluxes!(coupled_model, atmo
     if !isnothing(ao_interface)
         ao_fluxes = computed_fluxes(ao_interface)
         if !isnothing(ao_fluxes)
-            launch!(arch, grid, params, _assemble_net_atmosphere_fluxes!, net, ao_fluxes)
+            launch!(arch, grid, params, _assemble_net_atmosphere_fluxes!, net, ao_fluxes, grid)
         end
     end
 
@@ -222,7 +223,7 @@ function NumericalEarth.EarthSystemModels.update_net_fluxes!(coupled_model, atmo
     if !isnothing(al_interface)
         al_fluxes = computed_fluxes(al_interface)
         if !isnothing(al_fluxes)
-            launch!(arch, grid, params, _assemble_net_atmosphere_fluxes!, net, al_fluxes)
+            launch!(arch, grid, params, _assemble_net_atmosphere_fluxes!, net, al_fluxes, grid)
         end
     end
 

--- a/ext/NumericalEarthBreezeExt/breeze_atmosphere_interface.jl
+++ b/ext/NumericalEarthBreezeExt/breeze_atmosphere_interface.jl
@@ -185,8 +185,7 @@ NumericalEarth.EarthSystemModels.InterfaceComputations.net_fluxes(atmos::BreezeA
         Qc = ao_fluxes.sensible_heat[i, j, 1]
         Fv = ao_fluxes.water_vapor[i, j, 1]
 
-        # ρu/ρv are face-located, so interpolate the (Center, Center) surface stress
-        # onto their velocity faces. Heat and moisture stay at centers.
+        # interpolate stresses on variable's location
         net.ρu[i, j, 1]  = ℑxᶠᵃᵃ(i, j, 1, grid, ao_fluxes.x_momentum)
         net.ρv[i, j, 1]  = ℑyᵃᶠᵃ(i, j, 1, grid, ao_fluxes.y_momentum)
         net.ρe[i, j, 1]  = Qc   # sensible heat only; latent heat handled by moisture flux

--- a/test/test_breeze_coupling.jl
+++ b/test/test_breeze_coupling.jl
@@ -175,9 +175,12 @@ end
             @test model.interfaces.net_fluxes.atmosphere.ρv === ρv_bc
 
             # After update_state!, those BC fields receive the computed MOST land surface
-            # stress (the atmosphere-feels-drag link), and the stress is nonzero.
-            @test Array(interior(ρu_bc)) ≈ Array(interior(al.fluxes.x_momentum))
-            @test Array(interior(ρv_bc)) ≈ Array(interior(al.fluxes.y_momentum))
+            # stress (the atmosphere-feels-drag link), interpolated onto the face-located
+            # ρu/ρv, so each interior face equals the mean of its two adjacent centers.
+            τx = Array(interior(al.fluxes.x_momentum))
+            τy = Array(interior(al.fluxes.y_momentum))
+            @test Array(interior(ρu_bc))[2:end, :, :] ≈ (τx[1:end-1, :, :] .+ τx[2:end, :, :]) ./ 2
+            @test Array(interior(ρv_bc))[:, 2:end, :] ≈ (τy[:, 1:end-1, :] .+ τy[:, 2:end, :]) ./ 2
             @test maximum(abs, interior(ρu_bc)) > 0
         end
 
@@ -286,9 +289,12 @@ end
             @test model.interfaces.net_fluxes.atmosphere.ρu === ρu_bc
             @test model.interfaces.net_fluxes.atmosphere.ρv === ρv_bc
 
-            # MOST land surface stress reaches the nested child's bottom BC.
-            @test Array(interior(ρu_bc)) ≈ Array(interior(al.fluxes.x_momentum))
-            @test Array(interior(ρv_bc)) ≈ Array(interior(al.fluxes.y_momentum))
+            # MOST land surface stress reaches the nested child's bottom BC, interpolated
+            # onto the face-located ρu/ρv (each interior face = mean of adjacent centers).
+            τx = Array(interior(al.fluxes.x_momentum))
+            τy = Array(interior(al.fluxes.y_momentum))
+            @test Array(interior(ρu_bc))[2:end, :, :] ≈ (τx[1:end-1, :, :] .+ τx[2:end, :, :]) ./ 2
+            @test Array(interior(ρv_bc))[:, 2:end, :] ≈ (τy[:, 1:end-1, :] .+ τy[:, 2:end, :]) ./ 2
             @test maximum(abs, interior(ρu_bc)) > 0
         end
 


### PR DESCRIPTION
Closes #472.

## Problem
When the atmosphere is a Breeze `AtmosphereModel`, the coupler installs its computed MOST surface momentum stress as the **bottom `FluxBoundaryCondition`** of Breeze's prognostic `ρu`/`ρv` (`breeze_atmosphere_simulation.jl` wires the `ρτˣ`/`ρτʸ` flux `Field`s there, replacing Breeze's own surface BCs — the coupling does **not** use Breeze's `BulkDrag`). Those flux `Field`s are stored at cell **centers** (`Field{Center, Center, Nothing}`), but `ρu`/`ρv` are **face-located** (`ρu` at `(Face, Center, Center)`, `ρv` at `(Center, Face, Center)`). A bottom flux BC on a face-located field is consumed by the tendency at the **velocity face**, so the value at `[i, j, 1]` is taken as the stress at that face — and writing the center-computed stress raw applies it a **half-cell off** in the staggered direction (an O(½Δx) error in the *position* of the applied stress). It affects both Breeze surface couplings (atmosphere–ocean and atmosphere–land); heat/moisture are unaffected (genuine center quantities) and a `PrescribedAtmosphere` is immune (no momentum back-reaction).

## Fix
`_assemble_net_atmosphere_fluxes!` now interpolates the momentum components onto their velocity faces with `ℑxᶠᵃᵃ`/`ℑyᵃᶠᵃ` (with `grid` threaded into the kernel); heat `ρe` and moisture `ρqᵛᵉ` stay at centers. This mirrors the sea-ice→ocean assembly (`src/SeaIces/assemble_net_sea_ice_fluxes.jl`), which already interpolates center→face before applying the stress.

```julia
net.ρu[i, j, 1] = ℑxᶠᵃᵃ(i, j, 1, grid, ao_fluxes.x_momentum)
net.ρv[i, j, 1] = ℑyᵃᶠᵃ(i, j, 1, grid, ao_fluxes.y_momentum)
```

## Tests
The `test_breeze_coupling.jl` momentum checks (direct `AtmosphereLandModel` and nested-child paths) previously asserted the applied `ρu`/`ρv` equalled the **raw center** stress; they now assert each interior face equals the mean of its two adjacent centers. Both blocks pass locally (land 7/7, nested 15/15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
