### PR TITLE
Add synthetic datasets so dataset code paths are tested offline

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ args = parse_args(ARGS)
 # download_utils and runtests_setup are not tests!
 delete!(testsuite, "runtests_setup")
 delete!(testsuite, "download_utils")
+delete!(testsuite, "synthetic_datasets")
 delete!(testsuite, "test_distributed_utils")
 
 gpu_test = parse(Bool, get(ENV, "GPU_TEST", "false"))

--- a/test/runtests_setup.jl
+++ b/test/runtests_setup.jl
@@ -185,7 +185,7 @@ function test_dataset_restoring(arch, dataset, dates, inpainting;
         field = NamedTuple{fldnames}(ntuple(i->CenterField(grid), length(fldnames)))
 
         # A window-averaged product has no node at its first date: the first sits half a window later.
-        clock = Clock(; time = first(var_restoring.field_time_series.times))
+        clock = Clock(; time = first(on_architecture(CPU(), var_restoring.field_time_series.times)))
 
         @allowscalar begin
             @test var_restoring(1, 1,   10, grid, clock, field) ≈ var_restoring.rate

--- a/test/runtests_setup.jl
+++ b/test/runtests_setup.jl
@@ -185,7 +185,7 @@ function test_dataset_restoring(arch, dataset, dates, inpainting;
         field = NamedTuple{fldnames}(ntuple(i->CenterField(grid), length(fldnames)))
 
         # A window-averaged product has no node at its first date: the first sits half a window later.
-        clock = Clock(; time = first(on_architecture(CPU(), var_restoring.field_time_series.times)))
+        clock = Clock(; time = @allowscalar first(var_restoring.field_time_series.times))
 
         @allowscalar begin
             @test var_restoring(1, 1,   10, grid, clock, field) ≈ var_restoring.rate

--- a/test/runtests_setup.jl
+++ b/test/runtests_setup.jl
@@ -188,12 +188,12 @@ function test_dataset_restoring(arch, dataset, dates, inpainting;
         clock = Clock(; time = first(var_restoring.field_time_series.times))
 
         @allowscalar begin
-            @test var_restoring(1, 1,   10, grid, clock, field) == var_restoring.rate
-            @test var_restoring(1, 11,  10, grid, clock, field) == var_restoring.rate / 2
+            @test var_restoring(1, 1,   10, grid, clock, field) ≈ var_restoring.rate
+            @test var_restoring(1, 11,  10, grid, clock, field) ≈ var_restoring.rate / 2
             @test var_restoring(1, 21,  10, grid, clock, field) == 0
             @test var_restoring(1, 80,  10, grid, clock, field) == 0
-            @test var_restoring(1, 90,  10, grid, clock, field) == var_restoring.rate / 2
-            @test var_restoring(1, 100, 10, grid, clock, field) == var_restoring.rate
+            @test var_restoring(1, 90,  10, grid, clock, field) ≈ var_restoring.rate / 2
+            @test var_restoring(1, 100, 10, grid, clock, field) ≈ var_restoring.rate
             @test var_restoring(1, 1,   5,  grid, clock, field) == 0
             @test var_restoring(1, 10,  5,  grid, clock, field) == 0
         end
@@ -320,3 +320,5 @@ function test_inpainting_algorithm(arch, dataset, start_date, inpainting;
     end
     return nothing
 end
+
+include("synthetic_datasets.jl")

--- a/test/synthetic_datasets.jl
+++ b/test/synthetic_datasets.jl
@@ -66,8 +66,10 @@ function synthetic_value(::SyntheticAtmosphere, name, λ, φ, z)
         300 * cosd(φ)
     elseif name == :downwelling_longwave_radiation
         250
-    else # freshwater fluxes
+    elseif name in (:rain_freshwater_flux, :snow_freshwater_flux, :river_freshwater_flux, :iceberg_freshwater_flux)
         1e-5
+    else
+        error("SyntheticAtmosphere has no variable $name")
     end
 end
 

--- a/test/synthetic_datasets.jl
+++ b/test/synthetic_datasets.jl
@@ -1,0 +1,142 @@
+# Analytic stand-ins for the remote datasets. Their `download` writes a small NetCDF file, so
+# `Field`, `FieldTimeSeries`, `DatasetRestoring` and `regrid_bathymetry` run their dataset code
+# paths without network access, and tests can assert exact values.
+
+using Dates
+using Downloads: Downloads
+using NCDatasets: NCDataset, defDim, defVar
+using NumericalEarth.Atmospheres: PrescribedPrecipitationFlux
+using NumericalEarth.DataWrangling: DataWrangling, AbstractStaticBathymetry, native_grid
+using Oceananigans.Grids: λnodes, φnodes, znodes
+
+const synthetic_data_directory = mktempdir()
+
+struct SyntheticBathymetry <: AbstractStaticBathymetry end
+
+abstract type SyntheticDataset end
+struct SyntheticOcean <: SyntheticDataset end      # 3-D `:temperature` and `:salinity`
+struct SyntheticAtmosphere <: SyntheticDataset end # 2-D fields named as in JRA55
+
+const Synthetic = Union{SyntheticBathymetry, SyntheticDataset}
+
+DataWrangling.default_download_directory(::Synthetic) = synthetic_data_directory
+DataWrangling.longitude_interfaces(::Synthetic) = (-180, 180)
+DataWrangling.latitude_interfaces(::Synthetic) = (-90, 90)
+DataWrangling.dataset_variable_name(metadata::Metadata{<:Synthetic}) = string(metadata.name)
+
+Base.size(::SyntheticBathymetry) = (36, 18, 1)
+DataWrangling.metadata_filename(::SyntheticBathymetry, name, date, region) = "synthetic_bathymetry.nc"
+
+Base.size(::SyntheticOcean, name) = (36, 18, 4)
+Base.size(::SyntheticAtmosphere, name) = (36, 18, 1)
+DataWrangling.z_interfaces(::SyntheticOcean) = (-5000, 0)
+DataWrangling.reversed_vertical_axis(::SyntheticOcean) = false
+DataWrangling.is_three_dimensional(::Metadata{<:SyntheticAtmosphere}) = false
+DataWrangling.all_dates(::SyntheticDataset, name) = DateTime(2000, 1, 1):Month(1):DateTime(2000, 12, 1)
+
+DataWrangling.metadata_filename(::SyntheticDataset, name, date, region) =
+    string("synthetic_", name, "_", year(date), "_", lpad(month(date), 2, '0'), ".nc")
+
+DataWrangling.inpainted_metadata_path(metadata::Metadatum{<:SyntheticDataset}) =
+    joinpath(metadata.dir, replace(metadata.filename, ".nc" => "_inpainted.jld2"))
+
+# One continent in an otherwise global ocean
+synthetic_land(λ, φ) = -60 ≤ λ ≤ 20 && -30 ≤ φ ≤ 40
+
+synthetic_value(::SyntheticBathymetry, name, λ, φ, z) = synthetic_land(λ, φ) ? 500 : -4000
+
+function synthetic_value(::SyntheticOcean, name, λ, φ, z)
+    synthetic_land(λ, φ) && return NaN
+    stratification = cosd(φ)^2 * (1 + z / 5000)
+    return name == :temperature ? 2 + 20 * stratification : 34 + stratification
+end
+
+function synthetic_value(::SyntheticAtmosphere, name, λ, φ, z)
+    if name == :temperature
+        273 + 15 * cosd(φ)
+    elseif name == :sea_level_pressure
+        101325
+    elseif name == :specific_humidity
+        0.01
+    elseif name == :eastward_velocity
+        5
+    elseif name == :northward_velocity
+        1
+    elseif name == :downwelling_shortwave_radiation
+        300 * cosd(φ)
+    elseif name == :downwelling_longwave_radiation
+        250
+    else # freshwater fluxes
+        1e-5
+    end
+end
+
+function write_synthetic_netcdf(path, metadatum)
+    # The file is global whatever the region of `metadatum`: one file serves every region.
+    grid = native_grid(Metadata(metadatum.name, metadatum.dataset, metadatum.dates, nothing, metadatum.dir))
+    λ = λnodes(grid, Center())
+    φ = φnodes(grid, Center())
+    three_dimensional = metadatum.dataset isa SyntheticOcean
+    z = three_dimensional ? znodes(grid, Center()) : [0]
+    data = [Float32(synthetic_value(metadatum.dataset, metadatum.name, λ[i], φ[j], z[k]))
+            for i in eachindex(λ), j in eachindex(φ), k in eachindex(z)]
+
+    NCDataset(path, "c") do ds
+        defDim(ds, "longitude", length(λ))
+        defDim(ds, "latitude", length(φ))
+        defVar(ds, "longitude", Float64, ("longitude",))[:] = λ
+        defVar(ds, "latitude", Float64, ("latitude",))[:] = φ
+        if three_dimensional
+            defDim(ds, "z", length(z))
+            defVar(ds, "z", Float64, ("z",))[:] = z
+            defVar(ds, string(metadatum.name), Float32, ("longitude", "latitude", "z"))[:, :, :] = data
+        else
+            defVar(ds, string(metadatum.name), Float32, ("longitude", "latitude"))[:, :] = data[:, :, 1]
+        end
+    end
+
+    return path
+end
+
+# Each process writes into its own directory.
+function Downloads.download(metadata::Metadata{<:Synthetic})
+    for metadatum in metadata
+        path = metadata_path(metadatum)
+        isfile(path) || write_synthetic_netcdf(path, metadatum)
+    end
+    return metadata_path(metadata)
+end
+
+synthetic_field_time_series(name, arch; dates = all_dates(SyntheticAtmosphere(), name), time_indices_in_memory = 2) =
+    FieldTimeSeries(Metadata(name; dataset = SyntheticAtmosphere(), dates), arch;
+                    time_indices_in_memory, inpainting = nothing)
+
+function synthetic_prescribed_atmosphere(arch = CPU(); kw...)
+    u  = synthetic_field_time_series(:eastward_velocity, arch; kw...)
+    v  = synthetic_field_time_series(:northward_velocity, arch; kw...)
+    T  = synthetic_field_time_series(:temperature, arch; kw...)
+    qᵛ = synthetic_field_time_series(:specific_humidity, arch; kw...)
+    p  = synthetic_field_time_series(:sea_level_pressure, arch; kw...)
+    rain = synthetic_field_time_series(:rain_freshwater_flux, arch; kw...)
+    snow = synthetic_field_time_series(:snow_freshwater_flux, arch; kw...)
+    precipitation_flux = PrescribedPrecipitationFlux(; rain, snow)
+
+    return PrescribedAtmosphere(u.grid, u.times;
+                                source = SyntheticAtmosphere(),
+                                velocities = (; u, v),
+                                temperature = T,
+                                specific_humidity = qᵛ,
+                                pressure = p,
+                                precipitation_flux)
+end
+
+synthetic_prescribed_radiation(arch = CPU(); kw...) =
+    PrescribedRadiation(synthetic_field_time_series(:downwelling_shortwave_radiation, arch; kw...),
+                        synthetic_field_time_series(:downwelling_longwave_radiation, arch; kw...))
+
+synthetic_prescribed_land(arch = CPU(); kw...) =
+    PrescribedLand((; rivers = synthetic_field_time_series(:river_freshwater_flux, arch; kw...),
+                      icebergs = synthetic_field_time_series(:iceberg_freshwater_flux, arch; kw...)))
+
+synthetic_bottom_height(grid; kw...) =
+    regrid_bathymetry(grid, Metadatum(:bottom_height; dataset = SyntheticBathymetry()); cache = false, kw...)

--- a/test/test_checkpointer.jl
+++ b/test/test_checkpointer.jl
@@ -15,9 +15,9 @@ function make_coupled_model(grid)
     set!(sea_ice.model, h=hi, ℵ=hi)
 
     arch = architecture(grid)
-    atmosphere = JRA55PrescribedAtmosphere(arch)
-    land = JRA55PrescribedLand(arch)
-    radiation = JRA55PrescribedRadiation(arch)
+    atmosphere = synthetic_prescribed_atmosphere(arch)
+    land = synthetic_prescribed_land(arch)
+    radiation = synthetic_prescribed_radiation(arch)
 
     return OceanSeaIceModel(ocean, sea_ice; atmosphere, land, radiation)
 end

--- a/test/test_distributed_utils.jl
+++ b/test/test_distributed_utils.jl
@@ -5,56 +5,9 @@ MPI.Init()
 
 using CFTime
 using Dates
-using NCDatasets
 using NumericalEarth.DataWrangling: metadata_path
 using Oceananigans.DistributedComputations
 using Oceananigans.DistributedComputations: reconstruct_global_grid
-
-# We start by building a fake bathymetry on rank 0 and save it to file
-rm("./trivial_bathymetry.nc", force=true)
-
-res = 0.5 # degrees
-λ = -180+res/2:res:180-res/2
-φ = 0:res:50
-
-Nλ = length(λ)
-Nφ = length(φ)
-
-@root begin
-    ds = NCDataset("./trivial_bathymetry.nc", "c")
-
-    # Define the dimension "lon" and "lat" with the size Nλ and Nφ respectively
-    defDim(ds, "lon", Nλ)
-    defDim(ds, "lat", Nφ)
-    defVar(ds, "lat", Float32, ("lat", ))
-    defVar(ds, "lon", Float32, ("lon", ))
-
-    # Define the variables z
-    z = defVar(ds, "z", Float32, ("lon", "lat"))
-
-    # Generate some example data
-    data = [Float32(-i) for i = 1:Nλ, j = 1:Nφ]
-
-    # write a the complete data set
-    ds["lon"][:] = λ
-    ds["lat"][:] = φ
-    z[:, :] = data
-
-    close(ds)
-end
-
-struct TrivalBathymetry end
-
-using Downloads: Downloads, download
-import NumericalEarth.DataWrangling: z_interfaces, longitude_interfaces, latitude_interfaces, metadata_filename
-
-Downloads.download(::Metadatum{<:TrivalBathymetry}) = nothing
-Base.size(::TrivalBathymetry) = (Nλ, Nφ, 1)
-Base.size(::TrivalBathymetry, variable) = (Nλ, Nφ, 1)
-z_interfaces(::TrivalBathymetry) = (0, 1)
-longitude_interfaces(::TrivalBathymetry) = (-180, 180)
-latitude_interfaces(::TrivalBathymetry) = (0, 50)
-metadata_filename(::TrivalBathymetry, name, date, region) = "trivial_bathymetry.nc"
 
 @testset "Distributed ECCO download" begin
     dates = DateTimeProlepticGregorian(1992, 1, 1) : Month(1) : DateTimeProlepticGregorian(1994, 4, 1)
@@ -67,7 +20,7 @@ metadata_filename(::TrivalBathymetry, name, date, region) = "trivial_bathymetry.
 end
 
 @testset "Distributed Bathymetry interpolation" begin
-    TrivialBathymetry_metadata = Metadata(:z, TrivalBathymetry(), nothing, nothing, ".")
+    metadata = Metadatum(:bottom_height; dataset = SyntheticBathymetry())
 
     global_grid = LatitudeLongitudeGrid(CPU();
                                         size = (40, 40, 1),
@@ -76,8 +29,7 @@ end
                                         z = (0, 1))
 
     interpolation_passes = 4
-    global_height = regrid_bathymetry(global_grid, TrivialBathymetry_metadata;
-                                      interpolation_passes)
+    global_height = regrid_bathymetry(global_grid, metadata; interpolation_passes, cache = false)
 
     arch_x  = Distributed(CPU(), partition=Partition(4, 1))
     arch_y  = Distributed(CPU(), partition=Partition(1, 4))
@@ -90,8 +42,7 @@ end
                                            latitude = (0, 20),
                                            z = (0, 1))
 
-        local_height = regrid_bathymetry(local_grid, TrivialBathymetry_metadata;
-                                         interpolation_passes)
+        local_height = regrid_bathymetry(local_grid, metadata; interpolation_passes, cache = false)
 
         Nx, Ny, _ = size(local_grid)
         rx, ry, _ = arch.local_index

--- a/test/test_field_cache.jl
+++ b/test/test_field_cache.jl
@@ -10,7 +10,7 @@ using NumericalEarth.DataWrangling: FieldRegridding, field_cache_filename, field
                                  latitude = (-45, 45),
                                  z = (-1000, 0))
 
-    metadatum = Metadatum(:temperature; dataset = EN4Monthly(), date = start_date)
+    metadatum = Metadatum(:temperature; dataset = SyntheticOcean())
 
     config1 = FieldRegridding(grid, metadatum, (;))
     config2 = FieldRegridding(grid, metadatum, (;))
@@ -29,7 +29,7 @@ using NumericalEarth.DataWrangling: FieldRegridding, field_cache_filename, field
     @test field_cache_filename(FieldRegridding(grid, metadatum, (; inpainting = 7))) !=
           field_cache_filename(config1)
 
-    other_datum = Metadatum(:salinity; dataset = EN4Monthly(), date = start_date)
+    other_datum = Metadatum(:salinity; dataset = SyntheticOcean())
     @test field_cache_filename(FieldRegridding(grid, other_datum, (;))) !=
           field_cache_filename(config1)
 
@@ -48,7 +48,7 @@ end
                                  latitude = (-30, 30),
                                  z = (-800, 0))
 
-    metadatum = Metadatum(:temperature; dataset = EN4Monthly(), date = start_date)
+    metadatum = Metadatum(:temperature; dataset = SyntheticOcean())
 
     # Key the cache only after the dataset file exists — the key stamps it
     download(metadatum)

--- a/test/test_radiations.jl
+++ b/test/test_radiations.jl
@@ -99,12 +99,12 @@ end
     end
 end
 
-@testset "JRA55PrescribedRadiation" begin
+@testset "Dataset-backed PrescribedRadiation" begin
     for arch in test_architectures
         A = typeof(arch)
-        @info "Testing JRA55PrescribedRadiation on $A..."
+        @info "Testing dataset-backed PrescribedRadiation on $A..."
 
-        radiation = JRA55PrescribedRadiation(arch; time_indices_in_memory=2)
+        radiation = synthetic_prescribed_radiation(arch)
 
         @test radiation isa PrescribedRadiation
         @test radiation.downwelling_shortwave isa FieldTimeSeries

--- a/test/test_synthetic_dataset.jl
+++ b/test/test_synthetic_dataset.jl
@@ -21,9 +21,10 @@ for arch in test_architectures
             datum = Metadatum(:temperature; dataset)
             field = Field(datum, arch; inpainting = nothing)
             values = Array(interior(field))
-            λ = λnodes(field.grid, Center())
-            φ = φnodes(field.grid, Center())
-            z = znodes(field.grid, Center())
+            grid = on_architecture(CPU(), field.grid)
+            λ = λnodes(grid, Center())
+            φ = φnodes(grid, Center())
+            z = znodes(grid, Center())
             expected = [synthetic_value(dataset, :temperature, λ[i], φ[j], z[k])
                         for i in eachindex(λ), j in eachindex(φ), k in eachindex(z)]
             @test all(isequal.(values, Float32.(expected)))
@@ -63,8 +64,9 @@ for arch in test_architectures
         grid = LatitudeLongitudeGrid(arch; size = (36, 18, 1), longitude = (-180, 180), latitude = (-90, 90), z = (0, 1))
         bottom_height = synthetic_bottom_height(grid; major_basins = Inf)
         values = Array(interior(bottom_height, :, :, 1))
-        λ = λnodes(grid, Center())
-        φ = φnodes(grid, Center())
+        cpu_grid = on_architecture(CPU(), grid)
+        λ = λnodes(cpu_grid, Center())
+        φ = φnodes(cpu_grid, Center())
         expected = [synthetic_value(SyntheticBathymetry(), :bottom_height, λ[i], φ[j], 0) for i in eachindex(λ), j in eachindex(φ)]
         @test values == expected
     end

--- a/test/test_synthetic_dataset.jl
+++ b/test/test_synthetic_dataset.jl
@@ -21,12 +21,11 @@ for arch in test_architectures
             datum = Metadatum(:temperature; dataset)
             field = Field(datum, arch; inpainting = nothing)
             values = Array(interior(field))
-            grid = on_architecture(CPU(), field.grid)
-            λ = λnodes(grid, Center())
-            φ = φnodes(grid, Center())
-            z = znodes(grid, Center())
-            expected = [synthetic_value(dataset, :temperature, λ[i], φ[j], z[k])
-                        for i in eachindex(λ), j in eachindex(φ), k in eachindex(z)]
+            λ = λnodes(field.grid, Center())
+            φ = φnodes(field.grid, Center())
+            z = znodes(field.grid, Center())
+            expected = @allowscalar [synthetic_value(dataset, :temperature, λ[i], φ[j], z[k])
+                                     for i in eachindex(λ), j in eachindex(φ), k in eachindex(z)]
             @test all(isequal.(values, Float32.(expected)))
             @test any(isnan, values)
         end
@@ -64,10 +63,9 @@ for arch in test_architectures
         grid = LatitudeLongitudeGrid(arch; size = (36, 18, 1), longitude = (-180, 180), latitude = (-90, 90), z = (0, 1))
         bottom_height = synthetic_bottom_height(grid; major_basins = Inf)
         values = Array(interior(bottom_height, :, :, 1))
-        cpu_grid = on_architecture(CPU(), grid)
-        λ = λnodes(cpu_grid, Center())
-        φ = φnodes(cpu_grid, Center())
-        expected = [synthetic_value(SyntheticBathymetry(), :bottom_height, λ[i], φ[j], 0) for i in eachindex(λ), j in eachindex(φ)]
+        λ = λnodes(grid, Center())
+        φ = φnodes(grid, Center())
+        expected = @allowscalar [synthetic_value(SyntheticBathymetry(), :bottom_height, λ[i], φ[j], 0) for i in eachindex(λ), j in eachindex(φ)]
         @test values == expected
     end
 

--- a/test/test_synthetic_dataset.jl
+++ b/test/test_synthetic_dataset.jl
@@ -1,0 +1,82 @@
+include("runtests_setup.jl")
+include("download_utils.jl")
+
+using NumericalEarth.DataWrangling: NearestNeighborInpainting, native_times
+using Oceananigans.Grids: topology, λnodes, φnodes, znodes
+using Oceananigans.OutputReaders: time_indices
+using Oceananigans.TimeSteppers: update_state!
+using Oceananigans.Units
+
+dataset = SyntheticOcean()
+dates = all_dates(dataset, :temperature)[1:4]
+inpainting = NearestNeighborInpainting(10)
+
+for arch in test_architectures
+    A = typeof(arch)
+
+    @testset "$A synthetic ocean dataset" begin
+        @info "Running synthetic dataset tests on $A..."
+
+        @testset "Native-grid values" begin
+            datum = Metadatum(:temperature; dataset)
+            field = Field(datum, arch; inpainting = nothing)
+            values = Array(interior(field))
+            λ = λnodes(field.grid, Center())
+            φ = φnodes(field.grid, Center())
+            z = znodes(field.grid, Center())
+            expected = [synthetic_value(dataset, :temperature, λ[i], φ[j], z[k])
+                        for i in eachindex(λ), j in eachindex(φ), k in eachindex(z)]
+            @test all(isequal.(values, Float32.(expected)))
+            @test any(isnan, values)
+        end
+
+        @testset "Setting a field from a dataset" begin
+            test_setting_from_metadata(arch, dataset, dates[1], inpainting)
+        end
+
+        @testset "Timestepping with a dataset" begin
+            test_timestepping_with_dataset(arch, dataset, dates[1], inpainting)
+        end
+
+        @testset "Field utilities" begin
+            test_ocean_metadata_utilities(arch, dataset, dates, inpainting)
+        end
+
+        @testset "DatasetRestoring with LinearlyTaperedPolarMask" begin
+            test_dataset_restoring(arch, dataset, dates, inpainting)
+        end
+
+        @testset "Timestepping with DatasetRestoring" begin
+            test_timestepping_with_dataset_restoring(arch, dataset, dates, inpainting)
+        end
+
+        @testset "Dataset cycling boundaries" begin
+            test_cycling_dataset_restoring(arch, dataset, dates, inpainting)
+        end
+
+        @testset "Inpainting algorithm" begin
+            test_inpainting_algorithm(arch, dataset, dates[1], inpainting)
+        end
+    end
+
+    @testset "$A synthetic bathymetry" begin
+        grid = LatitudeLongitudeGrid(arch; size = (36, 18, 1), longitude = (-180, 180), latitude = (-90, 90), z = (0, 1))
+        bottom_height = synthetic_bottom_height(grid; major_basins = Inf)
+        values = Array(interior(bottom_height, :, :, 1))
+        λ = λnodes(grid, Center())
+        φ = φnodes(grid, Center())
+        expected = [synthetic_value(SyntheticBathymetry(), :bottom_height, λ[i], φ[j], 0) for i in eachindex(λ), j in eachindex(φ)]
+        @test values == expected
+    end
+
+    @testset "$A synthetic prescribed components" begin
+        atmosphere = synthetic_prescribed_atmosphere(arch)
+        radiation = synthetic_prescribed_radiation(arch)
+        land = synthetic_prescribed_land(arch)
+
+        @test length(atmosphere.times) == 12
+        @test all(Array(interior(atmosphere.pressure[1])) .== 101325)
+        @test all(Array(interior(radiation.downwelling_longwave[1])) .== 250)
+        @test all(Array(interior(land.freshwater_flux.rivers[1])) .== 1f-5)
+    end
+end


### PR DESCRIPTION
> `test/synthetic_datasets.jl` defines three tiny analytic datasets whose `download` writes a NetCDF file on first use: a bathymetry, a 3-D ocean with temperature and salinity, and a 2-D atmosphere with the JRA55 variable names. `Field`, `FieldTimeSeries`, `DatasetRestoring`, `regrid_bathymetry` and the prescribed atmosphere, radiation and land components all run their dataset code paths on them without any network.
> 
> `test_synthetic_dataset.jl` drives the shared helpers in `runtests_setup.jl` with the synthetic ocean and checks exact values on the native grid. The checkpointer, radiation, field cache and distributed-bathymetry tests, which used real data only as a plausible forcing, now use the synthetic datasets; the hand-written bathymetry in `test_distributed_utils.jl` is replaced by the shared one.
> 
> The nonzero restoring assertions in `test_dataset_restoring` become approximate: spatially interpolating a constant field is exact only up to roundoff.
> 
> Claude-Session: https://claude.ai/code/session_01BrfCzkbvHmN8yotYXp1ozf