### PR TITLE
[CI] Run CPU job with 3 concurrent runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,15 +85,19 @@ jobs:
           '
       - uses: julia-actions/julia-runtest@v1
         with:
-          # Cap parallelism at 2 workers. ParallelTestRunner's default_njobs
+          # Cap parallelism at 3 workers. ParallelTestRunner's default_njobs
           # assumes ~2 GiB per worker, but the Breeze-compilation and bathymetry
           # tests peak at 2.5-3.5 GiB RSS each. On the 16 GiB GitHub-hosted
           # runner, the default (4 = core count) intermittently OOMs when several
           # heavy tests coincide, and the runner reports it as
-          # "The operation was canceled." Two workers keep peak memory well
+          # "The operation was canceled." Three workers keep peak memory well
           # within budget while staying comfortably under the job timeout.
-          test_args: '--verbose --jobs=2'
+          test_args: '--verbose --jobs=3'
           optimize: 0
+        env:
+          # Reduce memory threshold before recycling ParallelTestRunner's
+          # workers.
+          JULIA_TEST_MAXRSS_MB: 2800
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.12.5"
+          - "1.12.7"
         os:
           - ubuntu-latest
         arch:
@@ -275,7 +275,7 @@ jobs:
   #     - uses: actions/checkout@v7
   #     - uses: julia-actions/setup-julia@v3
   #       with:
-  #         version: '1.12.5'
+  #         version: '1.12.7'
   #     - name: Instantiate and precompile
   #       shell: julia --project --color=yes {0}
   #       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           echo "JULIA_CPU_TARGET=generic;haswell,-xsaveopt,clone_all;znver3,-rdrnd,base(1);znver4,-rdrnd,base(1);sapphirerapids,-rdrnd,base(1)" | tee -a "${GITHUB_ENV}"
       - name: Instantiate test environment
-        timeout-minutes: 45
+        timeout-minutes: 60
         shell: bash
         run: |
           julia --project=test --color=yes --check-bounds=yes -e '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
-        with:
-          cache-scratchspaces: false
       - name: Set JULIA_CPU_TARGET
         shell: bash
         run: |
@@ -228,8 +226,6 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
-        with:
-          cache-scratchspaces: false
       - name: Set JULIA_CPU_TARGET
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           echo "JULIA_CPU_TARGET=generic;haswell,-xsaveopt,clone_all;znver3,-rdrnd,base(1);znver4,-rdrnd,base(1);sapphirerapids,-rdrnd,base(1)" | tee -a "${GITHUB_ENV}"
       - name: Instantiate test environment
-        timeout-minutes: 30
+        timeout-minutes: 45
         shell: bash
         run: |
           julia --project=test --color=yes --check-bounds=yes -e '
@@ -186,7 +186,7 @@ jobs:
           Pkg.Registry.add("General")
           Pkg.Registry.update()
       - name: Instantiate test environment
-        timeout-minutes: 30
+        timeout-minutes: 45
         shell: bash
         run: |
           julia --project=test --color=yes --check-bounds=yes -e '
@@ -263,7 +263,7 @@ jobs:
         run: |
           echo "JULIA_CPU_TARGET=generic;haswell,-xsaveopt,clone_all;znver3,-rdrnd,base(1);znver4,-rdrnd,base(1);sapphirerapids,-rdrnd,base(1)" | tee -a "${GITHUB_ENV}"
       - name: Instantiate test environment
-        timeout-minutes: 30
+        timeout-minutes: 45
         shell: bash
         run: |
           julia --project=test --color=yes --check-bounds=auto -e '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
       - uses: julia-actions/cache@v3
         with:
           cache-scratchspaces: false
+      - name: Set JULIA_CPU_TARGET
+        shell: bash
+        run: |
+          echo "JULIA_CPU_TARGET=generic;haswell,-xsaveopt,clone_all;znver3,-rdrnd,base(1);znver4,-rdrnd,base(1);sapphirerapids,-rdrnd,base(1)" | tee -a "${GITHUB_ENV}"
       - name: Instantiate test environment
         timeout-minutes: 30
         shell: bash
@@ -254,6 +258,10 @@ jobs:
       - uses: julia-actions/cache@v3
         with:
           cache-scratchspaces: false
+      - name: Set JULIA_CPU_TARGET
+        shell: bash
+        run: |
+          echo "JULIA_CPU_TARGET=generic;haswell,-xsaveopt,clone_all;znver3,-rdrnd,base(1);znver4,-rdrnd,base(1);sapphirerapids,-rdrnd,base(1)" | tee -a "${GITHUB_ENV}"
       - name: Instantiate test environment
         timeout-minutes: 30
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,21 +47,7 @@ jobs:
         arch:
           - "default"
     steps:
-      - name: Show available storage before cleanup
-        run: |
-          echo " --> df -h /"
-          df -h /
-          echo " --> df -a /"
-          df -a /
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: true
-          large-packages: false
-      - name: Cleanup /opt
-        run: |
-          sudo rm -rf /opt/*
-      - name: Show available storage after cleanup
+      - name: Show available storage at the beginning
         run: |
           echo " --> df -h /"
           df -h /
@@ -230,21 +216,7 @@ jobs:
         arch:
           - default
     steps:
-      - name: Show available storage before cleanup
-        run: |
-          echo " --> df -h /"
-          df -h /
-          echo " --> df -a /"
-          df -a /
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: true
-          large-packages: false
-      - name: Cleanup /opt
-        run: |
-          sudo rm -rf /opt/*
-      - name: Show available storage after cleanup
+      - name: Show available storage at the beginning
         run: |
           echo " --> df -h /"
           df -h /
@@ -283,6 +255,14 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Show available storage at the end
+        if: always()
+        timeout-minutes: 2
+        run: |
+          echo " --> df -h /"
+          df -h /
+          echo " --> df -a /"
+          df -a /
   
   #####
   ##### Distributed MPI tests (GitHub-hosted runners)


### PR DESCRIPTION
#660 already brought a substantial speedup for the CPU job, but we should also be able to use 3 concurrent jobs, instead of just 2.