### PR TITLE
Speed up tracer budget test

### DIFF
--- a/test/test_tracer_budget.jl
+++ b/test/test_tracer_budget.jl
@@ -66,7 +66,7 @@ function test_tracer_budget(coupled_model, Sᵒᶜ, Δt, nsteps; heat_rtol, fres
         # Heat content changes by the surface heat flux plus the enthalpy carried by the freshwater
         # (rain − evaporation at SST). The live Tᴺ Jʷ exchange cancels the z-star ambient carry, so
         # the freshwater's own enthalpy Σᵢ Tᵢ Jʷᵢ is what remains.
-        heat_content_tendency = sum(ρᵒᶜ * cᵒᶜ * ΔVT)
+        heat_content_tendency = ρᵒᶜ * cᵒᶜ * sum(ΔVT)
         expected_heat_content_tendency = (previous_radiative_rate - previous_heat_flux + previous_enthalpy) * last_Δt
         @test isapprox(heat_content_tendency, expected_heat_content_tendency; rtol=heat_rtol)
 

--- a/test/test_tracer_budget.jl
+++ b/test/test_tracer_budget.jl
@@ -118,7 +118,7 @@ end
 
             Δt = 605seconds
             Sᵒᶜ = 35 # reference salinity [psu]
-            free_surface = SplitExplicitFreeSurface(substeps=20)
+            free_surface = SplitExplicitFreeSurface(substeps=5)
 
             # Without shortwave penetration
             @testset "Surface-only fluxes" begin

--- a/test/test_tracer_budget.jl
+++ b/test/test_tracer_budget.jl
@@ -2,6 +2,7 @@ include("runtests_setup.jl")
 
 using CUDA: @allowscalar
 using Oceananigans.AbstractOperations: KernelFunctionOperation
+using Oceananigans.Diagnostics: NaNChecker, nan_detected
 using Oceananigans.Grids: MutableVerticalDiscretization
 using Oceananigans.Operators: volume
 using Oceananigans.Units
@@ -48,6 +49,10 @@ function test_tracer_budget(coupled_model, Sᵒᶜ, Δt, nsteps; heat_rtol, fres
     set!(VS⁻, S * volume)
     ∫S⁻ = sum(VS⁻)
 
+    sea_ice = coupled_model.sea_ice
+    sea_ice_fields = isnothing(sea_ice) ? NamedTuple() : Oceananigans.prognostic_fields(sea_ice.model)
+    nan_checker = NaNChecker(fields = merge(Oceananigans.prognostic_fields(ocean.model), sea_ice_fields))
+
     for _ = 1:nsteps
         set!(VT⁻, T * volume)
         set!(VV⁻, cell_volume)
@@ -59,6 +64,9 @@ function test_tracer_budget(coupled_model, Sᵒᶜ, Δt, nsteps; heat_rtol, fres
 
         time_step!(coupled_model, Δt)
         last_Δt = ocean.model.clock.last_Δt
+
+        nan_checker(ocean)
+        @test !nan_detected(nan_checker)
 
         compute!(ΔVT)
         compute!(ΔVV)


### PR DESCRIPTION
This seems to almost halve the time to run `test_tracer_budget` locally for me, see the individual commits for an explanation of how they help.