### PR TITLE
Drive the forcing-only tests with the synthetic datasets

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,15 +40,6 @@ remote_data_tests = ["test_bathymetry",
                      "test_soilgrids",
                      "test_dataset_region",
                      "test_diagnostics_1",
-                     # Use real data only as forcing or initial condition; to be moved onto the synthetic datasets
-                     "test_coefficient_based_fluxes",
-                     "test_surface_fluxes",
-                     "test_sea_ice_ocean_heat_fluxes",
-                     "test_ocean_only_model",
-                     "test_ocean_sea_ice_model",
-                     "test_tracer_budget",
-                     "test_column_field",
-                     "test_speedy_coupling",
                      "test_mangling"]
 
 if filter_tests!(testsuite, args)

--- a/test/synthetic_datasets.jl
+++ b/test/synthetic_datasets.jl
@@ -40,8 +40,10 @@ DataWrangling.metadata_filename(::SyntheticDataset, name, date, region) =
 DataWrangling.inpainted_metadata_path(metadata::Metadatum{<:SyntheticDataset}) =
     joinpath(metadata.dir, replace(metadata.filename, ".nc" => "_inpainted.jld2"))
 
-# One continent in an otherwise global ocean
-synthetic_land(λ, φ) = -60 ≤ λ ≤ 20 && -30 ≤ φ ≤ 40
+# A continent across the equator, a south polar cap, and land under the two north poles of the
+# default `TripolarGrid` (55°N at 70°E and 110°W)
+synthetic_land(λ, φ) = (-60 ≤ λ ≤ 20 && -30 ≤ φ ≤ 40) || φ ≤ -70 ||
+                       (45 ≤ φ ≤ 65 && (40 ≤ λ ≤ 100 || -140 ≤ λ ≤ -80))
 
 synthetic_value(::SyntheticBathymetry, name, λ, φ, z) = synthetic_land(λ, φ) ? 500 : -4000
 

--- a/test/test_coefficient_based_fluxes.jl
+++ b/test/test_coefficient_based_fluxes.jl
@@ -84,8 +84,7 @@ end
                                  closure = nothing,
                                  bottom_drag_coefficient = 0)
 
-        dates = all_dates(RepeatYearJRA55(), :temperature)
-        atmosphere = JRA55PrescribedAtmosphere(arch; end_date=dates[2])
+        atmosphere = synthetic_prescribed_atmosphere(arch)
 
         constant_fluxes = CoefficientBasedFluxes(transfer_coefficients = SimilarityScales(2e-3, 2e-3, 2e-3))
         interfaces = ComponentInterfaces(atmosphere, ocean; atmosphere_ocean_fluxes=constant_fluxes)
@@ -117,8 +116,7 @@ end
                                  closure = nothing,
                                  bottom_drag_coefficient = 0)
 
-        dates = all_dates(RepeatYearJRA55(), :temperature)
-        atmosphere = JRA55PrescribedAtmosphere(arch; end_date=dates[2])
+        atmosphere = synthetic_prescribed_atmosphere(arch)
 
         poly_drag = PolynomialNeutralDragCoefficient()
         poly_fluxes = CoefficientBasedFluxes(transfer_coefficients = SimilarityScales(poly_drag, 1e-3, 1e-3))
@@ -154,8 +152,7 @@ end
                                  closure = nothing,
                                  bottom_drag_coefficient = 0)
 
-        dates = all_dates(RepeatYearJRA55(), :temperature)
-        atmosphere = JRA55PrescribedAtmosphere(arch; end_date=dates[2])
+        atmosphere = synthetic_prescribed_atmosphere(arch)
 
         ly = LargeYeagerTransferCoefficients()
         ly_fluxes = CoefficientBasedFluxes(transfer_coefficients = ly,

--- a/test/test_column_field.jl
+++ b/test/test_column_field.jl
@@ -11,7 +11,7 @@ using Oceananigans.BoundaryConditions: fill_halo_regions!
 using Oceananigans.Fields: location
 using Oceananigans.Grids: λnodes, φnodes, topology, Flat, Bounded, Periodic
 
-# Test coordinates for end-to-end Column tests (ECCO4 ocean point)
+# Test coordinates for end-to-end Column tests (an ocean point of the synthetic dataset)
 const test_longitude = 12.0
 const test_latitude = -50.0
 
@@ -120,7 +120,7 @@ end
 
         @testset "Column Field with Linear interpolation on $A" begin
             col = Column(test_longitude, test_latitude; interpolation=Linear())
-            md = Metadatum(:temperature; dataset=ECCO4Monthly(), date=start_date, region=col)
+            md = Metadatum(:temperature; dataset=SyntheticOcean(), region=col)
             field = Field(md, arch)
 
             @test field.grid isa RectilinearGrid
@@ -135,7 +135,7 @@ end
 
         @testset "Column Field with Nearest interpolation on $A" begin
             col = Column(test_longitude, test_latitude; interpolation=Nearest())
-            md = Metadatum(:temperature; dataset=ECCO4Monthly(), date=start_date, region=col)
+            md = Metadatum(:temperature; dataset=SyntheticOcean(), region=col)
             field = Field(md, arch)
 
             @test field.grid isa RectilinearGrid
@@ -148,7 +148,7 @@ end
 
         @testset "set! with Column metadata on $A" begin
             col = Column(test_longitude, test_latitude)
-            md = Metadatum(:temperature; dataset=ECCO4Monthly(), date=start_date, region=col)
+            md = Metadatum(:temperature; dataset=SyntheticOcean(), region=col)
 
             # Build a target column field
             column_grid = native_grid(md, arch)
@@ -165,8 +165,8 @@ end
             col_lin = Column(test_longitude, test_latitude; interpolation=Linear())
             col_near = Column(test_longitude, test_latitude; interpolation=Nearest())
 
-            md_lin = Metadatum(:temperature; dataset=ECCO4Monthly(), date=start_date, region=col_lin)
-            md_near = Metadatum(:temperature; dataset=ECCO4Monthly(), date=start_date, region=col_near)
+            md_lin = Metadatum(:temperature; dataset=SyntheticOcean(), region=col_lin)
+            md_near = Metadatum(:temperature; dataset=SyntheticOcean(), region=col_near)
 
             field_lin = Field(md_lin, arch)
             field_near = Field(md_near, arch)

--- a/test/test_ocean_only_model.jl
+++ b/test/test_ocean_only_model.jl
@@ -17,8 +17,8 @@ using Oceananigans.OrthogonalSphericalShellGrids
         data = Int[]
         pushdata(sim) = push!(data, iteration(sim))
         add_callback!(ocean, pushdata)
-        atmosphere = JRA55PrescribedAtmosphere(arch; time_indices_in_memory=4)
-        radiation = JRA55PrescribedRadiation(arch; time_indices_in_memory=4)
+        atmosphere = synthetic_prescribed_atmosphere(arch)
+        radiation = synthetic_prescribed_radiation(arch)
         coupled_model = OceanOnlyModel(ocean; atmosphere, radiation)
         Δt = 60
         for n = 1:3
@@ -37,10 +37,10 @@ using Oceananigans.OrthogonalSphericalShellGrids
                             halo = (7, 7, 7),
                             z = (-5000, 0))
 
-        bottom_height = regrid_bathymetry(grid;
-                                          minimum_depth = 10,
-                                          interpolation_passes = 5,
-                                          major_basins = 1)
+        bottom_height = synthetic_bottom_height(grid;
+                                                minimum_depth = 10,
+                                                interpolation_passes = 5,
+                                                major_basins = 1)
 
         grid = ImmersedBoundaryGrid(grid, GridFittedBottom(bottom_height); active_cells_map=true)
 
@@ -49,8 +49,8 @@ using Oceananigans.OrthogonalSphericalShellGrids
 
         @test NumericalEarth.Oceans.get_radiative_forcing(ocean) isa NumericalEarth.Oceans.TwoColorRadiation
 
-        atmosphere = JRA55PrescribedAtmosphere(arch; time_indices_in_memory=4)
-        radiation = JRA55PrescribedRadiation(arch; time_indices_in_memory=4)
+        atmosphere = synthetic_prescribed_atmosphere(arch)
+        radiation = synthetic_prescribed_radiation(arch)
 
         # Fluxes are computed when the model is constructed, so we just test that this works.
         @test begin
@@ -63,9 +63,8 @@ using Oceananigans.OrthogonalSphericalShellGrids
         ##### Ocean with prescribed atmosphere and land
         #####
 
-        @info "Testing OceanOnlyModel with JRA55PrescribedLand on $A..."
-        land_dates = all_dates(RepeatYearJRA55(), :river_freshwater_flux)
-        land = JRA55PrescribedLand(arch; end_date=land_dates[2])
+        @info "Testing OceanOnlyModel with PrescribedLand on $A..."
+        land = synthetic_prescribed_land(arch)
 
         @test begin
             ocean_with_land = ocean_simulation(grid; free_surface)

--- a/test/test_ocean_sea_ice_model.jl
+++ b/test/test_ocean_sea_ice_model.jl
@@ -18,10 +18,10 @@ using ClimaSeaIce.Rheologies
                             halo = (7, 7, 7),
                             z = (-5000, 0))
 
-        bottom_height = regrid_bathymetry(grid;
-                                          minimum_depth = 10,
-                                          interpolation_passes = 5,
-                                          major_basins = 1)
+        bottom_height = synthetic_bottom_height(grid;
+                                                minimum_depth = 10,
+                                                interpolation_passes = 5,
+                                                major_basins = 1)
 
         grid = ImmersedBoundaryGrid(grid, GridFittedBottom(bottom_height); active_cells_map=true)
         free_surface = SplitExplicitFreeSurface(grid; substeps=20)
@@ -30,59 +30,48 @@ using ClimaSeaIce.Rheologies
         ##### Coupled ocean-sea ice and prescribed atmosphere
         #####
 
-        for dataset in [ECCO4Monthly(), EN4Monthly()]
-            @info "Testing timestepping with $(typeof(dataset)) on $A"
+        initial_state = MetadataSet(:temperature, :salinity; dataset=SyntheticOcean(), date=DateTime(2000, 1, 1))
 
-            start_date = DateTimeProlepticGregorian(1993, 1, 1)
-            time_resolution = dataset isa ECCO2Daily ? Day(1) : Month(1)
-            end_date = DateTimeProlepticGregorian(1993, 2, 1)
-            dates = start_date : time_resolution : end_date
+        ocean = ocean_simulation(grid; free_surface)
 
-            initial_state = MetadataSet(:temperature, :salinity;
-                                        dataset, date=start_date)
+        sea_ice  = sea_ice_simulation(grid, ocean; advection=WENO(order=7))
+        liquidus = sea_ice.model.phase_transitions.liquidus
 
-            ocean = ocean_simulation(grid; free_surface)
+        # Set the ocean temperature and salinity
+        set!(ocean.model, initial_state)
+        above_freezing_ocean_temperature!(ocean, grid, sea_ice)
 
-            sea_ice  = sea_ice_simulation(grid, ocean; advection=WENO(order=7))
-            liquidus = sea_ice.model.phase_transitions.liquidus
+        # Test that ocean temperatures are above freezing
+        T = on_architecture(CPU(), ocean.model.tracers.T)
+        S = on_architecture(CPU(), ocean.model.tracers.S)
 
-            # Set the ocean temperature and salinity
-            set!(ocean.model, initial_state)
-            above_freezing_ocean_temperature!(ocean, grid, sea_ice)
+        Tm = KernelFunctionOperation{Center, Center, Center}(kernel_melting_temperature, grid, liquidus, S)
+        @test all(T .≥ Tm)
 
-            # Test that ocean temperatures are above freezing
-            T = on_architecture(CPU(), ocean.model.tracers.T)
-            S = on_architecture(CPU(), ocean.model.tracers.S)
+        atmosphere = synthetic_prescribed_atmosphere(arch)
+        radiation = synthetic_prescribed_radiation(arch)
 
-            Tm = KernelFunctionOperation{Center, Center, Center}(kernel_melting_temperature, grid, liquidus, S)
-            @test all(T .≥ Tm)
+        # Fluxes are computed when the model is constructed, so we just test that this works.
+        # And that we can time step with sea ice
+        @test begin
+            coupled_model = OceanSeaIceModel(ocean, sea_ice; atmosphere, radiation)
+            time_step!(coupled_model, 1)
+            true
+        end
 
-            atmosphere = JRA55PrescribedAtmosphere(arch; time_indices_in_memory=4)
-            radiation = JRA55PrescribedRadiation(arch; time_indices_in_memory=4)
+        @info "Testing OceanSeaIceModel with land on $A..."
+        land = synthetic_prescribed_land(arch)
 
-            # Fluxes are computed when the model is constructed, so we just test that this works.
-            # And that we can time step with sea ice
-            @test begin
-                coupled_model = OceanSeaIceModel(ocean, sea_ice; atmosphere, radiation)
-                time_step!(coupled_model, 1)
-                true
-            end
+        @test begin
+            ocean_with_land = ocean_simulation(grid; free_surface)
+            set!(ocean_with_land.model, initial_state)
+            sea_ice_with_land = sea_ice_simulation(grid, ocean_with_land; advection=WENO(order=7))
+            above_freezing_ocean_temperature!(ocean_with_land, grid, sea_ice_with_land)
 
-            @info "Testing OceanSeaIceModel with land on $A..."
-            land_dates = all_dates(RepeatYearJRA55(), :river_freshwater_flux)
-            land = JRA55PrescribedLand(arch; end_date=land_dates[2])
-
-            @test begin
-                ocean_with_land = ocean_simulation(grid; free_surface)
-                set!(ocean_with_land.model, initial_state)
-                sea_ice_with_land = sea_ice_simulation(grid, ocean_with_land; advection=WENO(order=7))
-                above_freezing_ocean_temperature!(ocean_with_land, grid, sea_ice_with_land)
-
-                coupled_model = OceanSeaIceModel(ocean_with_land, sea_ice_with_land; atmosphere, land, radiation)
-                @test !isnothing(coupled_model.interfaces.exchanger.land)
-                time_step!(coupled_model, 1)
-                true
-            end
+            coupled_model = OceanSeaIceModel(ocean_with_land, sea_ice_with_land; atmosphere, land, radiation)
+            @test !isnothing(coupled_model.interfaces.exchanger.land)
+            time_step!(coupled_model, 1)
+            true
         end
     end
 end

--- a/test/test_sea_ice_ocean_heat_fluxes.jl
+++ b/test/test_sea_ice_ocean_heat_fluxes.jl
@@ -199,8 +199,8 @@ end
         ocean = ocean_simulation(grid, momentum_advection=nothing, closure=nothing, tracer_advection=nothing)
         sea_ice = sea_ice_simulation(grid, ocean)
 
-        atmosphere = JRA55PrescribedAtmosphere(arch; time_indices_in_memory=4)
-        radiation = JRA55PrescribedRadiation(arch; time_indices_in_memory=4)
+        atmosphere = synthetic_prescribed_atmosphere(arch)
+        radiation = synthetic_prescribed_radiation(arch)
 
         for sea_ice_ocean_heat_flux in [IceBathHeatFlux(), ThreeEquationHeatFlux()]
             @testset "Salt flux with $(nameof(typeof(sea_ice_ocean_heat_flux)))" begin
@@ -254,8 +254,8 @@ end
         ocean = ocean_simulation(grid, momentum_advection=nothing, closure=nothing, tracer_advection=nothing)
         sea_ice = sea_ice_simulation(grid, ocean)
 
-        atmosphere = JRA55PrescribedAtmosphere(arch; time_indices_in_memory=4)
-        radiation = JRA55PrescribedRadiation(arch; time_indices_in_memory=4)
+        atmosphere = synthetic_prescribed_atmosphere(arch)
+        radiation = synthetic_prescribed_radiation(arch)
 
         for sea_ice_ocean_heat_flux in [IceBathHeatFlux(), ThreeEquationHeatFlux()]
             @testset "Flux magnitude with $(nameof(typeof(sea_ice_ocean_heat_flux)))" begin
@@ -391,8 +391,8 @@ end
         ocean = ocean_simulation(grid, momentum_advection=nothing, closure=nothing, tracer_advection=nothing)
         sea_ice = sea_ice_simulation(grid, ocean)
 
-        atmosphere = JRA55PrescribedAtmosphere(arch; time_indices_in_memory=4)
-        radiation = JRA55PrescribedRadiation(arch; time_indices_in_memory=4)
+        atmosphere = synthetic_prescribed_atmosphere(arch)
+        radiation = synthetic_prescribed_radiation(arch)
 
         for sea_ice_ocean_heat_flux in [IceBathHeatFlux(), ThreeEquationHeatFlux()]
             @testset "Frazil with $(nameof(typeof(sea_ice_ocean_heat_flux)))" begin
@@ -441,8 +441,8 @@ end
         ocean = ocean_simulation(grid, momentum_advection=nothing, closure=nothing, tracer_advection=nothing)
         sea_ice = sea_ice_simulation(grid, ocean)
 
-        atmosphere = JRA55PrescribedAtmosphere(arch; time_indices_in_memory=4)
-        radiation = JRA55PrescribedRadiation(arch; time_indices_in_memory=4)
+        atmosphere = synthetic_prescribed_atmosphere(arch)
+        radiation = synthetic_prescribed_radiation(arch)
 
         # Test with ThreeEquationHeatFlux (default)
         @test begin

--- a/test/test_speedy_coupling.jl
+++ b/test/test_speedy_coupling.jl
@@ -1,9 +1,7 @@
+include("runtests_setup.jl")
+
 using ConservativeRegridding
-using Dates
-using Oceananigans
-using NumericalEarth
 using SpeedyWeather
-using Test
 
 NumericalEarthSpeedyWeatherExt = Base.get_extension(NumericalEarth, :NumericalEarthSpeedyWeatherExt)
 @test !isnothing(NumericalEarthSpeedyWeatherExt)
@@ -12,7 +10,7 @@ spectral_grid = SpeedyWeather.SpectralGrid(truncation=52, nlayers=3, Grid=FullCl
 oceananigans_grid = LatitudeLongitudeGrid(Oceananigans.CPU(); size=(200, 100, 1), latitude=(-80, 80), longitude=(0, 360), z = (0, 1))
 
 ocean = NumericalEarth.Oceans.ocean_simulation(oceananigans_grid; momentum_advection=nothing, tracer_advection=nothing, closure=nothing)
-Oceananigans.set!(ocean.model, T=EN4Metadatum(:temperature), S=EN4Metadatum(:salinity))
+Oceananigans.set!(ocean.model, T=Metadatum(:temperature; dataset=SyntheticOcean()), S=Metadatum(:salinity; dataset=SyntheticOcean()))
 
 atmos = NumericalEarth.atmosphere_simulation(spectral_grid)
 

--- a/test/test_surface_fluxes.jl
+++ b/test/test_surface_fluxes.jl
@@ -46,8 +46,7 @@ end
                                  closure = nothing,
                                  bottom_drag_coefficient = 0)
 
-        dates = all_dates(RepeatYearJRA55(), :temperature)
-        atmosphere = JRA55PrescribedAtmosphere(arch; end_date=dates[2])
+        atmosphere = synthetic_prescribed_atmosphere(arch)
 
         @allowscalar begin
             h  = atmosphere.surface_layer_height
@@ -230,8 +229,7 @@ end
                                            bottom_drag_coefficient = 0)
 
         set!(ocean_with_land.model, T = 15, S = 30)
-        land_dates = all_dates(RepeatYearJRA55(), :river_freshwater_flux)
-        land = JRA55PrescribedLand(arch; end_date=land_dates[2])
+        land = synthetic_prescribed_land(arch)
         model_with_land = OceanOnlyModel(ocean_with_land; atmosphere, land)
 
         # Verify land exchanger is wired up
@@ -268,8 +266,7 @@ end
                                                   closure = nothing,
                                   bottom_drag_coefficient = 0.0)
 
-        dates = all_dates(RepeatYearJRA55(), :temperature)
-        atmosphere = JRA55PrescribedAtmosphere(arch; end_date=dates[2])
+        atmosphere = synthetic_prescribed_atmosphere(arch; dates = all_dates(SyntheticAtmosphere(), :temperature)[1:2])
 
         fill!(ocean.model.tracers.T, -2.0)
 

--- a/test/test_tracer_budget.jl
+++ b/test/test_tracer_budget.jl
@@ -96,17 +96,16 @@ end
                                            halo = (7, 7, 4),
                                            fold_topology)
 
-            bottom_height = regrid_bathymetry(underlying_grid,
-                                              Metadatum(:bottom_height, dataset=ETOPO2022());
-                                              minimum_depth=15,
-                                              interpolation_passes=1,
-                                              major_basins=1)
+            bottom_height = synthetic_bottom_height(underlying_grid;
+                                                    minimum_depth=15,
+                                                    interpolation_passes=1,
+                                                    major_basins=1)
 
             grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(bottom_height); active_cells_map = true)
 
             time_indices_in_memory = 4
-            radiation  = JRA55PrescribedRadiation(arch; time_indices_in_memory)
-            atmosphere = JRA55PrescribedAtmosphere(arch; time_indices_in_memory)
+            radiation  = synthetic_prescribed_radiation(arch; time_indices_in_memory)
+            atmosphere = synthetic_prescribed_atmosphere(arch; time_indices_in_memory)
 
             # An idealized, stably stratified initial state
             Tᵢ(λ, φ, z) = 2 + 26 * cosd(φ)^2 * exp(z / 30)


### PR DESCRIPTION
> Eight tests used JRA55, ETOPO, ECCO or EN4 only as a plausible forcing,
> bathymetry or initial condition and asserted nothing about the real
> values. They now use the synthetic datasets and leave the remote-data
> list in `runtests.jl`, so they run on every pull request again.
> 
> The synthetic bathymetry gains land under the two north poles of the
> default `TripolarGrid` and a south polar cap. The barotropic solver is
> singular at a wet pole, and sea ice over a wet south polar ocean
> exchanges enough salt to break the tracer budget's conservation check.
> 
> `test_mangling` stays a remote-data test: it asserts the layout of
> ECCO's Face-located `v_velocity` file.
> 
> Claude-Session: https://claude.ai/code/session_01BrfCzkbvHmN8yotYXp1ozf