### PR TITLE
Carry the reducer on MODISLAIClimatology and in its cache filename

### DIFF
--- a/examples/modis_leaf_area_index.jl
+++ b/examples/modis_leaf_area_index.jl
@@ -364,7 +364,7 @@ nothing #hide
 # closed evergreen canopy holds its leaf area through the year, where a temperate deciduous stand
 # swings by close to an order of magnitude between leaf-off and full canopy. For a domain like
 # this one a single peak-season field is therefore a defensible boundary condition, and
-# `build_lai_climatology!(…; reducer = maximum)` produces exactly that; for a mid-latitude domain
+# `MODISLAIClimatology(reducer = maximum)` produces exactly that; for a mid-latitude domain
 # the seasonal series is not optional.
 #
 # The gap panel is the one that sets the `years` default. Three years reaches the land-cover floor

--- a/src/DataWrangling/MODISLand/climatology.jl
+++ b/src/DataWrangling/MODISLand/climatology.jl
@@ -19,18 +19,14 @@ end
                            name = :leaf_area_index,
                            region,
                            periods = 1:periods_per_year(dataset),
-                           reducer = mean,
                            dir = default_download_directory(dataset))
 
 Build the cached per-period files behind a [`MODISLAIClimatology`](@ref) over `region`. For
 each composite period in `periods`, every contributing date of `dataset.years` is
 downloaded and screened, the retained retrievals are combined pixel by pixel with
-`reducer`, and one file is written holding the reduction and the retained-retrieval count.
-Periods already on disk are skipped, so an interrupted build resumes. Returns the paths of
-the files.
-
-`reducer` acts on the vector of retained values of a pixel: `mean` gives a seasonal mean,
-while `maximum` (or a high quantile) gives a peak-season field.
+`dataset.reducer`, and one file is written holding the reduction and the retained-retrieval
+count. Periods already on disk are skipped, so an interrupted build resumes. Returns the
+paths of the files.
 
 A date the archive holds no composite for is skipped with a warning.
 """
@@ -38,7 +34,6 @@ function build_lai_climatology!(dataset::MODISLAIClimatology;
                                 name = :leaf_area_index,
                                 region,
                                 periods = 1:periods_per_year(dataset),
-                                reducer = mean,
                                 dir = default_download_directory(dataset))
 
     haskey(MODISLAI_variable_names, name) ||
@@ -70,7 +65,7 @@ function build_lai_climatology!(dataset::MODISLAIClimatology;
 
         @info string("Compositing ", length(available), " retrievals into period ", period,
                      " of the ", modis_short_name(source), " ", name, " climatology...")
-        write_lai_composite(filepath, metadata, reducer)
+        write_lai_composite(filepath, metadata, dataset.reducer)
     end
 
     return paths

--- a/src/DataWrangling/MODISLand/datasets.jl
+++ b/src/DataWrangling/MODISLand/datasets.jl
@@ -51,11 +51,12 @@ Base.show(io::IO, dataset::MCD15A2H) =
     print(io, "MCD15A2H(screened_flags=", repr(dataset.screened_flags), ")")
 
 """
-    MODISLAIClimatology(; dataset = MCD15A2H(), years = 2003:2019)
+    MODISLAIClimatology(; dataset = MCD15A2H(), years = 2003:2019, reducer = mean)
 
 A seasonal climatology of a [`MODISLAIDataset`](@ref): one composite per period of the
-year, each reducing that period's retrievals across `years` pixel by pixel with the
-screen `dataset` carries. An 8-day source gives 46 periods, so
+year, each combining the retrievals `dataset`'s screen retains across `years` pixel by pixel
+with `reducer`, a named function of the vector of retained values (`mean` for a seasonal
+mean, `maximum` for a peak-season field). An 8-day source gives 46 periods, so
 `FieldTimeSeries(Metadata(:leaf_area_index; dataset = MODISLAIClimatology(), region), grid)`
 is a 46-slot cyclic seasonal series. Cells no year could observe stay `NaN`, and the
 number of retained retrievals behind every cell is stored beside the reduction, see
@@ -68,19 +69,21 @@ equatorial crossing times.
 julia> using NumericalEarth
 
 julia> MODISLAIClimatology()
-MODISLAIClimatology(MCD15A2H(screened_flags=0x0007), years=2003:2019)
+MODISLAIClimatology(MCD15A2H(screened_flags=0x0007), years=2003:2019, reducer=mean)
 ```
 """
-struct MODISLAIClimatology{D <: MODISLAIDataset, Y} <: AbstractMODISLandDataset
+struct MODISLAIClimatology{D <: MODISLAIDataset, Y, R} <: AbstractMODISLandDataset
     dataset :: D
     years :: Y
+    reducer :: R
 end
 
-MODISLAIClimatology(; dataset = MCD15A2H(), years = 2003:2019) =
-    MODISLAIClimatology(dataset, years)
+MODISLAIClimatology(; dataset = MCD15A2H(), years = 2003:2019, reducer = mean) =
+    MODISLAIClimatology(dataset, years, reducer)
 
 Base.show(io::IO, climatology::MODISLAIClimatology) =
-    print(io, "MODISLAIClimatology(", climatology.dataset, ", years=", climatology.years, ")")
+    print(io, "MODISLAIClimatology(", climatology.dataset, ", years=", climatology.years,
+          ", reducer=", climatology.reducer, ")")
 
 """
     MCD12Q1(; legend = :IGBP)
@@ -277,7 +280,7 @@ DataWrangling.conversion_units(::MODISLandCoverMetadatum) = nothing
 #####
 ##### Each granule read produces one regional file holding every layer, so the raw filename
 ##### is keyed by date and region but not by variable. The climatology reduces a single
-##### variable, so its filename carries the variable, the years, and the period.
+##### variable, so its filename carries the variable, the years, the reducer, and the period.
 #####
 
 date_tag(date) = Dates.format(DateTime(date), "yyyymmdd")
@@ -307,7 +310,7 @@ DataWrangling.metadata_filename(dataset::MCD12Q1, name, date, region) =
 function DataWrangling.metadata_filename(dataset::MODISLAIClimatology, name, date, region)
     period = period_index(date, composite_period_days(dataset))
     return string(modis_short_name(dataset), "_", modis_version(dataset), "_", name,
-                  "_climatology_", years_tag(dataset.years),
+                  "_climatology_", years_tag(dataset.years), "_", nameof(dataset.reducer),
                   "_p", lpad(period, 2, '0'), "_", region_tag(region), ".nc")
 end
 

--- a/test/test_modis_land.jl
+++ b/test/test_modis_land.jl
@@ -958,16 +958,10 @@ end
         @test build_lai_climatology!(climatology; region, periods = period:period, dir) == paths
         @test mtime(only(paths)) == modified
 
-        # A peak reducer selects the largest retained value instead of averaging.
-        peak_dir = mkpath(joinpath(dir, "peak"))
-        for date in source_dates
-            source = Metadatum(:leaf_area_index; dataset = MCD15A2H(), region, date, dir)
-            cp(joinpath(dir, source.filename), joinpath(peak_dir, source.filename))
-        end
-        build_lai_climatology!(climatology; region, periods = period:period,
-                               dir = peak_dir, reducer = maximum)
-        peak = Metadatum(:leaf_area_index; dataset = climatology, region, date = stamp,
-                         dir = peak_dir)
+        # A peak reducer selects the largest retained value, in its own file beside the mean's.
+        peak = Metadatum(:leaf_area_index; dataset = MODISLAIClimatology(; years, reducer = maximum),
+                         region, date = stamp, dir)
+        @test peak.filename != metadatum.filename
         @test Array(interior(Field(peak), :, :, 1))[1, 1] ≈ 30 * MODIS_LAI_SCALE
 
         # The count is stored beside a reduction, so it is not something the builder makes.


### PR DESCRIPTION
`MODISLAIClimatology` now carries its `reducer` (`mean` by default) and puts its name in the cache filename, so a `maximum` climatology no longer shares files with the `mean` one, and a read built on demand uses the right reduction. `build_lai_climatology!` loses its `reducer` keyword. Closes #655.

```julia
peak = MODISLAIClimatology(years = 2015:2019, reducer = maximum)
```
