### PR TITLE
Introduce a ``nested'' ocean model

### DIFF
--- a/ext/NumericalEarthBreezeExt/breeze_nested_atmosphere.jl
+++ b/ext/NumericalEarthBreezeExt/breeze_nested_atmosphere.jl
@@ -15,7 +15,7 @@ using NumericalEarth.Atmospheres: PrescribedAtmosphere
 using NumericalEarth.DataWrangling: default_download_directory, default_horizontal_padding,
                                     matching_single_level_dataset
 using NumericalEarth.NestedModels: NestedModel, parent_boundary_conditions, parent_forcings,
-                                   blend_parent_terrain!
+                                   blend_parent_terrain!, davies_relaxation_mask, SmoothStepRamp
 using Oceananigans: Oceananigans, WENO
 using Oceananigans.Architectures: architecture
 using Oceananigans.BoundaryConditions: ValueBoundaryCondition, NormalFlowBoundaryCondition
@@ -23,7 +23,7 @@ using Oceananigans.Coriolis: SphericalCoriolis
 using Oceananigans.Fields: AbstractField, CenterField, Field, XFaceField, YFaceField,
                            compute!, interior, interpolate!, set!
 using Oceananigans.Forcings: Relaxation
-using Oceananigans.Grids: znode, λnodes, φnodes, minimum_xspacing, Center, Face
+using Oceananigans.Grids: znode, minimum_xspacing, Center, Face
 using Oceananigans.TimeSteppers: update_state!
 using Oceananigans.Units: Time
 using GPUArraysCore: @allowscalar
@@ -39,27 +39,6 @@ function default_nested_microphysics()
     ext = Base.get_extension(Breeze, :BreezeCloudMicrophysicsExt)
     isnothing(ext) && return SaturationAdjustment(equilibrium = WarmPhaseEquilibrium())
     return ext.OneMomentCloudMicrophysics(cloud_formation = SaturationAdjustment(equilibrium = MixedPhaseEquilibrium()))
-end
-
-# Ramp shapes (isbits callables) for a nudging zone: weight vs. normalized distance from the wall, s ∈ [0, 1].
-# Contract: ramp(0)=1, ramp(1)=0, monotone between.
-struct CosineRamp end
-struct SmoothStepRamp end
-
-@inline (::CosineRamp)(s)     = (1 + cos(π * s)) / 2
-@inline (::SmoothStepRamp)(s) = 1 - s^2 * (3 - 2s)
-
-# Davies mask: 1 at the lateral walls, ramping to 0 over the outermost `width` cells.
-function davies_relaxation_mask(grid, width; ramp = CosineRamp())
-    λ₁, λ₂ = extrema(λnodes(grid, Face(), Center(), Center()))
-    φ₁, φ₂ = extrema(φnodes(grid, Center(), Face(), Center()))
-    Nx, Ny, _ = size(grid)
-    w = width * max((λ₂ - λ₁) / Nx, (φ₂ - φ₁) / Ny)
-    return (λ, φ, z) -> begin
-        d = min(λ - λ₁, λ₂ - λ, φ - φ₁, φ₂ - φ)
-        s = clamp(d / w, zero(d), one(d))
-        return oftype(d, ramp(s))
-    end
 end
 
 # Cubic-ramp (smoothstep) Rayleigh mask over the top `depth` metres of the domain, for the ρw lid sponge.

--- a/src/Atmospheres/Atmospheres.jl
+++ b/src/Atmospheres/Atmospheres.jl
@@ -19,6 +19,7 @@ using Oceananigans.Utils: Utils, prettysummary, launch!
 using Thermodynamics.Parameters: AbstractThermodynamicsParameters
 
 using ...NumericalEarth: NumericalEarth
+using ..Grids: is_three_dimensional
 using ..EarthSystemModels: EarthSystemModels, AbstractPrescribedComponent, set_prescribed_field!
 using ..EarthSystemModels.InterfaceComputations: interface_kernel_parameters, ComponentExchanger
 

--- a/src/Atmospheres/prescribed_atmosphere.jl
+++ b/src/Atmospheres/prescribed_atmosphere.jl
@@ -58,12 +58,8 @@ function velocity_boundary_conditions(grid::OrthogonalSphericalShellGrids.Tripol
     return FieldBoundaryConditions(grid, loc; north = north_boundary_condition)
 end
 
-# Surface (2D, z-`Nothing`) vs 3D (z-`Center`) defaults are inferred from the grid's vertical size:
-# `Nz == 1` ⇒ surface forcing (ocean / sea-ice coupling); `Nz > 1` ⇒ a 3D atmosphere (e.g. a
-# `NestedSimulation` parent). A single-level grid — even one with a `Bounded` z, like an ocean
-# coupling grid — is treated as surface. Dataset builders pass their own fields explicitly and so are
-# unaffected; only the `default_*` paths consult this. Override any field via kwarg.
-@inline is_three_dimensional(grid) = size(grid, 3) > 1
+# Dataset builders pass their own fields explicitly and so are unaffected by
+# `is_three_dimensional`; only the `default_*` paths consult it. Override any field via kwarg.
 
 function default_atmosphere_velocities(grid, times)
     # The horizontal velocity boundary conditions carry the tripolar north-fold sign flip, a property

--- a/src/Bathymetry/Bathymetry.jl
+++ b/src/Bathymetry/Bathymetry.jl
@@ -1,6 +1,6 @@
 module Bathymetry
 
-export regrid_bathymetry, regrid_topography, ORCAGrid
+export regrid_bathymetry, regrid_topography, bathymetry_from_missing_values, ORCAGrid
 
 using Downloads: Downloads, download
 using ImageMorphology: ImageMorphology
@@ -11,8 +11,9 @@ using Oceananigans.Architectures: architecture, CPU, on_architecture
 using Oceananigans.BoundaryConditions: BoundaryConditions
 using Oceananigans.DistributedComputations: DistributedComputations, DistributedGrid,
                                             reconstruct_global_grid, all_reduce
+using DocStringExtensions: TYPEDSIGNATURES
 using Oceananigans.Fields: Field, interior, interpolate!
-using Oceananigans.Grids: x_domain, y_domain, topology, Face, Center,
+using Oceananigans.Grids: x_domain, y_domain, topology, znode, Face, Center,
                           Flat, Periodic, Bounded,
                           RectilinearGrid, LatitudeLongitudeGrid, OrthogonalSphericalShellGrid
 using Oceananigans.Utils: launch!, worksize
@@ -25,6 +26,7 @@ using ..DataWrangling: DataWrangling, Metadatum, native_grid, metadata_path,
 using ..DataWrangling.ETOPO: ETOPO2022
 
 include("regrid_bathymetry.jl")
+include("bathymetry_from_missing_values.jl")
 include("orca_grid.jl")
 
 end # module

--- a/src/Bathymetry/bathymetry_from_missing_values.jl
+++ b/src/Bathymetry/bathymetry_from_missing_values.jl
@@ -1,0 +1,55 @@
+#####
+##### Bathymetry derived from where a three-dimensional ocean dataset has missing values
+#####
+#
+# A reanalysis like GLORYS marks the seafloor implicitly: cells below it hold the product's missing
+# value. That mask IS the bathymetry, and it is the only record of it — `Field`/`FieldTimeSeries`
+# inpaint by default, filling those cells with propagated ocean values, so the seafloor cannot be
+# recovered downstream. Deriving it here, from the raw field, is what lets a nested child's boundary
+# bathymetry be made consistent with the parent state that drives it.
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the bottom height (m, negative below sea level) implied by `mask`, a three-dimensional boolean
+field that is `true` where a dataset has no data. The seafloor of a column is the bottom face of its
+deepest wet cell; a column that is wet nowhere sits at sea level.
+"""
+function bottom_height_from_mask(mask)
+    grid = mask.grid
+    bottom_height = Field{Center, Center, Nothing}(grid)
+    launch!(architecture(grid), grid, :xy, _bottom_height_from_mask!, bottom_height, grid, mask)
+    return bottom_height
+end
+
+# `z` is ordered bottom-to-top, so sweeping downward in `k` leaves the deepest wet cell's bottom face
+# as the last value written.
+@kernel function _bottom_height_from_mask!(bottom_height, grid, mask)
+    i, j = @index(Global, NTuple)
+
+    zᵇ = zero(grid)
+    for k in size(grid, 3):-1:1
+        wet = @inbounds !mask[i, j, k]
+        zᵇ = ifelse(wet, znode(i, j, k, grid, Center(), Center(), Face()), zᵇ)
+    end
+
+    @inbounds bottom_height[i, j, 1] = zᵇ
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Regrid onto `target_grid` the bathymetry implied by `metadatum`'s missing values — the seafloor a
+three-dimensional ocean dataset carries implicitly through its land mask. The field is read without
+inpainting, so the mask survives to be read.
+"""
+function bathymetry_from_missing_values(target_grid, metadatum::Metadatum)
+    arch = architecture(target_grid)
+    dataset_field = Field(metadatum, arch; inpainting = nothing)
+    dataset_bottom_height = bottom_height_from_mask(DataWrangling.compute_mask(metadatum, dataset_field))
+
+    bottom_height = Field{Center, Center, Nothing}(target_grid)
+    interpolate!(bottom_height, dataset_bottom_height)
+
+    return bottom_height
+end

--- a/src/DataWrangling/GLORYS/GLORYS.jl
+++ b/src/DataWrangling/GLORYS/GLORYS.jl
@@ -64,6 +64,10 @@ Base.size(::GLORYSMetadatum) = (4320, 2040, 50, 1)
 
 reversed_vertical_axis(::GLORYSDataset) = true
 
+# Two native (1/12°) cells of margin, so a nested child's lateral-boundary interpolation stencils
+# stay inside the parent region.
+DataWrangling.default_horizontal_padding(::GLORYSDataset) = 1/6
+
 available_variables(::GLORYSDataset) = GLORYS_dataset_variable_names
 
 GLORYS_dataset_variable_names = Dict(

--- a/src/Diagnostics/interface_fluxes.jl
+++ b/src/Diagnostics/interface_fluxes.jl
@@ -37,7 +37,7 @@ end
 Return the net temperature flux (K m s⁻¹) at the ocean's surface in a coupled `esm`.
 """
 function net_ocean_temperature_flux(esm::EarthSystemModel)
-    Jᵀ = flux_field(esm.ocean.model.tracers.T.boundary_conditions.top.condition)
+    Jᵀ = flux_field(underlying_ocean_model(esm.ocean).tracers.T.boundary_conditions.top.condition)
     return Jᵀ + frazil_temperature_flux(esm)
 end
 
@@ -129,7 +129,7 @@ end
 Return the net salinity flux (g/kg m s⁻¹) at the ocean's surface in a coupled `esm`.
 """
 net_ocean_salinity_flux(esm::EarthSystemModel) =
-    flux_field(esm.ocean.model.tracers.S.boundary_conditions.top.condition)
+    flux_field(underlying_ocean_model(esm.ocean).tracers.S.boundary_conditions.top.condition)
 
 
 """

--- a/src/Diagnostics/meridional_heat_transport.jl
+++ b/src/Diagnostics/meridional_heat_transport.jl
@@ -75,7 +75,7 @@ Integral of BinaryOperation at (Center, Face, Center) over dims (1, 3)
 """
 function meridional_heat_transport(esm::EarthSystemModel; reference_temperature=0)
 
-    grid = esm.ocean.model.grid
+    grid = underlying_ocean_model(esm.ocean).grid
 
     validation_grid = grid isa ImmersedBoundaryGrid ? grid.underlying_grid : grid
 
@@ -88,8 +88,8 @@ function meridional_heat_transport(esm::EarthSystemModel; reference_temperature=
     ρᵒᶜ = reference_density(esm.ocean)
     cᵒᶜ = heat_capacity(esm.ocean)
 
-    T = esm.ocean.model.tracers.T
-    v = esm.ocean.model.velocities.v
+    T = underlying_ocean_model(esm.ocean).tracers.T
+    v = underlying_ocean_model(esm.ocean).velocities.v
 
     MHT = Integral(ρᵒᶜ * cᵒᶜ * v * (T - reference_temperature), dims=(1, 3))
     return MHT

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -1,7 +1,17 @@
 module Grids
 
-export PressureLevelVerticalDiscretization, PressureLevelGrid, surface_elevation
+export PressureLevelVerticalDiscretization, PressureLevelGrid, surface_elevation, is_three_dimensional
 
 include("pressure_level_vertical_discretization.jl")
+
+"""
+    is_three_dimensional(grid)
+
+Whether a prescribed component over `grid` carries volumetric (z-`Center`) fields rather than surface
+(z-`Nothing`) ones. `Nz == 1` ⇒ surface forcing (ocean / sea-ice coupling); `Nz > 1` ⇒ a volumetric
+state, such as the parent of a nest. A single-level grid — even one with a `Bounded` z, like an ocean
+coupling grid — is treated as surface.
+"""
+@inline is_three_dimensional(grid) = size(grid, 3) > 1
 
 end # module

--- a/src/NestedModels/NestedModels.jl
+++ b/src/NestedModels/NestedModels.jl
@@ -1,7 +1,8 @@
 module NestedModels
 
-export NestedModel, NestedSimulation, nested_atmosphere_model,
+export NestedModel, NestedSimulation, nested_atmosphere_model, nested_ocean_model,
        parent_boundary_conditions, parent_forcings, blend_parent_terrain!,
+       davies_relaxation_mask, CosineRamp, SmoothStepRamp,
        exchange_state!, total_density, reconstruct_parent_state
 
 # Model-specific extension point (methods defined in the Breeze extension):
@@ -10,6 +11,11 @@ export NestedModel, NestedSimulation, nested_atmosphere_model,
 # The child's lateral BCs / interior relaxation are built from the exchanger's parent-derived prognostic
 # `FieldTimeSeries` via the generic `parent_boundary_conditions` / `parent_forcings`.
 function nested_atmosphere_model end
+
+# `nested_ocean_model(parent, child_grid; …)` builds a child ocean over `child_grid` driven by `parent`
+# (lateral open boundary conditions + interior Davies relaxation), wrapped in a `NestedModel`. Methods
+# live in the `NestedOceans` submodule, which is loaded after `Oceans` and `DataWrangling`.
+function nested_ocean_model end
 
 # Total air density ρ = ρᵈ + Σρqˣ from a state exchanger's density-weighted prognostics at time index
 # `n` (method in the Breeze extension). Centralizes the partial-density sum so recovering specific
@@ -23,14 +29,16 @@ function total_density end
 # (method in the Breeze extension).
 function reconstruct_parent_state end
 
+using DocStringExtensions: TYPEDSIGNATURES
 using Oceananigans
 using Oceananigans.Forcings: Relaxation
-using Oceananigans.Grids: AbstractGrid
+using Oceananigans.Grids: AbstractGrid, Center, Face, xnodes, ynodes
 using Oceananigans.BoundaryConditions: NormalFlowBoundaryCondition, FieldBoundaryConditions
 using Oceananigans.Simulations: Simulation
 using Oceananigans.Units: Time
 
 include("nested_model.jl")
+include("relaxation_masks.jl")
 include("nested_simulation.jl")
 include("interpolated_fts_boundary.jl")
 include("parent_boundary_conditions.jl")

--- a/src/NestedModels/parent_boundary_conditions.jl
+++ b/src/NestedModels/parent_boundary_conditions.jl
@@ -35,10 +35,10 @@ Arguments
 - `sides`: a tuple of `Symbol`s naming which boundaries to drive. Choices are
   `:west, :east, :south, :north, :bottom, :top`.
 
-- `schemes`: optional `NamedTuple` keyed by child field name giving the
-  `NormalFlowBoundaryCondition` scheme (e.g. a `PerturbationAdvection`). Fields not
-  listed default to `scheme = nothing` (stiff Dirichlet). Only consulted when
-  the BC type for that field is `NormalFlowBoundaryCondition`.
+- `schemes`: optional `NamedTuple` keyed by child field name giving the open-boundary scheme (e.g. a
+  `PerturbationAdvection` or a `NormalRadiation`). Fields not listed default to `scheme = nothing`
+  (stiff Dirichlet). The scheme is carried by the boundary condition's classification, so it applies
+  to whichever BC type that field uses.
 
 - `bc_types`: optional `NamedTuple` keyed by child field name giving the BC
   constructor to use for that field. Each entry is either a single BC constructor
@@ -62,18 +62,11 @@ function parent_boundary_conditions(grid;
         scheme    = haskey(schemes, child_name) ? getproperty(schemes, child_name) : nothing
         condition = Interpolated(fts)
 
-        # `spec` is either one BC constructor for all sides or a per-side NamedTuple; `scheme`
-        # (e.g. PerturbationAdvection) is consulted only where the chosen type is NormalFlow.
+        # `spec` is either one BC constructor for all sides or a per-side NamedTuple. An open-boundary
+        # `scheme` is carried by the classification, so it reaches `NormalFlowBoundaryCondition` (normal
+        # velocities) and `ValueBoundaryCondition` (tracers, tangential velocities) alike.
         bc_type(side) = spec isa NamedTuple ? getproperty(spec, side) : spec
-        bc_at(side)   = bc_type(side) === NormalFlowBoundaryCondition ?
-                            NormalFlowBoundaryCondition(condition; scheme) : bc_type(side)(condition)
-
-        # A `scheme` only takes effect on NormalFlow sides; requesting one for a field that is
-        # NormalFlow on no side means it would be silently ignored — flag that as a user error.
-        if haskey(schemes, child_name) && !any(side -> bc_type(side) === NormalFlowBoundaryCondition, sides)
-            throw(ArgumentError("`schemes` was given for :$child_name, but none of its sides use a " *
-                                "NormalFlowBoundaryCondition, so the scheme would be ignored."))
-        end
+        bc_at(side)   = isnothing(scheme) ? bc_type(side)(condition) : bc_type(side)(condition; scheme)
 
         side_pairs = [side => bc_at(side) for side in sides]
         push!(field_pairs, child_name => FieldBoundaryConditions(; side_pairs...))

--- a/src/NestedModels/relaxation_masks.jl
+++ b/src/NestedModels/relaxation_masks.jl
@@ -1,0 +1,33 @@
+#####
+##### Relaxation-zone masks shared by nested children
+#####
+#
+# Ramp shapes are isbits callables giving the nudging weight against the normalized distance from a
+# wall, s ∈ [0, 1]. The contract is ramp(0) = 1, ramp(1) = 0, monotone in between.
+
+struct CosineRamp end
+struct SmoothStepRamp end
+
+@inline (::CosineRamp)(s)     = (1 + cos(π * s)) / 2
+@inline (::SmoothStepRamp)(s) = 1 - s^2 * (3 - 2s)
+
+"""
+$(TYPEDSIGNATURES)
+
+Return a callable `(x, y, z) -> [0, 1]` that is 1 at the lateral walls of `grid` and ramps to 0 over
+the outermost `width` cells, following `ramp`. This is the Davies relaxation zone of a nested child:
+pass it as the `mask` of [`parent_forcings`](@ref) so the interior nudging toward the parent acts only
+near the open boundaries.
+"""
+function davies_relaxation_mask(grid, width; ramp = CosineRamp())
+    x₁, x₂ = extrema(xnodes(grid, Face(), Center(), Center()))
+    y₁, y₂ = extrema(ynodes(grid, Center(), Face(), Center()))
+    Nx, Ny, _ = size(grid)
+    w = width * max((x₂ - x₁) / Nx, (y₂ - y₁) / Ny)
+
+    return (x, y, z) -> begin
+        d = min(x - x₁, x₂ - x, y - y₁, y₂ - y)
+        s = clamp(d / w, zero(d), one(d))
+        return oftype(d, ramp(s))
+    end
+end

--- a/src/NestedOceans/NestedOceans.jl
+++ b/src/NestedOceans/NestedOceans.jl
@@ -1,0 +1,36 @@
+module NestedOceans
+
+export nested_ocean_model, nested_ocean_grid, ocean_state_exchanger, OceanStateExchanger,
+       parent_ocean_variables
+
+using DocStringExtensions: TYPEDSIGNATURES
+using KernelAbstractions: @kernel, @index
+using Oceananigans: Oceananigans, instantiated_location
+using Oceananigans.Architectures: Architectures, on_architecture
+using Oceananigans.BoundaryConditions: FieldBoundaryConditions, GravityWaveRadiationBoundaryCondition,
+                                       NormalFlowBoundaryCondition, NormalRadiation, ValueBoundaryCondition
+using Oceananigans.Fields: interpolate, set!
+using Oceananigans.Grids: AbstractGrid, Center, Face, inactive_node, node
+using Oceananigans.ImmersedBoundaries: GridFittedBottom, ImmersedBoundaryGrid
+using Oceananigans.Operators: Δzᶠᶜᶜ, Δzᶜᶠᶜ
+using Oceananigans.OutputReaders: FieldTimeSeries
+using Oceananigans.OutputReaders: Linear as LinearTimeIndexing
+using Oceananigans.TimeSteppers: Clock, update_state!
+using Oceananigans.Units: Time, days
+using Oceananigans.Utils: launch!
+
+using ..Bathymetry: bathymetry_from_missing_values, regrid_bathymetry
+using ..DataWrangling: BoundingBox, Metadata, Metadatum, MetadataSet,
+                       default_download_directory, default_horizontal_padding
+using ..DataWrangling.ETOPO: ETOPO2022
+using ..Grids: is_three_dimensional
+using ..NestedModels: NestedModels, NestedModel, blend_parent_terrain!, davies_relaxation_mask,
+                      parent_boundary_conditions, parent_forcings
+using ..Oceans: PrescribedOcean, default_free_surface, ocean_model, update_prescribed_ocean_series!
+
+include("parent_ocean_variables.jl")
+include("ocean_state_exchanger.jl")
+include("nested_ocean_grid.jl")
+include("nested_ocean_model.jl")
+
+end # module NestedOceans

--- a/src/NestedOceans/nested_ocean_grid.jl
+++ b/src/NestedOceans/nested_ocean_grid.jl
@@ -1,0 +1,45 @@
+#####
+##### nested_ocean_grid: a child grid whose bathymetry matches the parent's at the open boundaries
+#####
+#
+# The child's lateral boundaries carry a transport integrated over the child's own column, so where the
+# child's seafloor disagrees with the parent's, the prescribed transport does not fit the geometry it is
+# imposed on. Blending the child bathymetry toward the parent's over an outer frame removes that
+# mismatch at the walls while leaving the interior at the child's own resolution.
+#
+# This is a grid-level constructor rather than a `nested_ocean_model` keyword because the bathymetry is
+# fixed when the `ImmersedBoundaryGrid` is built — `compute_numerical_bottom_height!` snaps the bottom to
+# cell interfaces there — so by the time a model receives its grid the blend is already too late.
+
+"""
+$(TYPEDSIGNATURES)
+
+Build the `ImmersedBoundaryGrid` of a nested ocean child over `underlying_grid`: bathymetry regridded
+from `bathymetry_dataset`, blended toward `parent_dataset`'s own seafloor over the outermost
+`blend_width` cells so the geometry at the open boundaries matches the state that will drive them.
+
+The parent's seafloor is derived from where `parent_dataset` has missing values at `date` — the only
+record of it, since the parent series are inpainted (see [`bathymetry_from_missing_values`](@ref)). Pass
+`blend_width = 0` to keep the child's own bathymetry everywhere.
+
+Additional keyword arguments flow to `regrid_bathymetry`.
+"""
+function nested_ocean_grid(underlying_grid, parent_dataset;
+                           date,
+                           bathymetry_dataset = ETOPO2022(),
+                           blend_width = 5,
+                           parent_padding = default_horizontal_padding(parent_dataset),
+                           dir = default_download_directory(parent_dataset),
+                           kw...)
+
+    bottom_height = regrid_bathymetry(underlying_grid; dataset = bathymetry_dataset, kw...)
+
+    if blend_width > 0
+        region = BoundingBox(underlying_grid; padding = parent_padding)
+        metadatum = Metadatum(:temperature; dataset = parent_dataset, date, region, dir)
+        parent_bottom_height = bathymetry_from_missing_values(underlying_grid, metadatum)
+        blend_parent_terrain!(bottom_height, parent_bottom_height; width = blend_width)
+    end
+
+    return ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(bottom_height))
+end

--- a/src/NestedOceans/nested_ocean_model.jl
+++ b/src/NestedOceans/nested_ocean_model.jl
@@ -1,0 +1,178 @@
+#####
+##### Nested-ocean model: an Oceananigans child driven by a parent ocean state.
+#####
+#
+# The parent carries the child's own variables (u, v, T, S, η), so the lateral boundary conditions and
+# the interior Davies relaxation interpolate the parent series directly — no combine, unlike the
+# atmosphere nest. What the parent does not carry is the barotropic transport the Flather condition
+# needs; the `OceanStateExchanger` derives it over the child's own column depth (see
+# `ocean_state_exchanger.jl`).
+
+const OCEAN_SIDES = (:west, :east, :south, :north)
+
+# The parent velocity that crosses each side, and hence drives its normal-flow boundary condition.
+side_normal_velocity(side) = side in (:west, :east) ? :u : :v
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the `(Uᵉˣᵗ, ηᵉˣᵗ)` Flather boundary conditions for the barotropic transports `U` and `V`,
+reading the exchanger slabs that [`exchange_state!`](@ref) refreshes each step.
+"""
+function barotropic_boundary_conditions(exchanger; sides = OCEAN_SIDES, gravitational_acceleration)
+    zonal = filter(side -> side in (:west, :east), sides)
+    meridional = filter(side -> side in (:south, :north), sides)
+
+    flather(side) = (slabs = getproperty(exchanger.boundaries, side);
+                     GravityWaveRadiationBoundaryCondition((slabs.U, slabs.η); gravitational_acceleration))
+
+    boundary_conditions = NamedTuple()
+
+    if !isempty(zonal)
+        U = FieldBoundaryConditions(; NamedTuple(side => flather(side) for side in zonal)...)
+        boundary_conditions = merge(boundary_conditions, (; U))
+    end
+
+    if !isempty(meridional)
+        V = FieldBoundaryConditions(; NamedTuple(side => flather(side) for side in meridional)...)
+        boundary_conditions = merge(boundary_conditions, (; V))
+    end
+
+    return boundary_conditions
+end
+
+# Momentum radiates as a `NormalFlowBoundaryCondition` on the side its own face coincides with, and as a
+# `ValueBoundaryCondition` on the tangential sides, where a normal-flow fill would leave it
+# under-constrained — the same per-side split the atmosphere nest uses for `ρu`/`ρv`.
+function baroclinic_boundary_condition_types(sides)
+    momentum_type(component, side) =
+        side_normal_velocity(side) === component ? NormalFlowBoundaryCondition : ValueBoundaryCondition
+
+    u = NamedTuple(side => momentum_type(:u, side) for side in sides)
+    v = NamedTuple(side => momentum_type(:v, side) for side in sides)
+
+    return (; u, v, T = ValueBoundaryCondition, S = ValueBoundaryCondition)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build a child ocean over `child_grid` nested in `parent_ocean` — a volumetric [`PrescribedOcean`](@ref)
+carrying the parent's `u`, `v`, `T`, `S` and `η` — wrapped in a `NestedModel`.
+
+The child's baroclinic velocities and tracers radiate through `NormalRadiation` (Orlanski, with
+Marchesiello et al. adaptive nudging toward the parent at `inflow_timescale`/`outflow_timescale`), and
+its barotropic transport through `GravityWaveRadiation` (Flather) against the exterior transport the
+exchanger integrates over the child's own column. Oceananigans pairs the free surface's Chapman
+companion condition automatically on the Flather sides.
+
+When `relaxation_rate` (s⁻¹) is given, the child interior is additionally relaxed toward the parent
+over `relaxation_mask` — by default a cosine ramp over the outermost `relaxation_width` cells.
+
+Any `boundary_conditions`/`forcing` the caller passes are merged with the parent-derived ones (caller
+wins), and remaining keyword arguments flow to `ocean_model`.
+"""
+function NestedModels.nested_ocean_model(parent_ocean::PrescribedOcean, child_grid::AbstractGrid;
+                                         sides = OCEAN_SIDES,
+                                         inflow_timescale = 1days,
+                                         outflow_timescale = 360days,
+                                         relaxation_rate = nothing,
+                                         relaxation_width = 5,
+                                         relaxation_mask = davies_relaxation_mask(child_grid, relaxation_width),
+                                         gravitational_acceleration = Oceananigans.defaults.gravitational_acceleration,
+                                         free_surface = default_free_surface(child_grid),
+                                         boundary_conditions = NamedTuple(),
+                                         forcing = NamedTuple(),
+                                         kw...)
+
+    is_three_dimensional(parent_ocean.grid) || throw(ArgumentError(
+        "a nested ocean needs a volumetric parent; `PrescribedOcean` over a single-level grid carries " *
+        "surface fields only, which cannot drive the child's baroclinic boundaries"))
+
+    exchanger = ocean_state_exchanger(parent_ocean, child_grid; sides)
+
+    radiation = NormalRadiation(eltype(child_grid); inflow_timescale, outflow_timescale)
+    schemes = (u = radiation, v = radiation, T = radiation, S = radiation)
+    bc_types = baroclinic_boundary_condition_types(sides)
+    variables = (u = exchanger.variables.u, v = exchanger.variables.v,
+                 T = exchanger.variables.T, S = exchanger.variables.S)
+
+    baroclinic_bcs = parent_boundary_conditions(child_grid; variables, sides, schemes, bc_types)
+    barotropic_bcs = barotropic_boundary_conditions(exchanger; sides, gravitational_acceleration)
+    nested_bcs = merge(baroclinic_bcs, barotropic_bcs)
+
+    davies = if isnothing(relaxation_rate)
+        NamedTuple()
+    else
+        mask = relaxation_mask isa Number ? Returns(relaxation_mask) : relaxation_mask
+        parent_forcings(; variables, rate = relaxation_rate, mask)
+    end
+
+    child = ocean_model(child_grid;
+                        free_surface,
+                        gravitational_acceleration,
+                        boundary_conditions = merge(nested_bcs, NamedTuple(boundary_conditions)),
+                        forcing = merge(davies, NamedTuple(forcing)),
+                        kw...)
+
+    return NestedModel(parent_ocean, child, exchanger)
+end
+
+# The parent a nested ocean child is driven by, on the dataset's native grid over `region`.
+function prescribed_parent_ocean(dataset, region, dates, architecture, FT, dir)
+    series(name) = FieldTimeSeries(Metadata(name; dataset, dates, region, dir), architecture;
+                                   time_indexing = LinearTimeIndexing())
+
+    temperature = series(:temperature)
+
+    return PrescribedOcean(temperature.grid, temperature.times;
+                           FT,
+                           clock = Clock{FT}(time = 0),
+                           temperature,
+                           salinity = series(:salinity),
+                           velocities = (u = series(:u_velocity), v = series(:v_velocity)),
+                           free_surface = series(:free_surface))
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build the parent ocean state from `parent_dataset`, nest a child ocean in it over `child_grid`, and
+initialize the child from the same dataset at `first(dates)` — the returned model is ready to step.
+
+The parent spans `child_grid`'s bounding box padded by `parent_padding` (default `parent_dataset`'s
+`default_horizontal_padding`, margin for the lateral-boundary interpolation stencils) at `dates`, on
+`parent_dataset`'s native grid. The child is initialized through the same interpolation that drives its
+boundaries, so interior and wall agree at `first(dates)` and no standing jump forces the walls.
+
+Remaining keyword arguments flow to `nested_ocean_model(parent_ocean, child_grid; kw...)`.
+"""
+function NestedModels.nested_ocean_model(child_grid::AbstractGrid, parent_dataset;
+                                         dates,
+                                         dir = default_download_directory(parent_dataset),
+                                         parent_padding = default_horizontal_padding(parent_dataset),
+                                         kw...)
+
+    architecture = Architectures.architecture(child_grid)
+    parent_region = BoundingBox(child_grid; padding = parent_padding)
+    parent_ocean = prescribed_parent_ocean(parent_dataset, parent_region, dates, architecture,
+                                           eltype(child_grid), dir)
+
+    nested_model = NestedModels.nested_ocean_model(parent_ocean, child_grid; kw...)
+    initialize_nested_child!(nested_model, parent_dataset, first(dates), parent_region, dir)
+
+    return nested_model
+end
+
+# Initialize the child from the SAME parent-derived state that drives its lateral boundaries, so the
+# interior initial condition and the prescribed boundary agree at the walls.
+function initialize_nested_child!(nested_model, dataset, date, region, dir)
+    child = nested_model.child
+    variables = (:temperature, :salinity, :u_velocity, :v_velocity, :free_surface)
+    metadata_set = MetadataSet(variables; dataset, date, region, dir)
+
+    set!(child, metadata_set)
+    update_state!(nested_model)
+
+    return nested_model
+end

--- a/src/NestedOceans/ocean_state_exchanger.jl
+++ b/src/NestedOceans/ocean_state_exchanger.jl
@@ -1,0 +1,130 @@
+#####
+##### OceanStateExchanger: parent-derived state a nested ocean child needs each step
+#####
+#
+# The parent hands over the child's own variables (u, v, T, S, η), so — unlike the atmosphere nest —
+# there is no thermodynamic combine. What the parent does NOT carry is the barotropic transport the
+# Flather (`GravityWaveRadiation`) condition needs. The exchanger builds it, per side, by integrating
+# the interpolated parent velocity over the CHILD's column: integrating over the parent's column
+# instead would prescribe a transport that does not fit the child's bathymetry, and the domain would
+# leak volume.
+#
+# `GravityWaveRadiation`'s exterior value is a 2-tuple whose elements may be arrays, so each side's
+# condition is literally `(Uᵉˣᵗ, ηᵉˣᵗ)` — two slabs this exchanger refreshes.
+
+struct OceanStateExchanger{P, V, B, G}
+    parent_ocean :: P   # the parent whose series drive the child (e.g. a volumetric `PrescribedOcean`)
+    variables    :: V   # (u, v, T, S, η) drawn from the parent by `parent_ocean_variables`
+    boundaries   :: B   # NamedTuple keyed by side: (U = array, η = array) on the child boundary
+    grid         :: G   # the child grid
+end
+
+@inline boundary_index(::Val{:west},  N) = 1
+@inline boundary_index(::Val{:south}, N) = 1
+@inline boundary_index(::Val{:east},  N) = N + 1
+@inline boundary_index(::Val{:north}, N) = N + 1
+
+@inline normal_dimension(::Union{Val{:west}, Val{:east}}) = 1
+@inline normal_dimension(::Union{Val{:south}, Val{:north}}) = 2
+
+@kernel function _compute_zonal_boundary_transport!(U, η, iᵇ, grid, uᵖ, uᵍ, ηᵖ, ηᵍ, parent_location, surface_location, t)
+    j = @index(Global, Linear)
+    Nz = size(grid, 3)
+
+    Σ = zero(grid)
+    for k in 1:Nz
+        X = node(iᵇ, j, k, grid, Face(), Center(), Center())
+        uₚ = interpolate(X, Time(t), uᵖ, parent_location, uᵍ)
+        active = !inactive_node(iᵇ, j, k, grid, Face(), Center(), Center())
+        Σ += ifelse(active, Δzᶠᶜᶜ(iᵇ, j, k, grid) * uₚ, zero(grid))
+    end
+
+    Xη = node(iᵇ, j, 1, grid, Face(), Center(), Center())
+
+    @inbounds U[j, 1, 1] = Σ
+    @inbounds η[j, 1, 1] = interpolate(Xη, Time(t), ηᵖ, surface_location, ηᵍ)
+end
+
+@kernel function _compute_meridional_boundary_transport!(V, η, jᵇ, grid, vᵖ, vᵍ, ηᵖ, ηᵍ, parent_location, surface_location, t)
+    i = @index(Global, Linear)
+    Nz = size(grid, 3)
+
+    Σ = zero(grid)
+    for k in 1:Nz
+        X = node(i, jᵇ, k, grid, Center(), Face(), Center())
+        vₚ = interpolate(X, Time(t), vᵖ, parent_location, vᵍ)
+        active = !inactive_node(i, jᵇ, k, grid, Center(), Face(), Center())
+        Σ += ifelse(active, Δzᶜᶠᶜ(i, jᵇ, k, grid) * vₚ, zero(grid))
+    end
+
+    Xη = node(i, jᵇ, 1, grid, Center(), Face(), Center())
+
+    @inbounds V[i, 1, 1] = Σ
+    @inbounds η[i, 1, 1] = interpolate(Xη, Time(t), ηᵖ, surface_location, ηᵍ)
+end
+
+function boundary_transport_arrays(grid, side)
+    FT = eltype(grid)
+    Nx, Ny, _ = size(grid)
+    N = normal_dimension(Val(side)) == 1 ? Ny : Nx
+    arch = Architectures.architecture(grid)
+    U = on_architecture(arch, zeros(FT, N, 1, 1))
+    η = on_architecture(arch, zeros(FT, N, 1, 1))
+    return (; U, η)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build the state exchanger of a nested ocean: the `parent_ocean` series plus, for every side in
+`sides`, the `(Uᵉˣᵗ, ηᵉˣᵗ)` slabs that drive the child's Flather boundary condition there.
+"""
+function ocean_state_exchanger(parent_ocean, child_grid; sides = (:west, :east, :south, :north))
+    boundaries = NamedTuple(side => boundary_transport_arrays(child_grid, side) for side in sides)
+    return OceanStateExchanger(parent_ocean, parent_ocean_variables(parent_ocean), boundaries, child_grid)
+end
+
+function refresh_boundary_transport!(exchanger, side, time)
+    grid = exchanger.grid
+    Nx, Ny, _ = size(grid)
+    slabs = getproperty(exchanger.boundaries, side)
+    η = exchanger.variables.η
+    surface_location = instantiated_location(η)
+    arch = Architectures.architecture(grid)
+
+    if normal_dimension(Val(side)) == 1
+        u = exchanger.variables.u
+        iᵇ = boundary_index(Val(side), Nx)
+        launch!(arch, grid, tuple(Ny), _compute_zonal_boundary_transport!,
+                slabs.U, slabs.η, iᵇ, grid, u, u.grid, η, η.grid,
+                instantiated_location(u), surface_location, time)
+    else
+        v = exchanger.variables.v
+        jᵇ = boundary_index(Val(side), Ny)
+        launch!(arch, grid, tuple(Nx), _compute_meridional_boundary_transport!,
+                slabs.U, slabs.η, jᵇ, grid, v, v.grid, η, η.grid,
+                instantiated_location(v), surface_location, time)
+    end
+
+    return nothing
+end
+
+# Advance the parent windows, then rebuild every side's barotropic exterior from them.
+function NestedModels.exchange_state!(exchanger::OceanStateExchanger, time)
+    refresh_parent_state!(exchanger.parent_ocean, Time(time))
+
+    for side in keys(exchanger.boundaries)
+        refresh_boundary_transport!(exchanger, side, time)
+    end
+
+    return nothing
+end
+
+Base.summary(exchanger::OceanStateExchanger) =
+    string("OceanStateExchanger(sides=", keys(exchanger.boundaries), ")")
+
+function Base.show(io::IO, exchanger::OceanStateExchanger)
+    print(io, summary(exchanger), '\n',
+              "├── parent: ", summary(exchanger.parent_ocean), '\n',
+              "└── grid: ", summary(exchanger.grid))
+end

--- a/src/NestedOceans/parent_ocean_variables.jl
+++ b/src/NestedOceans/parent_ocean_variables.jl
@@ -1,0 +1,22 @@
+#####
+##### parent_ocean_variables: the parent series a nested ocean child is driven by
+#####
+#
+# Dispatched on the parent type so a prognostic parent (a live `HydrostaticFreeSurfaceModel`) can join
+# without touching the exchanger: `Interpolated` accepts a `Field` source as readily as a
+# `FieldTimeSeries`, so only this mapping and `refresh_parent_state!` differ between the two.
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the parent state driving a nested ocean child as a `NamedTuple` of `u`, `v`, `T`, `S` and `η`.
+"""
+parent_ocean_variables(parent::PrescribedOcean) = (u = parent.velocities.u,
+                                                   v = parent.velocities.v,
+                                                   T = parent.temperature,
+                                                   S = parent.salinity,
+                                                   η = parent.free_surface)
+
+# Reposition the parent's series ahead of the child's step. `NestedModel` steps the parent only after
+# the child, so the exchanger — not the parent's own `time_step!` — brackets the upcoming step.
+refresh_parent_state!(parent::PrescribedOcean, time) = update_prescribed_ocean_series!(parent, time)

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -44,6 +44,11 @@ export
     NestedModel,
     NestedSimulation,
     nested_atmosphere_model,
+    nested_ocean_model,
+    nested_ocean_grid,
+    bathymetry_from_missing_values,
+    ocean_model,
+    underlying_ocean_model,
     parent_boundary_conditions,
     parent_forcings,
     # Atmosphere-land interface closures
@@ -248,6 +253,7 @@ end
 
 include("Grids/Grids.jl")
 include("EarthSystemModels/EarthSystemModels.jl")
+include("NestedModels/NestedModels.jl")   # generic nesting core: depends only on Oceananigans
 include("Oceans/Oceans.jl")
 include("Atmospheres/Atmospheres.jl")
 include("Lands/Lands.jl")
@@ -257,7 +263,7 @@ include("InitialConditions/InitialConditions.jl")
 include("DataWrangling/DataWrangling.jl")
 include("Bathymetry/Bathymetry.jl")
 include("Diagnostics/Diagnostics.jl")
-include("NestedModels/NestedModels.jl")   # last: wraps a parent + a child (any component) model
+include("NestedOceans/NestedOceans.jl")   # last: the ocean child of a nest, over Oceans + DataWrangling
 
 using .Grids
 using .DataWrangling
@@ -273,7 +279,9 @@ using .SeaIces
 using .Diagnostics
 using .EarthSystemModels: ComponentInterfaces, MomentumRoughnessLength, ScalarRoughnessLength, default_sea_ice
 using .NestedModels
-using .NestedModels: NestedModel, NestedSimulation, nested_atmosphere_model, parent_boundary_conditions, parent_forcings
+using .NestedModels: NestedModel, NestedSimulation, nested_atmosphere_model, nested_ocean_model,
+                     parent_boundary_conditions, parent_forcings
+using .NestedOceans
 using .DataWrangling.ETOPO
 using .DataWrangling.ECCO
 using .DataWrangling.GLORYS

--- a/src/Oceans/Oceans.jl
+++ b/src/Oceans/Oceans.jl
@@ -1,6 +1,6 @@
 module Oceans
 
-export ocean_simulation, SlabOcean, PrescribedOcean
+export ocean_simulation, ocean_model, underlying_ocean_model, SlabOcean, PrescribedOcean
 
 using Adapt: Adapt, adapt
 using KernelAbstractions: @kernel, @index
@@ -38,6 +38,8 @@ using ..EarthSystemModels: EarthSystemModels,
                            default_stop_time,
                            heat_capacity
 using ..EarthSystemModels.InterfaceComputations: InterfaceComputations, ComponentExchanger
+using ..Grids: is_three_dimensional
+using ..NestedModels: NestedModel
 
 default_gravitational_acceleration = Oceananigans.defaults.gravitational_acceleration
 default_planet_rotation_rate = Oceananigans.defaults.planet_rotation_rate
@@ -77,22 +79,22 @@ include("assemble_net_ocean_fluxes.jl")
 # args in the convenience constructors (e.g. `OceanSeaIceModel`).
 EarthSystemModels.is_sea_ice_component(::OceananigansModelSimulations) = false
 
-EarthSystemModels.ocean_salinity(ocean::OceananigansModelSimulations)    = ocean.model.tracers.S
-EarthSystemModels.ocean_temperature(ocean::OceananigansModelSimulations) = ocean.model.tracers.T
+EarthSystemModels.ocean_salinity(ocean::OceananigansModelSimulations)    = underlying_ocean_model(ocean).tracers.S
+EarthSystemModels.ocean_temperature(ocean::OceananigansModelSimulations) = underlying_ocean_model(ocean).tracers.T
 
 function EarthSystemModels.ocean_surface_salinity(ocean::OceananigansModelSimulations)
-    kᴺ = size(ocean.model.grid, 3)
-    return view(ocean.model.tracers.S.data, :, :, kᴺ:kᴺ)
+    kᴺ = size(underlying_ocean_model(ocean).grid, 3)
+    return view(underlying_ocean_model(ocean).tracers.S.data, :, :, kᴺ:kᴺ)
 end
 
 function EarthSystemModels.ocean_surface_temperature(ocean::OceananigansModelSimulations)
-    kᴺ = size(ocean.model.grid, 3)
-    return view(ocean.model.tracers.T.data, :, :, kᴺ:kᴺ)
+    kᴺ = size(underlying_ocean_model(ocean).grid, 3)
+    return view(underlying_ocean_model(ocean).tracers.T.data, :, :, kᴺ:kᴺ)
 end
 
 function EarthSystemModels.ocean_surface_velocities(ocean::OceananigansModelSimulations)
-    kᴺ = size(ocean.model.grid, 3)
-    return view(ocean.model.velocities.u, :, :, kᴺ), view(ocean.model.velocities.v, :, :, kᴺ)
+    kᴺ = size(underlying_ocean_model(ocean).grid, 3)
+    return view(underlying_ocean_model(ocean).velocities.u, :, :, kᴺ), view(underlying_ocean_model(ocean).velocities.v, :, :, kᴺ)
 end
 
 # When using an Oceananigans simulation, we assume that the exchange grid is the ocean grid
@@ -100,13 +102,13 @@ end
 EarthSystemModels.interpolate_state!(exchanger, grid, ::OceananigansModelSimulations, coupled_model) = nothing
 
 function EarthSystemModels.InterfaceComputations.ComponentExchanger(ocean::OceananigansModelSimulations, grid)
-    ocean_grid = ocean.model.grid
+    ocean_grid = underlying_ocean_model(ocean).grid
 
     if ocean_grid == grid
-        u = ocean.model.velocities.u
-        v = ocean.model.velocities.v
-        T = ocean.model.tracers.T
-        S = ocean.model.tracers.S
+        u = underlying_ocean_model(ocean).velocities.u
+        v = underlying_ocean_model(ocean).velocities.v
+        T = underlying_ocean_model(ocean).tracers.T
+        S = underlying_ocean_model(ocean).tracers.S
     else
         u = Field{Center, Center, Nothing}(grid)
         v = Field{Center, Center, Nothing}(grid)
@@ -116,7 +118,7 @@ function EarthSystemModels.InterfaceComputations.ComponentExchanger(ocean::Ocean
 
     # Near-surface vertical tracer diffusivity, evaluated lazily inside the
     # interface flux kernel by formulations that consume it (`InteriorDiffusivity`).
-    model = ocean.model
+    model = underlying_ocean_model(ocean)
     temperature_index = findfirst(name -> name === :T, collect(keys(model.tracers)))
     κ = KernelFunctionOperation{Center, Center, Nothing}(Σκzᴺ,
                                                          ocean_grid,
@@ -173,15 +175,15 @@ end
 
 function EarthSystemModels.InterfaceComputations.net_fluxes(ocean::OceananigansModelSimulations)
     # TODO: Generalize this to work with any ocean model
-    τˣ = net_flux(ocean.model.velocities.u.boundary_conditions.top.condition)
-    τʸ = net_flux(ocean.model.velocities.v.boundary_conditions.top.condition)
+    τˣ = net_flux(underlying_ocean_model(ocean).velocities.u.boundary_conditions.top.condition)
+    τʸ = net_flux(underlying_ocean_model(ocean).velocities.v.boundary_conditions.top.condition)
     net_ocean_surface_fluxes = (; u=τˣ, v=τʸ)
 
-    tracers = ocean.model.tracers
+    tracers = underlying_ocean_model(ocean).tracers
     ocean_surface_tracer_fluxes = NamedTuple(name => net_flux(tracers[name].boundary_conditions.top.condition) for name in keys(tracers))
 
-    freshwater_volume_flux = extract_freshwater_flux(ocean.model.tracers.S.boundary_conditions.top.condition)
-    heat_exchange = freshwater_exchange(ocean.model.tracers.T.boundary_conditions.top.condition)
+    freshwater_volume_flux = extract_freshwater_flux(underlying_ocean_model(ocean).tracers.S.boundary_conditions.top.condition)
+    heat_exchange = freshwater_exchange(underlying_ocean_model(ocean).tracers.T.boundary_conditions.top.condition)
 
     fluxes = merge(ocean_surface_tracer_fluxes, net_ocean_surface_fluxes,
                    (; η = freshwater_volume_flux,

--- a/src/Oceans/assemble_net_ocean_fluxes.jl
+++ b/src/Oceans/assemble_net_ocean_fluxes.jl
@@ -14,7 +14,7 @@ using ..EarthSystemModels.InterfaceComputations: computed_fluxes
 EarthSystemModels.update_net_fluxes!(coupled_model::Union{NoOceanInterfaceModel, NoInterfaceModel}, ocean::OceananigansModelSimulations) = nothing
 
 EarthSystemModels.update_net_fluxes!(coupled_model, ocean::OceananigansModelSimulations) =
-    update_net_ocean_fluxes!(coupled_model, ocean, ocean.model.grid)
+    update_net_ocean_fluxes!(coupled_model, ocean, underlying_ocean_model(ocean).grid)
 
 rainfall_flux(coupled_model::NoAtmosInterfaceModel) = ZeroField(eltype(coupled_model))
 rainfall_flux(coupled_model) = coupled_model.interfaces.exchanger.atmosphere.state.Jʳⁿ.data

--- a/src/Oceans/nonhydrostatic_ocean_simulation.jl
+++ b/src/Oceans/nonhydrostatic_ocean_simulation.jl
@@ -1,11 +1,9 @@
 using SeawaterPolynomials.TEOS10: TEOS10EquationOfState
 
 """
-    nonhydrostatic_ocean_simulation(grid;
-                                    clock = Clock(grid),
-                                    stop_time = default_stop_time(grid, clock),
-                                    Δt = 1,
-                                    closure = nothing,
+    nonhydrostatic_ocean_model(grid;
+                               clock = Clock(grid),
+                               closure = nothing,
                                     tracers = (:T, :S),
                                     coriolis = nothing,
                                     reference_density = 1020,
@@ -16,8 +14,9 @@ using SeawaterPolynomials.TEOS10: TEOS10EquationOfState
                                     boundary_conditions::NamedTuple = NamedTuple(),
                                     verbose = false)
 
-Construct and return a nonhydrostatic ocean simulation suitable for Large Eddy
-Simulation (LES). Called by `ocean_simulation(grid; model=:nonhydrostatic, ...)`.
+Construct and return a nonhydrostatic ocean model suitable for Large Eddy Simulation (LES). Called by
+`ocean_model(grid; model=:nonhydrostatic, ...)`; [`nonhydrostatic_ocean_simulation`](@ref) wraps it in a
+`Simulation`.
 
 Uses Oceananigans' `NonhydrostaticModel`, which resolves the full 3D pressure field
 (no hydrostatic approximation). No free surface, barotropic forcing, or split-explicit
@@ -27,10 +26,6 @@ timestepping is needed.
 
 - `clock`: Clock for the underlying model. Defaults to `Clock(grid)`, a numeric clock starting at `time = 0`. 
   Pass a `DateTime`-based clock to step the simulation in calendar time (e.g. when coupling).
-- `stop_time`: Stop time for the simulation. Defaults to `Inf` for numeric clocks, or 
-  `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks. On Reactant architectures it defaults to `nothing`, since 
-  Reactant does not support `stop_time`.
-- `Δt`: Timestep used by the `Simulation`. Defaults to `1` second.
 - `closure`: Turbulence closure. Defaults to `nothing` (implicit LES via WENO advection scheme).
 - `tracers`: Tuple of tracer names. Defaults to `(:T, :S)`.
 - `coriolis`: Coriolis parameter. Defaults to `nothing`.
@@ -42,20 +37,18 @@ timestepping is needed.
 - `boundary_conditions`: User-supplied boundary conditions; merged with defaults.
 - `verbose`: If `true`, prints additional setup information.
 """
-function nonhydrostatic_ocean_simulation(grid;
-                                         clock = Clock(grid),
-                                         stop_time = default_stop_time(grid, clock),
-                                         Δt = 1,
-                                         closure = nothing,
-                                         tracers = (:T, :S),
-                                         coriolis = nothing,
-                                         reference_density = 1020,
-                                         gravitational_acceleration = default_gravitational_acceleration,
-                                         equation_of_state = TEOS10EquationOfState(; reference_density),
-                                         advection = WENO(order=9),
-                                         forcing = NamedTuple(),
-                                         boundary_conditions::NamedTuple = NamedTuple(),
-                                         verbose = false)
+function nonhydrostatic_ocean_model(grid;
+                                    clock = Clock(grid),
+                                    closure = nothing,
+                                    tracers = (:T, :S),
+                                    coriolis = nothing,
+                                    reference_density = 1020,
+                                    gravitational_acceleration = default_gravitational_acceleration,
+                                    equation_of_state = TEOS10EquationOfState(; reference_density),
+                                    advection = WENO(order=9),
+                                    forcing = NamedTuple(),
+                                    boundary_conditions::NamedTuple = NamedTuple(),
+                                    verbose = false)
 
     # Set up boundary conditions using Field
     top_zonal_momentum_flux      = τx = Field{Face,   Center, Nothing}(grid)
@@ -86,7 +79,22 @@ function nonhydrostatic_ocean_simulation(grid;
                                       forcing,
                                       boundary_conditions)
 
-    ocean = Simulation(ocean_model; Δt, stop_time, verbose)
+    return ocean_model
+end
 
-    return ocean
+"""
+$(TYPEDSIGNATURES)
+
+Wrap [`nonhydrostatic_ocean_model`](@ref) in a `Simulation`.
+"""
+function nonhydrostatic_ocean_simulation(grid;
+                                         clock = Clock(grid),
+                                         stop_time = default_stop_time(grid, clock),
+                                         Δt = 1,
+                                         verbose = false,
+                                         kwargs...)
+
+    ocean_model = nonhydrostatic_ocean_model(grid; clock, verbose, kwargs...)
+
+    return Simulation(ocean_model; Δt, stop_time, verbose)
 end

--- a/src/Oceans/ocean_simulation.jl
+++ b/src/Oceans/ocean_simulation.jl
@@ -237,11 +237,27 @@ function ocean_simulation(grid; model::Symbol = :hydrostatic, kwargs...)
 end
 
 """
-    hydrostatic_ocean_simulation(grid;
-                                 clock = Clock(grid),
-                                 stop_time = default_stop_time(grid, clock),
-                                 Δt = estimate_maximum_Δt(grid),
-                                 closure = default_ocean_closure(),
+$(TYPEDSIGNATURES)
+
+Build the ocean `AbstractModel` that [`ocean_simulation`](@ref) wraps, without the `Simulation` around
+it. Use this where a bare model is needed — most notably as the child of a
+[`nested_ocean_model`](@ref).
+"""
+function ocean_model(grid; model::Symbol = :hydrostatic, kwargs...)
+    if model === :hydrostatic
+        return hydrostatic_ocean_model(grid; kwargs...)
+    elseif model === :nonhydrostatic
+        return nonhydrostatic_ocean_model(grid; kwargs...)
+    else
+        throw(ArgumentError("ocean_model: unknown model $(repr(model)); " *
+                            "use :hydrostatic (default) or :nonhydrostatic."))
+    end
+end
+
+"""
+    hydrostatic_ocean_model(grid;
+                            clock = Clock(grid),
+                            closure = default_ocean_closure(),
                                  tracers = (:T, :S),
                                  free_surface = default_free_surface(grid),
                                  reference_density = 1020,
@@ -306,10 +322,6 @@ defaults on a per-field basis.
 
 - `clock`: Clock for the underlying model. Defaults to `Clock(grid)`, a numeric clock starting at `time = 0`. 
   Pass a `DateTime`-based clock to step the simulation in calendar time (e.g. when coupling).
-- `stop_time`: Stop time for the simulation. Defaults to `Inf` for numeric clocks, or 
-  `DateTime(9999, 12, 31, 23, 59, 59)` for `DateTime` clocks. On Reactant architectures it defaults to `nothing`, since 
-  Reactant does not support `stop_time`.
-- `Δt`: Timestep used by the `Simulation`. Defaults to the maximum stable timestep estimated from the `grid`.
 - `closure`: A turbulence or mixing closure. Defaults to `default_ocean_closure()`.
 - `tracers`: Tuple of tracer names. Defaults to `(:T, :S)`.
 - `free_surface`: Free–surface solver. Defaults to `default_free_surface(grid)`.
@@ -330,29 +342,27 @@ defaults on a per-field basis.
 - `warn`: If `true`, warnings are emitted for potentially unintended setups.
 - `verbose`: If `true`, prints additional setup information.
 """
-function hydrostatic_ocean_simulation(grid;
-                                      clock = Clock(grid),
-                                      stop_time = default_stop_time(grid, clock),
-                                      Δt = estimate_maximum_Δt(grid),
-                                      closure = default_ocean_closure(),
-                                      tracers = (:T, :S),
-                                      free_surface = default_free_surface(grid),
-                                      reference_density = 1020,
-                                      rotation_rate = default_planet_rotation_rate,
-                                      gravitational_acceleration = default_gravitational_acceleration,
-                                      bottom_drag_coefficient = Default(0.003),
-                                      forcing = NamedTuple(),
-                                      additional_surface_fluxes = NamedTuple(),
-                                      biogeochemistry = nothing,
-                                      timestepper = :SplitRungeKutta3,
-                                      coriolis = Default(HydrostaticSphericalCoriolis(; rotation_rate)),
-                                      momentum_advection = WENOVectorInvariant(time_discretization = AdaptiveVerticallyImplicitDiscretization(cfl=0.5)),
-                                      tracer_advection = WENO(order=7, time_discretization = AdaptiveVerticallyImplicitDiscretization(cfl=0.5)),
-                                      equation_of_state = TEOS10EquationOfState(; reference_density),
-                                      boundary_conditions::NamedTuple = NamedTuple(),
-                                      radiative_forcing = default_radiative_forcing(grid),
-                                      warn = true,
-                                      verbose = false)
+function hydrostatic_ocean_model(grid;
+                                 clock = Clock(grid),
+                                 closure = default_ocean_closure(),
+                                 tracers = (:T, :S),
+                                 free_surface = default_free_surface(grid),
+                                 reference_density = 1020,
+                                 rotation_rate = default_planet_rotation_rate,
+                                 gravitational_acceleration = default_gravitational_acceleration,
+                                 bottom_drag_coefficient = Default(0.003),
+                                 forcing = NamedTuple(),
+                                 additional_surface_fluxes = NamedTuple(),
+                                 biogeochemistry = nothing,
+                                 timestepper = :SplitRungeKutta3,
+                                 coriolis = Default(HydrostaticSphericalCoriolis(; rotation_rate)),
+                                 momentum_advection = WENOVectorInvariant(time_discretization = AdaptiveVerticallyImplicitDiscretization(cfl=0.5)),
+                                 tracer_advection = WENO(order=7, time_discretization = AdaptiveVerticallyImplicitDiscretization(cfl=0.5)),
+                                 equation_of_state = TEOS10EquationOfState(; reference_density),
+                                 boundary_conditions::NamedTuple = NamedTuple(),
+                                 radiative_forcing = default_radiative_forcing(grid),
+                                 warn = true,
+                                 verbose = false)
 
     FT = eltype(grid)
 
@@ -498,20 +508,48 @@ function hydrostatic_ocean_simulation(grid;
                                               forcing,
                                               boundary_conditions)
 
-    ocean = Simulation(ocean_model; Δt, stop_time, verbose)
+    return ocean_model
+end
 
-    return ocean
+"""
+$(TYPEDSIGNATURES)
+
+Wrap [`hydrostatic_ocean_model`](@ref) in a `Simulation`. `Δt`, `stop_time` and `verbose` configure the
+simulation; every other keyword argument flows to the model constructor.
+"""
+function hydrostatic_ocean_simulation(grid;
+                                      clock = Clock(grid),
+                                      stop_time = default_stop_time(grid, clock),
+                                      Δt = estimate_maximum_Δt(grid),
+                                      verbose = false,
+                                      kwargs...)
+
+    ocean_model = hydrostatic_ocean_model(grid; clock, verbose, kwargs...)
+
+    return Simulation(ocean_model; Δt, stop_time, verbose)
 end
 
 hasclosure(closure, ClosureType) = closure isa ClosureType
 hasclosure(closure_tuple::Tuple, ClosureType) = any(hasclosure(c, ClosureType) for c in closure_tuple)
 
+const OceananigansOceanModels = Union{HydrostaticFreeSurfaceModel, NonhydrostaticModel}
+
 const OceananigansModelSimulations = Union{
-    Simulation{<:HydrostaticFreeSurfaceModel},
-    Simulation{<:NonhydrostaticModel}
+    Simulation{<:OceananigansOceanModels},
+    Simulation{<:NestedModel{<:Any, <:OceananigansOceanModels}}
 }
 
-Grids.grid(ocean::OceananigansModelSimulations) = ocean.model.grid
+"""
+$(TYPEDSIGNATURES)
+
+Return the Oceananigans model underlying an ocean component. A nested ocean carries its prognostic
+state on the child, so the coupled interface reaches through the `NestedModel` wrapper to it.
+"""
+underlying_ocean_model(ocean::Simulation) = underlying_ocean_model(ocean.model)
+underlying_ocean_model(model::OceananigansOceanModels) = model
+underlying_ocean_model(nested::NestedModel) = underlying_ocean_model(nested.child)
+
+Grids.grid(ocean::OceananigansModelSimulations) = underlying_ocean_model(ocean).grid
 
 #####
 ##### Extending NumericalEarth interface
@@ -519,9 +557,9 @@ Grids.grid(ocean::OceananigansModelSimulations) = ocean.model.grid
 
 EarthSystemModels.reference_density(eos::TEOS10EquationOfState) = eos.reference_density
 EarthSystemModels.reference_density(buoyancy_formulation::SeawaterBuoyancy) = EarthSystemModels.reference_density(buoyancy_formulation.equation_of_state)
-EarthSystemModels.reference_density(ocean::OceananigansModelSimulations) = EarthSystemModels.reference_density(ocean.model.buoyancy.formulation)
+EarthSystemModels.reference_density(ocean::OceananigansModelSimulations) = EarthSystemModels.reference_density(underlying_ocean_model(ocean).buoyancy.formulation)
 
-EarthSystemModels.heat_capacity(ocean::OceananigansModelSimulations) = heat_capacity(ocean.model.buoyancy.formulation)
+EarthSystemModels.heat_capacity(ocean::OceananigansModelSimulations) = heat_capacity(underlying_ocean_model(ocean).buoyancy.formulation)
 EarthSystemModels.heat_capacity(buoyancy_formulation::SeawaterBuoyancy) = heat_capacity(buoyancy_formulation.equation_of_state)
 
 function EarthSystemModels.heat_capacity(::TEOS10EquationOfState{FT}) where FT

--- a/src/Oceans/prescribed_ocean.jl
+++ b/src/Oceans/prescribed_ocean.jl
@@ -10,16 +10,18 @@ using NumericalEarth.EarthSystemModels: AbstractPrescribedComponent
                     density = 1025,
                     heat_capacity = 4000,
                     clock = Clock{FT}(time=0),
-                    sea_surface_temperature = default_prescribed_sst(grid, times),
-                    sea_surface_salinity = default_prescribed_sss(grid, times),
-                    velocities = default_prescribed_velocities(grid, times))
+                    temperature = default_prescribed_temperature(grid, times),
+                    salinity = default_prescribed_salinity(grid, times),
+                    velocities = default_prescribed_velocities(grid, times),
+                    free_surface = default_prescribed_free_surface(grid, times))
 
-A prescribed ocean component for `EarthSystemModel` with sea surface
-temperature, salinity, and velocities prescribed as `FieldTimeSeries`.
+An ocean whose state is prescribed as `FieldTimeSeries` rather than evolved.
 
-The ocean state does not evolve in response to surface fluxes — it follows
-the prescribed data. Surface fluxes are still computed so the atmosphere
-feels the ocean.
+Surface (z-`Nothing`) and volumetric (z-`Center`) fields are selected from the grid's vertical size
+through [`is_three_dimensional`](@ref): a single-level grid builds a surface ocean, the coupling
+component of an `EarthSystemModel`, whose state follows the data while surface fluxes are still
+computed so the atmosphere feels it; a resolved vertical builds a volumetric ocean, the parent of a
+[`nested_ocean_model`](@ref). `free_surface` is two-dimensional either way.
 
 Arguments
 =========
@@ -33,55 +35,66 @@ Keyword Arguments
 - `density`: Seawater density in kg/m³. Default: 1025.
 - `heat_capacity`: Seawater specific heat capacity in J/(kg·K). Default: 4000.
 - `clock`: Clock for tracking ocean time. Default: `Clock{FT}(time=0)`.
-- `sea_surface_temperature`: `FieldTimeSeries` for SST.
-- `sea_surface_salinity`: `FieldTimeSeries` for SSS.
+- `temperature`: `FieldTimeSeries` for temperature.
+- `salinity`: `FieldTimeSeries` for salinity.
 - `velocities`: `NamedTuple` of `FieldTimeSeries` for `(u, v)`.
+- `free_surface`: `FieldTimeSeries` for the free surface displacement.
 """
-mutable struct PrescribedOcean{FT, G, C, T, S, U, TI, R, HC} <: AbstractPrescribedComponent
+mutable struct PrescribedOcean{FT, G, C, T, S, U, E, TI, R, HC} <: AbstractPrescribedComponent
     grid :: G
     clock :: C
-    sea_surface_temperature :: T
-    sea_surface_salinity :: S
+    temperature :: T
+    salinity :: S
     velocities :: U
+    free_surface :: E
     times :: TI
     density :: R
     heat_capacity :: HC
 
-    function PrescribedOcean{FT}(grid::G, clock::C, sst::T, sss::S, u::U, times::TI, ρ::R, cp::HC) where {FT, G, C, T, S, U, TI, R, HC}
-        return new{FT, G, C, T, S, U, TI, R, HC}(grid, clock, sst, sss, u, times, ρ, cp)
+    function PrescribedOcean{FT}(grid::G, clock::C, T::T̃, S::S̃, u::U, η::E, times::TI, ρ::R, cp::HC) where {FT, G, C, T̃, S̃, U, E, TI, R, HC}
+        return new{FT, G, C, T̃, S̃, U, E, TI, R, HC}(grid, clock, T, S, u, η, times, ρ, cp)
     end
 end
 
-function default_prescribed_sst(grid, times)
-    return FieldTimeSeries{Center, Center, Nothing}(grid, times)
+prescribed_ocean_location(grid) = (Center, Center, is_three_dimensional(grid) ? Center : Nothing)
+
+function default_prescribed_temperature(grid, times)
+    LX, LY, LZ = prescribed_ocean_location(grid)
+    return FieldTimeSeries{LX, LY, LZ}(grid, times)
 end
 
-function default_prescribed_sss(grid, times)
-    sss = FieldTimeSeries{Center, Center, Nothing}(grid, times)
-    parent(sss) .= 35
-    return sss
+function default_prescribed_salinity(grid, times)
+    LX, LY, LZ = prescribed_ocean_location(grid)
+    salinity = FieldTimeSeries{LX, LY, LZ}(grid, times)
+    parent(salinity) .= 35
+    return salinity
 end
 
 function default_prescribed_velocities(grid, times)
-    u = FieldTimeSeries{Center, Center, Nothing}(grid, times)
-    v = FieldTimeSeries{Center, Center, Nothing}(grid, times)
+    LX, LY, LZ = prescribed_ocean_location(grid)
+    u = FieldTimeSeries{LX, LY, LZ}(grid, times)
+    v = FieldTimeSeries{LX, LY, LZ}(grid, times)
     return (; u, v)
 end
+
+default_prescribed_free_surface(grid, times) = FieldTimeSeries{Center, Center, Nothing}(grid, times)
 
 function PrescribedOcean(grid, times=[zero(grid)];
                          FT = eltype(grid),
                          density = 1025,
                          heat_capacity = 4000,
                          clock = Clock{FT}(time=0),
-                         sea_surface_temperature = default_prescribed_sst(grid, times),
-                         sea_surface_salinity = default_prescribed_sss(grid, times),
-                         velocities = default_prescribed_velocities(grid, times))
+                         temperature = default_prescribed_temperature(grid, times),
+                         salinity = default_prescribed_salinity(grid, times),
+                         velocities = default_prescribed_velocities(grid, times),
+                         free_surface = default_prescribed_free_surface(grid, times))
 
-    return PrescribedOcean{FT}(grid, 
+    return PrescribedOcean{FT}(grid,
                                clock,
-                               sea_surface_temperature,
-                               sea_surface_salinity,
-                               velocities, 
+                               temperature,
+                               salinity,
+                               velocities,
+                               free_surface,
                                times,
                                convert(FT, density),
                                convert(FT, heat_capacity))
@@ -89,11 +102,12 @@ end
 
 Grids.grid(ocean::PrescribedOcean) = ocean.grid
 
-function Oceananigans.set!(ocean::PrescribedOcean; T=nothing, S=nothing, u=nothing, v=nothing)
-    !isnothing(T) && (parent(ocean.sea_surface_temperature) .= T)
-    !isnothing(S) && (parent(ocean.sea_surface_salinity) .= S)
+function Oceananigans.set!(ocean::PrescribedOcean; T=nothing, S=nothing, u=nothing, v=nothing, η=nothing)
+    !isnothing(T) && (parent(ocean.temperature) .= T)
+    !isnothing(S) && (parent(ocean.salinity) .= S)
     !isnothing(u) && (parent(ocean.velocities.u) .= u)
     !isnothing(v) && (parent(ocean.velocities.v) .= v)
+    !isnothing(η) && (parent(ocean.free_surface) .= η)
     return nothing
 end
 
@@ -125,13 +139,14 @@ function EarthSystemModels.adopt_clock(ocean::PrescribedOcean{FT}, clock) where 
     new_clock = EarthSystemModels.matching_clock(ocean.clock, clock)
     isnothing(new_clock) && return ocean
     EarthSystemModels.warn_clock_coercion(ocean, new_clock)
-    return PrescribedOcean{FT}(ocean.grid, 
+    return PrescribedOcean{FT}(ocean.grid,
                                new_clock,
-                               ocean.sea_surface_temperature,
-                               ocean.sea_surface_salinity,
-                               ocean.velocities, 
+                               ocean.temperature,
+                               ocean.salinity,
+                               ocean.velocities,
+                               ocean.free_surface,
                                ocean.times,
-                               ocean.density, 
+                               ocean.density,
                                ocean.heat_capacity)
 end
 
@@ -139,11 +154,18 @@ EarthSystemModels.reference_density(ocean::PrescribedOcean) = ocean.density
 EarthSystemModels.heat_capacity(ocean::PrescribedOcean) = ocean.heat_capacity
 EarthSystemModels.temperature_units(::PrescribedOcean) = DegreesKelvin()
 
-EarthSystemModels.ocean_temperature(ocean::PrescribedOcean) = ocean.sea_surface_temperature
-EarthSystemModels.ocean_salinity(ocean::PrescribedOcean) = ocean.sea_surface_salinity
-EarthSystemModels.ocean_surface_temperature(ocean::PrescribedOcean) = ocean.sea_surface_temperature
-EarthSystemModels.ocean_surface_salinity(ocean::PrescribedOcean) = ocean.sea_surface_salinity
-EarthSystemModels.ocean_surface_velocities(ocean::PrescribedOcean) = ocean.velocities.u, ocean.velocities.v
+EarthSystemModels.ocean_temperature(ocean::PrescribedOcean) = ocean.temperature
+EarthSystemModels.ocean_salinity(ocean::PrescribedOcean) = ocean.salinity
+
+# The uppermost level of a prescribed series: the field itself when surface-only, its top level when
+# volumetric. The level index stays a range so both forms carry the same `(Nx, Ny, 1, Nt)` shape.
+surface_level(series) = (kᴺ = size(series.grid, 3); view(series, :, :, kᴺ:kᴺ, :))
+surface_level(series::FieldTimeSeries{<:Any, <:Any, Nothing}) = series
+
+EarthSystemModels.ocean_surface_temperature(ocean::PrescribedOcean) = surface_level(ocean.temperature)
+EarthSystemModels.ocean_surface_salinity(ocean::PrescribedOcean) = surface_level(ocean.salinity)
+EarthSystemModels.ocean_surface_velocities(ocean::PrescribedOcean) =
+    surface_level(ocean.velocities.u), surface_level(ocean.velocities.v)
 
 #####
 ##### InterfaceComputations interface
@@ -151,16 +173,16 @@ EarthSystemModels.ocean_surface_velocities(ocean::PrescribedOcean) = ocean.veloc
 
 function EarthSystemModels.InterfaceComputations.ComponentExchanger(ocean::PrescribedOcean, exchange_grid)
     grid = ocean.grid
-    T = CenterField(grid)
-    S = CenterField(grid)
-    u = CenterField(grid)
-    v = CenterField(grid)
+    T = Field{Center, Center, Nothing}(grid)
+    S = Field{Center, Center, Nothing}(grid)
+    u = Field{Center, Center, Nothing}(grid)
+    v = Field{Center, Center, Nothing}(grid)
 
     # Initialize from the first time snapshot
-    interior(T) .= interior(ocean.sea_surface_temperature)[:, :, :, 1]
-    interior(S) .= interior(ocean.sea_surface_salinity)[:, :, :, 1]
-    interior(u) .= interior(ocean.velocities.u)[:, :, :, 1]
-    interior(v) .= interior(ocean.velocities.v)[:, :, :, 1]
+    interior(T) .= interior(ocean.temperature)[:, :, end:end, 1]
+    interior(S) .= interior(ocean.salinity)[:, :, end:end, 1]
+    interior(u) .= interior(ocean.velocities.u)[:, :, end:end, 1]
+    interior(v) .= interior(ocean.velocities.v)[:, :, end:end, 1]
 
     return ComponentExchanger((; u, v, T, S), nothing)
 end
@@ -172,10 +194,10 @@ function EarthSystemModels.interpolate_state!(exchanger, grid, ocean::Prescribed
     # For single-time data (constant), time index 1 is always correct.
     # TODO: proper temporal interpolation for multi-time prescribed data.
     n = 1
-    interior(exchanger.state.T) .= interior(ocean.sea_surface_temperature)[:, :, :, n]
-    interior(exchanger.state.S) .= interior(ocean.sea_surface_salinity)[:, :, :, n]
-    interior(exchanger.state.u) .= interior(ocean.velocities.u)[:, :, :, n]
-    interior(exchanger.state.v) .= interior(ocean.velocities.v)[:, :, :, n]
+    interior(exchanger.state.T) .= interior(ocean.temperature)[:, :, end:end, n]
+    interior(exchanger.state.S) .= interior(ocean.salinity)[:, :, end:end, n]
+    interior(exchanger.state.u) .= interior(ocean.velocities.u)[:, :, end:end, n]
+    interior(exchanger.state.v) .= interior(ocean.velocities.v)[:, :, end:end, n]
     return nothing
 end
 
@@ -191,10 +213,18 @@ function Oceananigans.TimeSteppers.time_step!(ocean::PrescribedOcean, Δt)
     tick!(ocean.clock, Δt)
     time = Time(ocean.clock.time)
 
-    update_field_time_series!(ocean.sea_surface_temperature, time)
-    update_field_time_series!(ocean.sea_surface_salinity, time)
+    update_prescribed_ocean_series!(ocean, time)
+
+    return nothing
+end
+
+# Reposition every prescribed series to `time`. Shared with the nested-ocean exchanger, which advances
+# the parent's window ahead of the child's step rather than after it.
+function update_prescribed_ocean_series!(ocean::PrescribedOcean, time)
+    update_field_time_series!(ocean.temperature, time)
+    update_field_time_series!(ocean.salinity, time)
     update_field_time_series!(ocean.velocities.u, time)
     update_field_time_series!(ocean.velocities.v, time)
-
+    update_field_time_series!(ocean.free_surface, time)
     return nothing
 end

--- a/test/test_nested_ocean.jl
+++ b/test/test_nested_ocean.jl
@@ -1,0 +1,200 @@
+include("runtests_setup.jl")
+
+using NumericalEarth
+using NumericalEarth.Bathymetry: bottom_height_from_mask
+using NumericalEarth.EarthSystemModels: ocean_surface_temperature, ocean_surface_velocities,
+                                        ocean_temperature
+using NumericalEarth.Grids: is_three_dimensional
+using NumericalEarth.NestedOceans: parent_ocean_variables
+using Oceananigans
+using Oceananigans.BoundaryConditions: GravityWaveRadiation, NormalFlow, NormalRadiation,
+                                       SurfaceWaveRadiation, Value
+using Oceananigans.Operators: Azᶜᶜᶜ
+using Oceananigans.TimeSteppers: time_step!, update_state!
+using Oceananigans.Units: days
+using Test
+
+const SIDES = (:west, :east, :south, :north)
+
+# A resting parent bracketing the child, with a uniform zonal throughflow.
+function nesting_test_parent(; u = 0.1, T = 15, S = 35, η = 0)
+    grid = LatitudeLongitudeGrid(size = (12, 12, 6),
+                                 longitude = (-2, 2), latitude = (28, 32), z = (-1000, 0),
+                                 topology = (Bounded, Bounded, Bounded))
+
+    parent_ocean = PrescribedOcean(grid, [0.0, 10days])
+    set!(parent_ocean; T, S, u, v = 0, η)
+
+    return parent_ocean
+end
+
+# The halo must cover the default WENO(order=7) tracer advection stencil.
+nesting_test_child_grid() = LatitudeLongitudeGrid(size = (20, 20, 6), halo = (7, 7, 7),
+                                                  longitude = (-1, 1), latitude = (29, 31), z = (-1000, 0),
+                                                  topology = (Bounded, Bounded, Bounded))
+
+@testset "PrescribedOcean: grid vertical size selects surface vs volumetric fields" begin
+    surface_grid = LatitudeLongitudeGrid(size = (8, 8, 1), longitude = (-1, 1), latitude = (-1, 1),
+                                         z = (-1, 0), topology = (Bounded, Bounded, Bounded))
+    surface_ocean = PrescribedOcean(surface_grid)
+
+    @test !is_three_dimensional(surface_grid)
+    @test location(surface_ocean.temperature)  == (Center, Center, Nothing)
+    @test location(surface_ocean.salinity)     == (Center, Center, Nothing)
+    @test location(surface_ocean.velocities.u) == (Center, Center, Nothing)
+    @test location(surface_ocean.free_surface) == (Center, Center, Nothing)
+
+    volumetric_grid = LatitudeLongitudeGrid(size = (8, 8, 4), longitude = (-1, 1), latitude = (-1, 1),
+                                            z = (-100, 0), topology = (Bounded, Bounded, Bounded))
+    volumetric_ocean = PrescribedOcean(volumetric_grid)
+
+    @test is_three_dimensional(volumetric_grid)
+    @test location(volumetric_ocean.temperature)  == (Center, Center, Center)
+    @test location(volumetric_ocean.velocities.v) == (Center, Center, Center)
+
+    # The free surface stays two-dimensional either way.
+    @test location(volumetric_ocean.free_surface) == (Center, Center, Nothing)
+
+    # Salinity defaults to 35 in both forms.
+    @test all(interior(volumetric_ocean.salinity) .== 35)
+
+    @test keys(parent_ocean_variables(volumetric_ocean)) == (:u, :v, :T, :S, :η)
+
+    # `ocean_temperature` is the full state; `ocean_surface_temperature` is its uppermost level, and both
+    # forms carry the same `(Nx, Ny, 1, Nt)` surface shape so the coupling interface sees one layout.
+    @test size(ocean_temperature(volumetric_ocean)) == (8, 8, 4, 1)
+    @test size(ocean_surface_temperature(volumetric_ocean)) == (8, 8, 1, 1)
+    @test size(ocean_surface_temperature(surface_ocean)) == (8, 8, 1, 1)
+    @test size(first(ocean_surface_velocities(volumetric_ocean))) == (8, 8, 1, 1)
+end
+
+@testset "nested_ocean_model: boundary conditions land where the nest needs them" begin
+    model = nested_ocean_model(nesting_test_parent(), nesting_test_child_grid())
+    child = model.child
+
+    free_surface = child.free_surface
+    U_bcs = free_surface.barotropic_velocities.U.boundary_conditions
+    V_bcs = free_surface.barotropic_velocities.V.boundary_conditions
+
+    # Flather on the barotropic transport, on the sides each component is normal to.
+    for side in (:west, :east)
+        @test getproperty(U_bcs, side).classification isa NormalFlow
+        @test getproperty(U_bcs, side).classification.scheme isa GravityWaveRadiation
+    end
+
+    for side in (:south, :north)
+        @test getproperty(V_bcs, side).classification isa NormalFlow
+        @test getproperty(V_bcs, side).classification.scheme isa GravityWaveRadiation
+    end
+
+    # Oceananigans pairs the Chapman companion on the free surface at exactly the Flather sides.
+    η_bcs = free_surface.displacement.boundary_conditions
+    for side in SIDES
+        @test getproperty(η_bcs, side).classification isa Value
+        @test getproperty(η_bcs, side).classification.scheme isa SurfaceWaveRadiation
+    end
+
+    # Tracers radiate as Value; momentum is NormalFlow on its own side and Value on the tangential ones.
+    for side in SIDES
+        for name in (:T, :S)
+            bc = getproperty(child.tracers[name].boundary_conditions, side)
+            @test bc.classification isa Value
+            @test bc.classification.scheme isa NormalRadiation
+        end
+
+        u_bc = getproperty(child.velocities.u.boundary_conditions, side)
+        v_bc = getproperty(child.velocities.v.boundary_conditions, side)
+        @test u_bc.classification isa (side in (:west, :east) ? NormalFlow : Value)
+        @test v_bc.classification isa (side in (:south, :north) ? NormalFlow : Value)
+        @test u_bc.classification.scheme isa NormalRadiation
+        @test v_bc.classification.scheme isa NormalRadiation
+    end
+
+    # The coupled interface reaches the child through the wrapper.
+    @test NumericalEarth.underlying_ocean_model(model) === child
+end
+
+@testset "OceanStateExchanger: barotropic exterior integrates over the child's column" begin
+    u₀ = 0.1
+    depth = 1000
+    model = nested_ocean_model(nesting_test_parent(; u = u₀), nesting_test_child_grid())
+    update_state!(model)
+
+    for side in SIDES
+        slabs = getproperty(model.exchanger.boundaries, side)
+
+        # Zonal sides see the full transport u₀ * H; meridional sides see none (the parent v is zero).
+        expected = side in (:west, :east) ? u₀ * depth : 0
+        @test all(isapprox.(Array(slabs.U), expected; atol = 1e-10))
+        @test all(Array(slabs.η) .== 0)
+    end
+
+    # One slab entry per boundary-face cell, indexed as `condition[i, k, 1]` by `getbc`.
+    Nx, Ny, _ = size(model.child.grid)
+    @test size(model.exchanger.boundaries.west.U)  == (Ny, 1, 1)
+    @test size(model.exchanger.boundaries.south.U) == (Nx, 1, 1)
+end
+
+@testset "nested_ocean_model: a quiescent parent leaves the child unchanged" begin
+    T₀, S₀ = 15.0, 35.0
+    model = nested_ocean_model(nesting_test_parent(; u = 0, T = T₀, S = S₀), nesting_test_child_grid())
+    set!(model, T = T₀, S = S₀, u = 0, v = 0)
+    update_state!(model)
+
+    for n in 1:20
+        time_step!(model, 60.0)
+    end
+
+    T = Array(interior(model.child.tracers.T))
+    S = Array(interior(model.child.tracers.S))
+
+    # Radiating boundaries on all four sides must not manufacture a gradient out of a uniform state.
+    @test maximum(abs, T .- T₀) < 1e-10
+    @test maximum(abs, S .- S₀) < 1e-10
+
+    # `NestedModel` advances the parent to the child's time.
+    @test model.parent.clock.time == model.clock.time == 20 * 60.0
+end
+
+@testset "nested_ocean_model: Flather holds the volume budget without a transport correction" begin
+    u₀ = 0.1
+    model = nested_ocean_model(nesting_test_parent(; u = u₀), nesting_test_child_grid(); coriolis = nothing)
+    set!(model, T = 15, S = 35, u = u₀, v = 0)
+    update_state!(model)
+
+    grid = model.child.grid
+    Nx, Ny, _ = size(grid)
+    cell_area = [Azᶜᶜᶜ(i, j, 1, grid) for i in 1:Nx, j in 1:Ny]
+    displacement = model.child.free_surface.displacement
+    total_volume() = sum(Array(interior(displacement))[:, :, 1] .* cell_area)
+
+    initial_volume = total_volume()
+    for n in 1:200
+        time_step!(model, 60.0)
+    end
+
+    # The Flather condition generates a compensating transport whenever the child's free surface drifts
+    # from the parent's, so a steady throughflow leaves the domain volume alone to within a nanometer of
+    # mean sea level over ~3 hours.
+    mean_sea_level_drift = (total_volume() - initial_volume) / sum(cell_area)
+    @test abs(mean_sea_level_drift) < 1e-6
+end
+
+@testset "bottom_height_from_mask: the seafloor a dataset marks with missing values" begin
+    # z runs bottom-to-top: k = 1 is the deepest cell, whose bottom face sits at -100.
+    grid = LatitudeLongitudeGrid(size = (3, 1, 4), longitude = (-1, 1), latitude = (-1, 1),
+                                 z = (-100, 0), topology = (Bounded, Bounded, Bounded))
+
+    mask = Field{Center, Center, Center}(grid, Bool)
+
+    # Column 1 wet throughout, column 2 wet only in the top two cells, column 3 dry throughout.
+    interior(mask)[1, 1, :] .= false
+    interior(mask)[2, 1, :] .= (true, true, false, false)
+    interior(mask)[3, 1, :] .= true
+
+    bottom_height = Array(interior(bottom_height_from_mask(mask)))
+
+    @test bottom_height[1, 1, 1] == -100   # full column
+    @test bottom_height[2, 1, 1] == -50    # deepest wet cell is k = 3, whose bottom face is at -50
+    @test bottom_height[3, 1, 1] == 0      # a dry column sits at sea level
+end

--- a/test/test_nested_simulation.jl
+++ b/test/test_nested_simulation.jl
@@ -7,7 +7,8 @@ using Oceananigans: prognostic_fields
 using Oceananigans.OutputReaders: interpolating_time_indices, memory_index
 using Oceananigans.Units: Time
 using Oceananigans.Fields: location
-using Oceananigans.BoundaryConditions: ValueBoundaryCondition, FieldBoundaryConditions, fill_halo_regions!
+using Oceananigans.BoundaryConditions: ValueBoundaryCondition, FieldBoundaryConditions, NormalRadiation,
+                                       fill_halo_regions!
 using Oceananigans.Forcings: MultipleForcings
 using Breeze
 using Breeze: ThermodynamicConstants, dry_air_gas_constant, vapor_gas_constant, CompressibleDynamics,
@@ -147,13 +148,19 @@ end
         @test getproperty(bcs.T, side).classification isa Oceananigans.BoundaryConditions.Value
     end
 
-    # Passing `schemes` for a non-NormalFlowBC field must error.
-    @test_throws ArgumentError parent_boundary_conditions(
-        child_grid;
-        variables = (T = T_fts,),
-        sides     = (:west, :east),
-        schemes   = (T = nothing,),
-        bc_types  = (T = ValueBoundaryCondition,))
+    # A scheme is carried by the classification, so it reaches a `ValueBoundaryCondition` field too —
+    # the tracer side of an open-boundary radiation condition.
+    radiating = parent_boundary_conditions(child_grid;
+                                           variables = (T = T_fts,),
+                                           sides     = (:west, :east),
+                                           schemes   = (T = NormalRadiation(),),
+                                           bc_types  = (T = ValueBoundaryCondition,))
+
+    for side in (:west, :east)
+        classification = getproperty(radiating.T, side).classification
+        @test classification isa Oceananigans.BoundaryConditions.Value
+        @test classification.scheme isa NormalRadiation
+    end
 end
 
 # Regression for the GPU `InvalidIRError` in the prognostic-parent path: a LIVE model


### PR DESCRIPTION
This PR introduces a nested ocean model that facilitates the use of open boundary conditions with realistic data. It is also a precursor for implementing 2-way coupling of hydrostatic and non-hydrostatic small scale ocean models which are interesting for localized ocean interventions.

Still needs a bit of work as it is a bit rough around the edges.