### PR TITLE
Key the Breeze energy BC by version: ρs on Breeze ≥0.10, ρe before

### DIFF
--- a/ext/NumericalEarthBreezeExt/breeze_atmosphere_simulation.jl
+++ b/ext/NumericalEarthBreezeExt/breeze_atmosphere_simulation.jl
@@ -26,6 +26,10 @@ function merge_fbcs(coupling::FieldBoundaryConditions, user::FieldBoundaryCondit
                                    immersed = pick(coupling.immersed, user.immersed))
 end
 
+# Breeze 0.10 renamed static energy e → s (Breeze #926), and the energy-BC interface key
+# (converted to a ρθ BC for potential-temperature formulations) follows the symbol.
+energy_bc_key() = pkgversion(Breeze) >= v"0.10" ? :ρs : :ρe
+
 function merge_boundary_conditions(coupling_bcs::NamedTuple, user_bcs::NamedTuple)
     all_keys = (keys(coupling_bcs)..., (k for k in keys(user_bcs) if !(k in keys(coupling_bcs)))...)
     pairs = (k => haskey(coupling_bcs, k) && haskey(user_bcs, k) ?
@@ -113,7 +117,7 @@ function NumericalEarth.Atmospheres.atmosphere_model(grid;
 
     moisture_key = moisture_prognostic_name(microphysics)
     moisture_bc = NamedTuple{tuple(moisture_key)}(tuple(FieldBoundaryConditions(bottom = FluxBoundaryCondition(Jᵛ))))
-    energy_bc = (; ρe = FieldBoundaryConditions(bottom = FluxBoundaryCondition(Jᵉ)))
+    energy_bc = NamedTuple{(energy_bc_key(),)}((FieldBoundaryConditions(bottom = FluxBoundaryCondition(Jᵉ)),))
 
     momentum_bcs = (
         ρu = FieldBoundaryConditions(bottom = FluxBoundaryCondition(ρτˣ)),

--- a/ext/NumericalEarthBreezeExt/breeze_nested_atmosphere.jl
+++ b/ext/NumericalEarthBreezeExt/breeze_nested_atmosphere.jl
@@ -264,13 +264,17 @@ function NumericalEarth.NestedModels.nested_atmosphere_model(parent_atmosphere::
     # side (prescribing the parent's tangential velocity in the halo — `NormalFlowBC` there leaves it
     # under-constrained and injects spurious near-boundary convergence). `ρᵈ`/energy/moisture are Center
     # scalars (`ValueBoundaryCondition` on all sides, since `NormalFlowBC` overwrites the first interior cell
-    # asymmetrically for Center fields). The energy BC is keyed `ρe` (Breeze's energy-BC interface): it merges
-    # with the coupling's bottom energy-flux BC on the same field, and for a potential-temperature formulation
-    # Breeze routes the (Value) `ρθ` boundary values through unchanged. `ρθ` and `ρe` must not both carry BCs.
-    dry_bc_variables = (ρᵈ = prognostic.ρᵈ, ρu = prognostic.ρu, ρv = prognostic.ρv, ρe = prognostic.ρθ)
+    # asymmetrically for Center fields). The energy BC uses Breeze's energy-BC interface key (`ρs` on
+    # Breeze ≥0.10, `ρe` before): it merges with the coupling's bottom energy-flux BC on the same field,
+    # and for a potential-temperature formulation Breeze routes the (Value) `ρθ` boundary values through
+    # unchanged. `ρθ` and the energy key must not both carry BCs.
+    energy_key = energy_bc_key()
+    dry_bc_variables = merge((ρᵈ = prognostic.ρᵈ, ρu = prognostic.ρu, ρv = prognostic.ρv),
+                             NamedTuple{(energy_key,)}((prognostic.ρθ,)))
     bc_variables = merge(dry_bc_variables, moist_variables)
 
-    density_and_energy_types = (ρᵈ = ValueBoundaryCondition, ρe = ValueBoundaryCondition)
+    density_and_energy_types = merge((ρᵈ = ValueBoundaryCondition,),
+                                     NamedTuple{(energy_key,)}((ValueBoundaryCondition,)))
     momentum_types = (ρu = (west = NormalFlowBoundaryCondition, east = NormalFlowBoundaryCondition, south = ValueBoundaryCondition, north = ValueBoundaryCondition),
                       ρv = (west = ValueBoundaryCondition, east = ValueBoundaryCondition, south = NormalFlowBoundaryCondition, north = NormalFlowBoundaryCondition))
     moist_types = NamedTuple{tuple(moisture_name)}(tuple(ValueBoundaryCondition))


### PR DESCRIPTION
Breeze 0.10 renamed static energy e → s (Breeze #926) and the energy-BC interface key followed; unknown boundary_conditions keys are silently dropped (Breeze #956), so the ρe-keyed coupling bottom flux and nested lateral θ values vanish and net_fluxes crashes unwrapping a default no-flux BC. Key by pkgversion(Breeze). Companion to the Breeze-0.10 compat PR — compat alone lets environments resolve into this crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)