### PR TITLE
[CI] Don't cache scratchspaces again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set JULIA_CPU_TARGET
         shell: bash
         run: |
-          echo "JULIA_CPU_TARGET=generic;haswell,-xsaveopt,clone_all;znver3,-rdrnd,base(1);znver4,-rdrnd,base(1);sapphirerapids,-rdrnd,base(1)" | tee -a "${GITHUB_ENV}"
+          echo "JULIA_CPU_TARGET=generic;haswell,-xsaveopt,clone_all;x86-64-v4,-rdrnd,base(1)" | tee -a "${GITHUB_ENV}"
       - name: Instantiate test environment
         timeout-minutes: 60
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
+        with:
+          cache-scratchspaces: false
       - name: Set JULIA_CPU_TARGET
         shell: bash
         run: |
@@ -226,6 +228,8 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
+        with:
+          cache-scratchspaces: false
       - name: Set JULIA_CPU_TARGET
         shell: bash
         run: |


### PR DESCRIPTION
#663 enabled scratchspaces caching under the assumption that they'd be small, it turned out that [they're not that small](https://github.com/NumericalEarth/NumericalEarth.jl/actions/runs/33932977068/job/101215231670?pr=663#step:5:55):
```
2.8G	/home/runner/.julia/scratchspaces
```
This adds about 800 MB to the compressed cache stored for GitHub Actions.  I have no clue of what's in there, will need to investigate, but that's clearly not helpful, so I'm going to revert that change