### PR TITLE
Add conservative surface flux restoring

### DIFF
--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -12,7 +12,8 @@ export AVISOMetadata, AVISODaily, AVISOMonthly, AVISOMetadatum
 export metadata_time_step, metadata_epoch
 export supported_datasets
 export LinearlyTaperedPolarMask
-export DatasetRestoring, SurfaceFluxRestoring
+export DatasetRestoring, SurfaceFluxRestoring, ConservativeSurfaceFluxRestoring
+export update_restoring_flux!, ConservativeSurfaceFluxRestoringCallback
 export ERA5HourlySingleLevel, ERA5MonthlySingleLevel, ERA5HourlyPressureLevels, ERA5MonthlyPressureLevels
 export ERA5HourlyLand, ERA5MonthlyLand
 export native_grid
@@ -26,12 +27,13 @@ using KernelAbstractions: @kernel, @index
 using Oceananigans: Oceananigans, pretty_filesize, location
 using Oceananigans.Architectures: AbstractArchitecture, CPU, architecture,
                                   on_architecture, child_architecture
+using Oceananigans.AbstractOperations: Average
 using Oceananigans.BoundaryConditions: fill_halo_regions!, FieldBoundaryConditions
 using Oceananigans.DistributedComputations: DistributedComputations, @root, all_reduce
 using Oceananigans.Grids: AbstractGrid, Center, Flat, Bounded,
                           LatitudeLongitudeGrid, RectilinearGrid, λnodes, φnodes,
                           topology, x_domain, y_domain, z_domain
-using Oceananigans.Fields: Fields, Field, interpolate, interpolate!, interior, set!
+using Oceananigans.Fields: Fields, Field, compute!, interpolate, interpolate!, interior, set!
 using Oceananigans.Grids: node
 using Oceananigans.OutputReaders: OnDisk, AbstractInMemoryBackend, Cyclical,
                                   FieldTimeSeries, FlavorOfFTS, time_indices

--- a/src/DataWrangling/restoring.jl
+++ b/src/DataWrangling/restoring.jl
@@ -270,6 +270,71 @@ function BoundaryConditions.getbc(sf::SurfaceFluxRestoring, i, j, grid, clock, f
     return - G * Δz
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Wrap a surface flux and store a corrected flux whose area-weighted mean over wet cells is zero.
+"""
+struct ConservativeSurfaceFluxRestoring{R, F, M} <: Function
+    flux :: R
+    corrected_flux :: F
+    mean_flux :: M
+end
+
+function ConservativeSurfaceFluxRestoring(flux, grid)
+    corrected_flux = Field{Center, Center, Nothing}(grid)
+    mean_flux = Field(Average(corrected_flux, dims=(1, 2)))
+    return ConservativeSurfaceFluxRestoring(flux, corrected_flux, mean_flux)
+end
+
+Adapt.adapt_structure(to, restoring::ConservativeSurfaceFluxRestoring) =
+    ConservativeSurfaceFluxRestoring(Adapt.adapt(to, restoring.flux),
+                                     Adapt.adapt(to, restoring.corrected_flux),
+                                     nothing)
+
+@inline BoundaryConditions.getbc(restoring::ConservativeSurfaceFluxRestoring,
+                                 i, j, grid, clock, fields) =
+    @inbounds restoring.corrected_flux[i, j, 1]
+
+@kernel function _materialize_surface_flux!(buffer, flux, grid, clock, fields)
+    i, j = @index(Global, NTuple)
+    @inbounds buffer[i, j, 1] = BoundaryConditions.getbc(flux, i, j, grid, clock, fields)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Evaluate `restoring.flux` from the current model state and subtract its
+area-weighted mean over wet cells.
+"""
+function update_restoring_flux!(restoring::ConservativeSurfaceFluxRestoring, model)
+    grid = model.grid
+    fields = merge(model.velocities, model.tracers)
+
+    launch!(architecture(grid), grid, :xy, _materialize_surface_flux!,
+            restoring.corrected_flux, restoring.flux, grid, model.clock, fields)
+
+    compute!(restoring.mean_flux)
+    interior(restoring.corrected_flux) .-= interior(restoring.mean_flux)
+    return nothing
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Refresh a conservative surface flux restoring from `model` whenever the callback runs.
+The restoring is also initialized at the beginning of `run!`.
+"""
+struct ConservativeSurfaceFluxRestoringCallback{R, M}
+    restoring :: R
+    model :: M
+end
+
+(callback::ConservativeSurfaceFluxRestoringCallback)(simulation) =
+    update_restoring_flux!(callback.restoring, callback.model)
+
+Oceananigans.initialize!(callback::ConservativeSurfaceFluxRestoringCallback, simulation) = callback(simulation)
+
 #####
 ##### Masks for restoring
 #####

--- a/test/test_flux_and_restoring.jl
+++ b/test/test_flux_and_restoring.jl
@@ -90,3 +90,56 @@ end
         end
     end
 end
+
+struct ZonalSurfaceSalinityRestoring{FT} <: Function
+    rate :: FT
+    target :: FT
+    variation :: FT
+end
+
+@inline function (restoring::ZonalSurfaceSalinityRestoring)(i, j, grid, clock, fields)
+    Nx = size(grid, 1)
+    Nz = size(grid, 3)
+    target = restoring.target + restoring.variation * sinpi(2 * (i - 1) / Nx)
+    @inbounds return restoring.rate * (fields.S[i, j, Nz] - target)
+end
+
+@testset "Conservative surface flux restoring" begin
+    for arch in test_architectures, timestepper in (:SplitRungeKutta3, :QuasiAdamsBashforth2)
+        grid = RectilinearGrid(arch;
+                               size = (8, 8, 4),
+                               halo = (7, 7, 7),
+                               x = (0, 1e5),
+                               y = (0, 1e5),
+                               z = (-100, 0),
+                               topology = (Periodic, Periodic, Bounded))
+
+        raw_restoring = ZonalSurfaceSalinityRestoring(1e-6, 37.0, 0.5)
+        restoring = ConservativeSurfaceFluxRestoring(raw_restoring, grid)
+
+        ocean = ocean_simulation(grid;
+                                 Δt = 1minute,
+                                 closure = nothing,
+                                 momentum_advection = nothing,
+                                 tracer_advection = nothing,
+                                 radiative_forcing = nothing,
+                                 bottom_drag_coefficient = 0,
+                                 timestepper,
+                                 additional_surface_fluxes = (; S=restoring),
+                                 warn = false)
+
+        set!(ocean.model, T=10, S=35)
+        salt_content = Field(Integral(ocean.model.tracers.S))
+        initial_salt = only(Array(interior(compute!(salt_content))))
+
+        refresh = ConservativeSurfaceFluxRestoringCallback(restoring, ocean.model)
+        add_callback!(ocean, refresh, IterationInterval(1); name=:conservative_restoring)
+        ocean.stop_iteration = 4
+        run!(ocean)
+
+        salinity = Array(interior(ocean.model.tracers.S))
+        final_salt = only(Array(interior(compute!(salt_content))))
+        @test final_salt ≈ initial_salt rtol=1e-10
+        @test maximum(salinity) - minimum(salinity) > 0
+    end
+end


### PR DESCRIPTION
Surface salinity restoring can carry a nonzero global mean and drift total ocean salt when the model mean differs from the target climatology. This adds `ConservativeSurfaceFluxRestoring`, which materializes the restoring flux and removes its wet-area mean before the boundary condition applies it.

The accompanying callback initializes the corrected field at the start of `run!` and refreshes it once per timestep. The integration test exercises both supported ocean timesteppers and verifies that restoring changes the salinity pattern while conserving volume-integrated salt on CPU and GPU test jobs.

Validation: `git diff --check`. Repository policy delegates test execution to GitHub CI.
