### PR TITLE
Write output already low-pass filtered in time: LowPassFilter

### DIFF
--- a/docs/src/NumericalEarth.bib
+++ b/docs/src/NumericalEarth.bib
@@ -515,3 +515,13 @@
   year={1977},
   doi={10.1175/1520-0485(1977)007<0952:IMITUO>2.0.CO;2}
 }
+
+@article{duchon1979lanczos,
+  title={Lanczos filtering in one and two dimensions},
+  author={Duchon, Claude E},
+  journal={Journal of Applied Meteorology},
+  volume={18},
+  number={8},
+  pages={1016--1022},
+  year={1979}
+}

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -4,10 +4,13 @@ export MixedLayerDepthField, MixedLayerDepthOperand
 export meridional_heat_transport
 export net_ocean_heat_flux, sea_ice_ocean_heat_flux, atmosphere_ocean_heat_flux, frazil_heat_flux,
        net_ocean_freshwater_flux, sea_ice_ocean_freshwater_flux, atmosphere_ocean_freshwater_flux
+export LowPassFilter
 
+using DocStringExtensions: TYPEDSIGNATURES
+using JLD2: jldopen
 using KernelAbstractions: @index, @kernel
 
-using Oceananigans: Oceananigans
+using Oceananigans: Oceananigans, AbstractDiagnostic, AbstractModel
 using Oceananigans.AbstractOperations: Integral
 using Oceananigans.Architectures: architecture
 using Oceananigans.BoundaryConditions: DiscreteBoundaryFunction, FieldBoundaryConditions, fill_halo_regions!
@@ -15,7 +18,9 @@ using Oceananigans.Fields: Field, FieldStatus, ZeroField
 using Oceananigans.Grids: new_data, inactive_cell, znode, Face, Center, OrthogonalSphericalShellGrid
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
 using Oceananigans.Models: buoyancy_operation
-using Oceananigans.Utils: launch!
+using Oceananigans.OutputWriters: JLD2Writer, fetch_output
+using Oceananigans.Units: days, hours
+using Oceananigans.Utils: AbstractSchedule, IterationInterval, launch!, prettytime
 
 using ..EarthSystemModels: EarthSystemModel, NoSeaIceInterfaceModel,
                            NoOceanInterfaceModel, NoInterfaceModel
@@ -24,5 +29,6 @@ using ..Oceans: MultipleFluxes
 include("mixed_layer_depth.jl")
 include("meridional_heat_transport.jl")
 include("interface_fluxes.jl")
+include("low_pass_filter.jl")
 
 end # module

--- a/src/Diagnostics/low_pass_filter.jl
+++ b/src/Diagnostics/low_pass_filter.jl
@@ -1,0 +1,136 @@
+mutable struct LowPassFilter{FT} <: AbstractSchedule
+    interval :: FT
+    window :: FT
+    cutoff :: FT
+    next_frame :: Int # frame k is centered at k * interval; 0 before the first time step
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return a schedule for `JLD2Writer` that writes its outputs low-pass filtered in time, one frame
+every `interval`. Each frame averages an output over a `window` centered on the frame time with
+the weights of a Lanczos filter [Duchon (1979)](@cite duchon1979lanczos),
+
+    w(τ) = sinc(2τ / cutoff) sinc(2τ / window),    |τ| ≤ window / 2,
+
+which pass periods longer than `cutoff` and remove shorter ones. The defaults remove the diurnal
+and semidiurnal tides.
+
+Frames fall on multiples of `interval` and are stamped with their center time; each is written
+`window / 2` after it. Frames whose window starts before the first time step are not written, so
+a simulation picked up from a checkpoint writes its first frame `window / 2` after the checkpoint.
+
+```jldoctest
+using NumericalEarth
+using Oceananigans.Units
+
+LowPassFilter(1day)
+
+# output
+LowPassFilter(interval=1 day, window=5 days, cutoff=1.667 days)
+```
+"""
+function LowPassFilter(interval; window = 5days, cutoff = 40hours)
+    interval, window, cutoff = promote(interval, window, cutoff)
+    return LowPassFilter(interval, window, cutoff, 0)
+end
+
+Base.summary(filter::LowPassFilter) = string("LowPassFilter(interval=", prettytime(filter.interval),
+                                             ", window=", prettytime(filter.window),
+                                             ", cutoff=", prettytime(filter.cutoff), ")")
+
+Base.show(io::IO, filter::LowPassFilter) = print(io, summary(filter))
+
+(filter::LowPassFilter)(model) = filter.next_frame > 0 &&
+                                 model.clock.time >= filter.next_frame * filter.interval + filter.window / 2
+
+Oceananigans.prognostic_state(::LowPassFilter) = nothing
+Oceananigans.restore_prognostic_state!(::LowPassFilter, ::Nothing) = nothing
+
+mutable struct LowPassFilteredOutput{O, A, FT} <: AbstractDiagnostic
+    operand :: O
+    filter :: LowPassFilter{FT}
+    schedule :: IterationInterval
+    sums :: Vector{A}     # weighted sum of the operand, one per frame in progress
+    weights :: Vector{FT} # sum of the weights in each
+    frames :: Vector{Int} # frame each sum belongs to
+    previous_time :: FT
+end
+
+function LowPassFilteredOutput(operand, filter, model)
+    output = fetch_output(operand, model)
+    frames_in_progress = floor(Int, filter.window / filter.interval) + 1
+    sums = [zero(output) for _ in 1:frames_in_progress]
+    FT = typeof(filter.interval)
+    return LowPassFilteredOutput(operand, filter, IterationInterval(1), sums,
+                                 zeros(FT, frames_in_progress), zeros(Int, frames_in_progress),
+                                 convert(FT, model.clock.time))
+end
+
+function Oceananigans.run_diagnostic!(output::LowPassFilteredOutput, model)
+    filter = output.filter
+    t = model.clock.time
+    Δt = t - output.previous_time
+    output.previous_time = t
+
+    # Frames whose window starts before the first time step seen are never complete.
+    if filter.next_frame == 0
+        filter.next_frame = ceil(Int, (t + filter.window / 2) / filter.interval)
+    end
+
+    φ = fetch_output(output.operand, model)
+    first_frame = max(filter.next_frame, ceil(Int, (t - filter.window / 2) / filter.interval))
+    last_frame = floor(Int, (t + filter.window / 2) / filter.interval)
+
+    for frame in first_frame:last_frame
+        n = mod(frame, length(output.sums)) + 1
+
+        if output.frames[n] != frame
+            output.frames[n] = frame
+            output.sums[n] .= 0
+            output.weights[n] = 0
+        end
+
+        τ = t - frame * filter.interval
+        w = sinc(2τ / filter.cutoff) * sinc(2τ / filter.window) * Δt
+        output.sums[n] .+= w .* φ
+        output.weights[n] += w
+    end
+
+    return nothing
+end
+
+function (output::LowPassFilteredOutput)(model)
+    n = mod(output.filter.next_frame, length(output.sums)) + 1
+    return output.sums[n] ./ output.weights[n]
+end
+
+Oceananigans.Grids.grid(output::LowPassFilteredOutput) = Oceananigans.Grids.grid(output.operand)
+Oceananigans.Fields.location(output::LowPassFilteredOutput) = Oceananigans.Fields.location(output.operand)
+Oceananigans.Fields.indices(output::LowPassFilteredOutput) = Oceananigans.Fields.indices(output.operand)
+
+function Oceananigans.OutputWriters.time_average_outputs(filter::LowPassFilter, outputs::NamedTuple, model)
+    filtered_outputs = NamedTuple(name => LowPassFilteredOutput(outputs[name], filter, model) for name in keys(outputs))
+    return filter, filtered_outputs
+end
+
+function Oceananigans.Simulations.add_dependency!(diagnostics, output::LowPassFilteredOutput)
+    output ∈ values(diagnostics) || (diagnostics[Symbol(:LowPassFilteredOutput, length(diagnostics) + 1)] = output)
+    return nothing
+end
+
+function Oceananigans.write_output!(writer::JLD2Writer{<:Any, <:LowPassFilter}, model::AbstractModel)
+    filter = writer.schedule
+    filter(model) || return nothing # only frames whose window is complete
+    @invoke Oceananigans.write_output!(writer::JLD2Writer, model::Any)
+
+    jldopen(writer.filepath, "r+"; writer.jld2_kw...) do file
+        address = "timeseries/t/$(model.clock.iteration)"
+        delete!(file, address)
+        file[address] = filter.next_frame * filter.interval
+    end
+
+    filter.next_frame += 1
+    return nothing
+end

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -152,6 +152,7 @@ export
     initialize!,
     net_ocean_heat_flux, sea_ice_ocean_heat_flux, atmosphere_ocean_heat_flux,
     net_ocean_freshwater_flux, sea_ice_ocean_freshwater_flux, atmosphere_ocean_freshwater_flux,
+    LowPassFilter,
     meridional_heat_transport,
     location,
     native_grid,

--- a/test/test_low_pass_filter.jl
+++ b/test/test_low_pass_filter.jl
@@ -1,0 +1,55 @@
+include("runtests_setup.jl")
+
+using Oceananigans.Units
+using Oceananigans.OutputWriters: Checkpointer
+
+# A slow signal carrying a semidiurnal and a diurnal tide.
+slow_signal(t) = 2 + cos(2π * t / 10days)
+tidal_signal(t) = slow_signal(t) + cos(2π * t / 12.4206hours) + cos(2π * t / 25.8193hours)
+@inline tidal_signal(i, j, k, grid, clock) = tidal_signal(clock.time)
+
+function filtered_tidal_signal(arch, directory; stop_time, pickup = false)
+    grid = RectilinearGrid(arch; size = (1, 1, 1), extent = (1, 1, 1))
+    model = NonhydrostaticModel(grid)
+    c = Field(KernelFunctionOperation{Center, Center, Center}(tidal_signal, grid, model.clock))
+
+    simulation = Simulation(model; Δt = 10minutes, stop_time)
+    simulation.output_writers[:daily] = JLD2Writer(model, (; c); dir = directory, filename = "daily",
+                                                   schedule = LowPassFilter(1day), overwrite_existing = pickup === false)
+    simulation.output_writers[:weekly] = JLD2Writer(model, (; c); dir = directory, filename = "weekly",
+                                                    schedule = LowPassFilter(7days), overwrite_existing = pickup === false)
+    simulation.output_writers[:checkpointer] = Checkpointer(model; dir = directory, prefix = "checkpoint",
+                                                            schedule = TimeInterval(5days))
+    run!(simulation; pickup)
+
+    daily = FieldTimeSeries(simulation.output_writers[:daily].filepath, "c")
+    weekly = FieldTimeSeries(simulation.output_writers[:weekly].filepath, "c")
+    return daily, weekly
+end
+
+frames(series) = Array(interior(series))[1, 1, 1, :]
+
+for arch in test_architectures
+    A = typeof(arch)
+
+    @testset "LowPassFilter removes the tides [$A]" begin
+        daily, weekly = filtered_tidal_signal(arch, mktempdir(); stop_time = 20days)
+
+        @test daily.times ≈ (3:17) .* days
+        @test weekly.times ≈ [7days, 14days]
+        @test maximum(abs, frames(daily) .- slow_signal.(daily.times)) < 0.02
+        @test maximum(abs, frames(weekly) .- slow_signal.(weekly.times)) < 0.02
+    end
+
+    @testset "LowPassFilter continues across a checkpoint [$A]" begin
+        continuous, _ = filtered_tidal_signal(arch, mktempdir(); stop_time = 20days)
+
+        directory = mktempdir()
+        filtered_tidal_signal(arch, directory; stop_time = 10days)
+        restarted, _ = filtered_tidal_signal(arch, directory; stop_time = 20days,
+                                             pickup = Int(5days / 10minutes))
+
+        @test restarted.times ≈ continuous.times
+        @test frames(restarted) == frames(continuous)
+    end
+end


### PR DESCRIPTION
## What this adds

`LowPassFilter(interval; window = 5days, cutoff = 40hours)` is a schedule for `JLD2Writer` that writes its
outputs low-pass filtered in time. Each frame is a Lanczos-weighted average of the output over a window
centered on the frame time ([Duchon 1979](https://doi.org/10.1175/1520-0450(1979)018%3C1016:LFIOAT%3E2.0.CO;2)).
The use case is long regional runs with tides: writing daily or 5-day output with the tides already removed,
instead of writing hourly output and filtering it afterwards.

```julia
simulation.output_writers[:daily] = JLD2Writer(model, outputs; filename = "daily",
                                               schedule = LowPassFilter(1day))

simulation.output_writers[:five_day] = JLD2Writer(model, outputs; filename = "five_day",
                                                  schedule = LowPassFilter(5days; window = 10days, cutoff = 10days))
```

Amplitude passed by each (5-minute sampling):

| | M2 | S2 | K1 | O1 | 2 d | 5 d | 10 d | 27.6 d |
|---|---|---|---|---|---|---|---|---|
| daily: 5 d window, 40 h cutoff | 0.05% | 0.01% | −0.45% | −1.1% | 78% | 101% | 100% | 100% |
| 5-day: 10 d window, 10 d cutoff | 0.0% | 0.0% | 0.0% | 0.0% | 0.0% | 5% | 56% | 93% |

## How it works

- Frames fall on multiples of `interval`, are stamped with their center time, and are written `window / 2`
  after it.
- Each output keeps `floor(window / interval) + 1` running sums (6 for the daily example, 3 for the 5-day
  one), advanced every time step with weights `sinc(2τ / cutoff) sinc(2τ / window) Δt` and normalized by
  their own sum, so variable time steps are handled and a constant passes exactly.
- Nothing is checkpointed. Frames whose window starts before the first time step are skipped, so a run picked
  up from a checkpoint taken one window before the end of the previous run continues the frame sequence.
- It plugs into the same Oceananigans machinery as `AveragedTimeInterval` (`time_average_outputs`,
  `add_dependency!`), so file splitting and output indices work unchanged.

## Points for review

- Oceananigans stamps every frame with the clock time, so `write_output!` for this schedule calls
  Oceananigans' own write and then restamps the frame with its center time. If Oceananigans schedules could
  supply the output time, that step would go away.
- Oceananigans writes every output at iteration 0 regardless of its schedule; frames are written only once
  their window is complete.
- `grid`, `location` and `indices` forward to the filtered output's operand: the JLD2 writer asks for them
  when it sets up the file, as for `WindowedTimeAverage`.
- I searched Oceananigans' `OutputWriters` (only the boxcar `WindowedTimeAverage`) and NumericalEarth's
  `Diagnostics` for existing time filtering and found none.
- JLD2 output and numeric clocks only; NumericalEarth does not use `NetCDFWriter` or `DateTime` clocks.

## Tests

`test/test_low_pass_filter.jl`:

1. A slow signal carrying an M2 and an O1 tide is sampled every 10 minutes for 20 days; daily and weekly
   frames land on their center times and recover the slow signal to within 0.02.
2. A run picked up from a day-5 checkpoint, appending to the same files, writes frames bitwise identical
   to an uninterrupted run.

## Validation

A 140 × 92 × 24 Mid-Atlantic Bight configuration, forced by 10 TPXO10 tidal constituents at the open
boundaries and as a body force, run for 15 days with CATKE and a variable time step (up to 4 minutes).
Sea surface height was written hourly, daily (`LowPassFilter(1day)`) and every 5 days
(`LowPassFilter(5days; window = 10days, cutoff = 10days)`).

- The frames written during the run agree with the same filter applied afterwards to the hourly output:
  4.1 × 10⁻⁵ m rms difference for the daily frames (the filtered signal is 4.1 mm rms) and
  1.5 × 10⁻⁵ m for the 5-day frames. The difference comes from sampling every time step versus every hour.
- A least-squares fit of M2, S2, N2, K1, O1 and Q1 to the hourly output (0.35 m rms) leaves 5.7 × 10⁻⁴ m rms
  after the daily filter, so 0.16% of the tide leaks into the daily frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
