### PR TITLE
Add tidal forcing: astronomical body force and TPXO10 boundary conditions

### DIFF
--- a/docs/src/NumericalEarth.bib
+++ b/docs/src/NumericalEarth.bib
@@ -515,3 +515,50 @@
   year={1977},
   doi={10.1175/1520-0485(1977)007<0952:IMITUO>2.0.CO;2}
 }
+
+@book{schureman1958manual,
+  title={Manual of Harmonic Analysis and Prediction of Tides},
+  author={Schureman, Paul},
+  series={Special Publication 98},
+  publisher={United States Government Printing Office},
+  year={1958}
+}
+
+@book{kowalik2019modern,
+  title={Modern Theory and Practice of Tide Analysis and Tidal Power},
+  author={Kowalik, Zygmunt and Luick, John},
+  publisher={Austides Consulting},
+  address={Adelaide, Australia},
+  year={2019}
+}
+
+@article{egbert2002efficient,
+  title={Efficient inverse modeling of barotropic ocean tides},
+  author={Egbert, Gary D and Erofeeva, Svetlana Y},
+  journal={Journal of Atmospheric and Oceanic Technology},
+  volume={19},
+  number={2},
+  pages={183--204},
+  year={2002},
+  doi={10.1175/1520-0426(2002)019<0183:EIMOBO>2.0.CO;2}
+}
+
+@article{flather1976tidal,
+  title={A tidal model of the north-west European continental shelf},
+  author={Flather, Roger A},
+  journal={M{\'e}moires de la Soci{\'e}t{\'e} Royale des Sciences de Li{\`e}ge},
+  volume={10},
+  pages={141--164},
+  year={1976}
+}
+
+@article{chapman1985numerical,
+  title={Numerical treatment of cross-shelf open boundaries in a barotropic coastal ocean model},
+  author={Chapman, David C},
+  journal={Journal of Physical Oceanography},
+  volume={15},
+  number={8},
+  pages={1060--1075},
+  year={1985},
+  doi={10.1175/1520-0485(1985)015<1060:NTOCSO>2.0.CO;2}
+}

--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -417,6 +417,7 @@ include("GloBFP3D/GloBFP3D.jl")
 include("GHSL/GHSL.jl")
 include("CopernicusLandAlbedo/CopernicusLandAlbedo.jl")
 include("WorldCover/WorldCover.jl")
+include("TPXO/TPXO.jl")
 
 using .ETOPO
 using .ECCO
@@ -439,6 +440,7 @@ using .GloBFP3D
 using .GHSL
 using .CopernicusLandAlbedo
 using .WorldCover
+using .TPXO
 
 function dataset_modules()
     modules = Module[]

--- a/src/DataWrangling/TPXO/TPXO.jl
+++ b/src/DataWrangling/TPXO/TPXO.jl
@@ -1,0 +1,107 @@
+module TPXO
+
+export TPXO10Atlas
+
+using DocStringExtensions: TYPEDSIGNATURES
+using NCDatasets: Dataset
+using Oceananigans.Fields: Field, interior
+using Oceananigans.Grids: Bounded, Center, Face, Flat, LatitudeLongitudeGrid
+
+using NumericalEarth.Oceans: Oceans
+using ..DataWrangling: DataWrangling, AbstractStaticDataset, BoundingBox, inpaint_mask!
+
+download_TPXO_cache::String = ""
+function __init__()
+    global download_TPXO_cache = DataWrangling.download_cache("TPXO10")
+end
+
+"""
+    TPXO10Atlas()
+
+The TPXO10-atlas-v2 solution for the barotropic tide, on a 1/30° grid
+[Egbert and Erofeeva (2002)](@cite egbert2002efficient).
+
+TPXO is licensed, so its files cannot be downloaded: request them at https://www.tpxo.net, then
+unpack `grid_tpxo10atlas_v2.nc` together with the elevation and transport files of the constituents
+to be forced into `dir`.
+"""
+struct TPXO10Atlas <: AbstractStaticDataset end
+
+DataWrangling.default_download_directory(::TPXO10Atlas) = download_TPXO_cache
+
+constituent_path(::TPXO10Atlas, dir, variable, constituent) =
+    joinpath(dir, string(variable, "_", lowercase(string(constituent)), "_tpxo10_atlas_30_v2.nc"))
+
+atlas_grid_path(::TPXO10Atlas, dir) = joinpath(dir, "grid_tpxo10atlas_v2.nc")
+
+# The atlas grid is an Arakawa C-grid: `lon_u` holds the western faces of the elevation cells and
+# `lat_v` their southern faces, so it maps onto a `LatitudeLongitudeGrid` cell for cell.
+function atlas_window(dataset, dir, region)
+    path = atlas_grid_path(dataset, dir)
+    isfile(path) ||
+        error("$path not found; TPXO10 is licensed and must be downloaded by hand from https://www.tpxo.net")
+
+    λᶠ, φᶠ = Dataset(path) do atlas
+        (atlas["lon_u"][:], atlas["lat_v"][:])
+    end
+
+    west, east = mod.(region.longitude, 360)
+    south, north = region.latitude
+
+    columns = searchsortedlast(λᶠ, west):(searchsortedfirst(λᶠ, east) - 1)
+    rows = searchsortedlast(φᶠ, south):(searchsortedfirst(φᶠ, north) - 1)
+
+    grid = LatitudeLongitudeGrid(size = (length(columns), length(rows)),
+                                 longitude = (λᶠ[first(columns)], λᶠ[last(columns) + 1]),
+                                 latitude = (φᶠ[first(rows)], φᶠ[last(rows) + 1]),
+                                 topology = (Bounded, Bounded, Flat))
+
+    return (; grid, rows, columns)
+end
+
+# The atlas stores its arrays as [latitude, longitude], and land as exactly zero in both parts.
+function atlas_field(window, path, names, (LX, LY), conversion)
+    columns = LX === Face ? (first(window.columns):(last(window.columns) + 1)) : window.columns
+    rows = LY === Face ? (first(window.rows):(last(window.rows) + 1)) : window.rows
+
+    real_data, imaginary_data = Dataset(path) do atlas
+        map(name -> permutedims(atlas[name][rows, columns]), names)
+    end
+
+    mask = Field{LX, LY, Nothing}(window.grid, Bool)
+    interior(mask, :, :, 1) .= @. (real_data == 0) & (imaginary_data == 0)
+
+    real_part, imaginary_part = map((real_data, imaginary_data)) do data
+        field = Field{LX, LY, Nothing}(window.grid)
+        interior(field, :, :, 1) .= conversion .* data
+        inpaint_mask!(field, mask)
+        field
+    end
+
+    constants = Field{LX, LY, Nothing}(window.grid, ComplexF64)
+    interior(constants, :, :, 1) .= complex.(interior(real_part, :, :, 1), interior(imaginary_part, :, :, 1))
+
+    return constants
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Read the harmonic constants of `constituent` over a window of the atlas covering `grid`. Elevations
+are stored in millimeters and transports in centimeters squared per second.
+"""
+function Oceans.tidal_atlas_constants(dataset::TPXO10Atlas, grid, constituent;
+                                      dir = DataWrangling.default_download_directory(dataset))
+
+    window = atlas_window(dataset, dir, BoundingBox(grid; padding = 1))
+    elevation_path = constituent_path(dataset, dir, "h", constituent)
+    transport_path = constituent_path(dataset, dir, "u", constituent)
+
+    sea_surface_height = atlas_field(window, elevation_path, ("hRe", "hIm"), (Center, Center), 1e-3)
+    eastward_transport = atlas_field(window, transport_path, ("uRe", "uIm"), (Face, Center), 1e-4)
+    northward_transport = atlas_field(window, transport_path, ("vRe", "vIm"), (Center, Face), 1e-4)
+
+    return (; sea_surface_height, eastward_transport, northward_transport)
+end
+
+end # module TPXO

--- a/src/NumericalEarth.jl
+++ b/src/NumericalEarth.jl
@@ -134,6 +134,7 @@ export
     ERA5HourlyPressureLevels, ERA5MonthlyPressureLevels,
     ERA5HourlyLand, ERA5MonthlyLand,
     ORCAOne, ORCAQuarter, ORCATwelfth,
+    TPXO10Atlas,
     ORCAGrid,
     OpenLandMapSoilDB,
     GlobalBuildingFootprints3D, building_morphometry,
@@ -147,6 +148,7 @@ export
     hydrostatic_pressure_from_surface,
     ocean_simulation,
     river_mouth_vertical_diffusivity,
+    TidalHarmonics, tidal_forcing, tidal_boundary_conditions,
     sea_ice_simulation,
     default_sea_ice,
     initialize!,
@@ -260,7 +262,7 @@ include("NestedModels/NestedModels.jl")   # last: wraps a parent + a child (any 
 
 using .Grids
 using .DataWrangling
-using .DataWrangling: ETOPO, ECCO, GLORYS, EN4, WOA, JRA55
+using .DataWrangling: ETOPO, ECCO, GLORYS, EN4, WOA, JRA55, TPXO
 using .Bathymetry
 using .InitialConditions
 using .EarthSystemModels
@@ -274,6 +276,7 @@ using .EarthSystemModels: ComponentInterfaces, MomentumRoughnessLength, ScalarRo
 using .NestedModels
 using .NestedModels: NestedModel, NestedSimulation, nested_atmosphere_model, parent_boundary_conditions
 using .DataWrangling.ETOPO
+using .DataWrangling.TPXO
 using .DataWrangling.ECCO
 using .DataWrangling.GLORYS
 using .DataWrangling.EN4

--- a/src/Oceans/Oceans.jl
+++ b/src/Oceans/Oceans.jl
@@ -1,21 +1,28 @@
 module Oceans
 
 export ocean_simulation, river_mouth_vertical_diffusivity, SlabOcean, PrescribedOcean,
-       TwoColorRadiation, ChlorophyllOptics, absorption_coefficient, equivalent_chlorophyll
+       TwoColorRadiation, ChlorophyllOptics, absorption_coefficient, equivalent_chlorophyll,
+       TidalHarmonics, tidal_forcing, tidal_boundary_conditions
 
 using Adapt: Adapt, adapt
+using Dates: Dates, DateTime
+using DocStringExtensions: TYPEDSIGNATURES
 using KernelAbstractions: @kernel, @index
 using Oceananigans: Oceananigans
 using Oceananigans.AbstractOperations: KernelFunctionOperation
+using Oceananigans.Architectures: architecture, on_architecture
 using Oceananigans.Advection: WENO, WENOVectorInvariant
 using Oceananigans.BoundaryConditions: DefaultBoundaryCondition, DiscreteBoundaryFunction,
                                        FieldBoundaryConditions, FluxBoundaryCondition,
+                                       GravityWaveRadiationBoundaryCondition,
+                                       SurfaceWaveRadiationBoundaryCondition,
                                        IMEXFluxBoundaryCondition, IMEXFlux, getbc
 using Oceananigans.BuoyancyFormulations: SeawaterBuoyancy
 using Oceananigans.Coriolis: HydrostaticSphericalCoriolis
-using Oceananigans.Fields: Field, CenterField, set!, interior
-using Oceananigans.Forcings: MultipleForcings, DiscreteForcing
-using Oceananigans.Grids: Grids, inactive_node, Face, Center, xspacings, yspacings, znodes, RectilinearGrid
+using Oceananigans.Fields: Field, CenterField, set!, interior, interpolate
+using Oceananigans.Forcings: Forcing, MultipleForcings, DiscreteForcing
+using Oceananigans.Grids: Grids, inactive_node, Face, Center, xspacings, yspacings, znodes, RectilinearGrid,
+                          λnode, φnode, λnodes, φnodes
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, ImmersedBoundaryCondition, MutableGridOfSomeKind
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: HydrostaticFreeSurfaceModel
 using Oceananigans.Models.HydrostaticFreeSurfaceModels.SplitExplicitFreeSurfaces: SplitExplicitFreeSurface
@@ -65,6 +72,7 @@ default_or_override(override, alternative_default=nothing) = override
 include("slab_ocean.jl")
 include("prescribed_ocean.jl")
 include("barotropic_potential_forcing.jl")
+include("tides.jl")
 include("radiative_forcing.jl")
 include("multiple_surface_fluxes.jl")
 include("ocean_simulation.jl")

--- a/src/Oceans/tides.jl
+++ b/src/Oceans/tides.jl
@@ -1,0 +1,271 @@
+#####
+##### Tidal astronomy
+#####
+
+const astronomical_epoch = DateTime(1900, 1, 1)
+
+# Mean solar angle and mean longitudes of the Moon, the Sun and the lunar perigee at
+# `astronomical_epoch` [°], followed by a right angle, and their rates [° per Julian century].
+const astronomical_angles = (0, 277.0248, 280.1895, 334.3853, 90)
+const astronomical_rates = (360 * 36525, 481267.8906, 36000.7689, 4069.0340, 0)
+
+# Longitude of the Moon's ascending node [°] and its rate [° per Julian century]
+const lunar_node_angle = 259.1568
+const lunar_node_rate = -1934.1420
+
+"""
+Properties of the tidal constituents: the equilibrium `amplitude` [m], which is the
+Cartwright–Tayler amplitude times the Love number factor ``1 + k - h`` of an elastic Earth; the
+multiples of the angles in `astronomical_angles` that sum to the equilibrium argument ``V``; and the
+`nodal` coefficients, with which the 18.6-year cycle of the lunar node longitude ``N`` modulates
+amplitude as ``f = f₀ + f₁ \\cos N`` and phase as ``u = u₁ \\sin N`` [°].
+
+The first multiple is the constituent's species: 2 semidiurnal, 1 diurnal, 0 long-period.
+
+References: Schureman (1958), [Kowalik and Luick (2019)](@cite kowalik2019modern).
+"""
+const tidal_constituents = (
+    M2 = (amplitude = 0.242334 * 0.693, argument = ( 2, -2,  2,  0,  0), nodal = (f₀ = 1.000, f₁ = -0.037, u₁ =  -2.1)),
+    S2 = (amplitude = 0.112743 * 0.693, argument = ( 2,  0,  0,  0,  0), nodal = (f₀ = 1.000, f₁ =  0.000, u₁ =   0.0)),
+    N2 = (amplitude = 0.046397 * 0.693, argument = ( 2, -3,  2,  1,  0), nodal = (f₀ = 1.000, f₁ = -0.037, u₁ =  -2.1)),
+    K2 = (amplitude = 0.030684 * 0.693, argument = ( 2,  0,  2,  0,  0), nodal = (f₀ = 1.024, f₁ =  0.286, u₁ = -17.7)),
+    K1 = (amplitude = 0.141565 * 0.736, argument = ( 1,  0,  1,  0,  1), nodal = (f₀ = 1.006, f₁ =  0.115, u₁ =  -8.9)),
+    O1 = (amplitude = 0.100661 * 0.695, argument = ( 1, -2,  1,  0, -1), nodal = (f₀ = 1.009, f₁ =  0.187, u₁ =  10.8)),
+    P1 = (amplitude = 0.046848 * 0.706, argument = ( 1,  0, -1,  0, -1), nodal = (f₀ = 1.000, f₁ =  0.000, u₁ =   0.0)),
+    Q1 = (amplitude = 0.019273 * 0.695, argument = ( 1, -3,  1,  1, -1), nodal = (f₀ = 1.009, f₁ =  0.187, u₁ =  10.8)),
+    Mf = (amplitude = 0.042041 * 0.693, argument = ( 0,  2,  0,  0,  0), nodal = (f₀ = 1.043, f₁ =  0.414, u₁ = -23.7)),
+    Mm = (amplitude = 0.022191 * 0.693, argument = ( 0,  1,  0, -1,  0), nodal = (f₀ = 1.000, f₁ = -0.130, u₁ =   0.0)),
+)
+
+struct TidalHarmonics{N, FT, C}
+    constituents :: C
+    reference_date :: DateTime
+    frequencies :: NTuple{N, FT}
+    phases :: NTuple{N, FT}
+    nodal_factors :: NTuple{N, FT}
+    equilibrium_amplitudes :: NTuple{N, FT}
+    species :: NTuple{N, Int}
+    ramp_time :: FT
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+The astronomical tide of `constituents` at `reference_date`: their frequencies ``ω`` and the phases
+``V + u`` that the equilibrium arguments and the nodal corrections reach at that date. Model time is
+seconds from `reference_date`, so a constituent of amplitude ``A`` and phase lag ``G`` contributes
+``f A \\cos(ω t + V + u - G)``.
+
+The available constituents are the eight primary astronomical ones, `:M2`, `:S2`, `:N2`, `:K2`,
+`:K1`, `:O1`, `:P1` and `:Q1`, and the two dominant long-period ones, `:Mf` and `:Mm`. A shelf
+generates the compound and overtides internally, so those are not offered.
+
+`ramp_time` eases the tide in from rest as ``\\tanh(t / T)``, which a basin started impulsively needs
+to avoid ringing its gravest gravity mode.
+
+A single `TidalHarmonics` feeds both `tidal_forcing` and `tidal_boundary_conditions`, which keeps
+the astronomical tide and the boundary tide in phase with each other.
+
+```jldoctest
+using NumericalEarth
+using Dates
+
+TidalHarmonics(DateTime(2019, 4, 1); constituents = (:M2, :K1))
+
+# output
+TidalHarmonics at 2019-04-01T00:00:00 with M2, K1
+```
+"""
+function TidalHarmonics(reference_date::DateTime;
+                        constituents = keys(tidal_constituents),
+                        ramp_time = 0)
+
+    names = Tuple(Symbol(constituent) for constituent in constituents)
+    properties = Tuple(tidal_constituents[name] for name in names)
+
+    centuries = Dates.value(reference_date - astronomical_epoch) / (86_400_000 * 36_525)
+    angles = astronomical_angles .+ astronomical_rates .* centuries
+    node = lunar_node_angle + lunar_node_rate * centuries
+
+    FT = Oceananigans.defaults.FloatType
+    frequencies = Tuple(FT(deg2rad(sum(p.argument .* astronomical_rates)) / (36_525 * 86_400)) for p in properties)
+    phases = Tuple(FT(deg2rad(mod(sum(p.argument .* angles) + p.nodal.u₁ * sind(node), 360))) for p in properties)
+    nodal_factors = Tuple(FT(p.nodal.f₀ + p.nodal.f₁ * cosd(node)) for p in properties)
+    equilibrium_amplitudes = Tuple(FT(p.amplitude) for p in properties)
+    species = Tuple(first(p.argument) for p in properties)
+
+    return TidalHarmonics(names, reference_date, frequencies, phases, nodal_factors,
+                          equilibrium_amplitudes, species, FT(ramp_time))
+end
+
+Adapt.adapt_structure(to, harmonics::TidalHarmonics) =
+    TidalHarmonics(nothing,
+                   harmonics.reference_date,
+                   harmonics.frequencies,
+                   harmonics.phases,
+                   harmonics.nodal_factors,
+                   harmonics.equilibrium_amplitudes,
+                   harmonics.species,
+                   harmonics.ramp_time)
+
+Base.summary(harmonics::TidalHarmonics) =
+    string("TidalHarmonics at ", harmonics.reference_date, " with ", join(harmonics.constituents, ", "))
+
+Base.show(io::IO, harmonics::TidalHarmonics) = print(io, summary(harmonics))
+
+@inline tidal_ramp(harmonics, t) = ifelse(harmonics.ramp_time > 0, tanh(t / harmonics.ramp_time), one(t))
+
+#####
+##### The equilibrium tide and its body force
+#####
+
+# Elevation [m] of the equilibrium tide at a cell center. The latitude structure of a constituent
+# follows from its species: cos²φ semidiurnal, sin2φ diurnal, and ½ - 3/2 sin²φ long-period.
+@inline function equilibrium_tide(i, j, k, grid, clock, harmonics)
+    λ = deg2rad(λnode(i, j, k, grid, Center(), Center(), Center()))
+    φ = deg2rad(φnode(i, j, k, grid, Center(), Center(), Center()))
+    t = clock.time
+
+    η = zero(grid)
+
+    @inbounds for n in eachindex(harmonics.frequencies)
+        s = harmonics.species[n]
+        structure = ifelse(s == 2, cos(φ)^2, ifelse(s == 1, sin(2φ), (1 - 3 * sin(φ)^2) / 2))
+        η += harmonics.nodal_factors[n] * harmonics.equilibrium_amplitudes[n] * structure *
+             cos(harmonics.frequencies[n] * t + harmonics.phases[n] + s * λ)
+    end
+
+    return η
+end
+
+@inline x_tidal_forcing(i, j, k, grid, clock, fields, p) =
+    p.gravitational_acceleration * ∂xᶠᶜᶜ(i, j, k, grid, equilibrium_tide, clock, p.harmonics) *
+    tidal_ramp(p.harmonics, clock.time)
+
+@inline y_tidal_forcing(i, j, k, grid, clock, fields, p) =
+    p.gravitational_acceleration * ∂yᶜᶠᶜ(i, j, k, grid, equilibrium_tide, clock, p.harmonics) *
+    tidal_ramp(p.harmonics, clock.time)
+
+"""
+$(TYPEDSIGNATURES)
+
+Forcing `(u = Fᵘ, v = Fᵛ)` of the astronomical tide of `harmonics` on a spherical grid, which enters
+the momentum equations as ``+g ∇η_{eq}`` for the equilibrium elevation ``η_{eq}``. The gradient is
+taken over the same cells as the model's pressure gradient, so a resting ocean with
+``η = η_{eq}`` stays at rest.
+
+The forcing is barotropic: the astronomical tide pulls uniformly over the column.
+
+```jldoctest
+using NumericalEarth
+using Dates
+
+harmonics = TidalHarmonics(DateTime(2019, 4, 1))
+keys(tidal_forcing(harmonics))
+
+# output
+(:u, :v)
+```
+"""
+function tidal_forcing(harmonics::TidalHarmonics;
+                       gravitational_acceleration = default_gravitational_acceleration)
+
+    parameters = (; harmonics, gravitational_acceleration)
+    u = Forcing(x_tidal_forcing; discrete_form = true, parameters)
+    v = Forcing(y_tidal_forcing; discrete_form = true, parameters)
+
+    return (; u, v)
+end
+
+#####
+##### Boundary conditions from a tidal atlas
+#####
+
+"""
+$(TYPEDSIGNATURES)
+
+Complex harmonic constants of `constituent` over a window of `dataset` covering `grid`, as `Field`s
+on the atlas's own staggered grid: sea surface height [m] at `(Center, Center)`, eastward transport
+[m² s⁻¹] at `(Face, Center)` and northward transport [m² s⁻¹] at `(Center, Face)`. A constant pairs
+with its Greenwich phase lag ``G`` as ``A e^{-i G}``.
+"""
+function tidal_atlas_constants end
+
+# Greenwich phase lags enter as complex constants, so a constituent contributes
+# real(f A e^{-iG} e^{i(ωt + V + u)}) to the transport and to the elevation alike.
+@inline function tidal_transport_and_elevation(i, j, grid, clock, fields, p)
+    t = clock.time
+    harmonics = p.harmonics
+
+    U = zero(grid)
+    η = zero(grid)
+
+    @inbounds for n in eachindex(harmonics.frequencies)
+        rotation = harmonics.nodal_factors[n] * cis(harmonics.frequencies[n] * t + harmonics.phases[n])
+        U += real(p.transport[i, n] * rotation)
+        η += real(p.elevation[i, n] * rotation)
+    end
+
+    ramp = tidal_ramp(harmonics, t)
+
+    return (ramp * U, ramp * η)
+end
+
+boundary_constants(constants, nodes) =
+    [interpolate((mod(λ, 360), φ), constant) for (λ, φ) in nodes, constant in constants]
+
+function flather_condition(harmonics, transport, elevation, architecture, transport_nodes, elevation_nodes)
+    parameters = (; harmonics,
+                  transport = on_architecture(architecture, boundary_constants(transport, transport_nodes)),
+                  elevation = on_architecture(architecture, boundary_constants(elevation, elevation_nodes)))
+
+    return GravityWaveRadiationBoundaryCondition(tidal_transport_and_elevation; discrete_form = true, parameters)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Boundary conditions `(U, V, η)` that drive the barotropic tide of `harmonics` through every lateral
+boundary of `grid`, with the tidal transports and elevations of `dataset`: Flather conditions
+[Flather (1976)](@cite flather1976tidal) on the transports `U` and `V`, which carry the tide in, and
+radiation conditions [Chapman (1985)](@cite chapman1985numerical) on the free surface `η`.
+
+The atlas is sampled at the boundary nodes themselves, the transports where the model holds `U` and
+`V` and the elevations at the adjacent cell centers, which the Flather condition compares with its
+own.
+
+The transports enter unconverted, so the tidal mass flux is preserved where the atlas and the model
+disagree about depth. Keyword arguments reach `dataset`, such as the `dir` it reads.
+"""
+function tidal_boundary_conditions(grid, harmonics::TidalHarmonics, dataset; kw...)
+
+    constants = map(constituent -> tidal_atlas_constants(dataset, grid, constituent; kw...), harmonics.constituents)
+    elevation = map(constant -> constant.sea_surface_height, constants)
+    eastward_transport = map(constant -> constant.eastward_transport, constants)
+    northward_transport = map(constant -> constant.northward_transport, constants)
+
+    arch = architecture(grid)
+    λᶜ, λᶠ = λnodes(grid, Center()), λnodes(grid, Face())
+    φᶜ, φᶠ = φnodes(grid, Center()), φnodes(grid, Face())
+
+    west = flather_condition(harmonics, eastward_transport, elevation, arch,
+                             [(first(λᶠ), φ) for φ in φᶜ], [(first(λᶜ), φ) for φ in φᶜ])
+
+    east = flather_condition(harmonics, eastward_transport, elevation, arch,
+                             [(last(λᶠ), φ) for φ in φᶜ], [(last(λᶜ), φ) for φ in φᶜ])
+
+    south = flather_condition(harmonics, northward_transport, elevation, arch,
+                              [(λ, first(φᶠ)) for λ in λᶜ], [(λ, first(φᶜ)) for λ in λᶜ])
+
+    north = flather_condition(harmonics, northward_transport, elevation, arch,
+                              [(λ, last(φᶠ)) for λ in λᶜ], [(λ, last(φᶜ)) for λ in λᶜ])
+
+    U = FieldBoundaryConditions(grid, (Face(), Center(), nothing); west, east)
+    V = FieldBoundaryConditions(grid, (Center(), Face(), nothing); south, north)
+
+    radiation = SurfaceWaveRadiationBoundaryCondition()
+    η = FieldBoundaryConditions(grid, (Center(), Center(), Face());
+                                west = radiation, east = radiation, south = radiation, north = radiation)
+
+    return (; U, V, η)
+end

--- a/test/test_tides.jl
+++ b/test/test_tides.jl
@@ -1,0 +1,187 @@
+include("runtests_setup.jl")
+
+using NCDatasets: NCDataset, defDim, defVar
+using NumericalEarth.TPXO: TPXO10Atlas
+using Oceananigans.BoundaryConditions: NormalFlowBoundaryCondition, NormalRadiation
+using Oceananigans.Units: hours
+using Statistics: mean
+
+# NOAA CO-OPS published angular speeds [° per hour], an independent source for the frequencies that
+# `TidalHarmonics` builds out of the constituents' astronomical arguments.
+const noaa_speeds = (M2 = 28.9841042, S2 = 30.0,       N2 = 28.4397295, K2 = 30.0821373,
+                     K1 = 15.0410686, O1 = 13.9430356, P1 = 14.9589314, Q1 = 13.3986609,
+                     Mf =  1.0980331, Mm =  0.5443747)
+
+# A TPXO-like atlas holding one constituent, written in the atlas's own layout: [latitude, longitude]
+# integer arrays, elevations in millimeters and transports in centimeters squared per second. The
+# elevation is uniform, and the transports are those of a basin centered on `center` that
+# co-oscillates with it, U = -x ∂η/∂t / 2 and V = -y ∂η/∂t / 2.
+function write_synthetic_atlas(dir, harmonics; amplitude = 0.5, center = (287, 35),
+                               longitude = (282, 292), latitude = (30, 40), resolution = 1//4)
+
+    λᶠ = collect(longitude[1]:resolution:(longitude[2] - resolution))
+    φᶠ = collect(latitude[1]:resolution:(latitude[2] - resolution))
+    Δ = resolution / 2
+
+    NCDataset(joinpath(dir, "grid_tpxo10atlas_v2.nc"), "c") do atlas
+        defDim(atlas, "nx", length(λᶠ))
+        defDim(atlas, "ny", length(φᶠ))
+        defVar(atlas, "lon_u", Float64, ("nx",))[:] = λᶠ
+        defVar(atlas, "lat_v", Float64, ("ny",))[:] = φᶠ
+    end
+
+    ω = first(harmonics.frequencies)
+    λ₀, φ₀ = center
+    eastward(λ, φ) = -Oceananigans.defaults.planet_radius * cosd(φ) * deg2rad(λ - λ₀) * ω * amplitude / 2
+    northward(λ, φ) = -Oceananigans.defaults.planet_radius * deg2rad(φ - φ₀) * ω * amplitude / 2
+
+    constituent = lowercase(string(first(harmonics.constituents)))
+
+    NCDataset(joinpath(dir, "h_$(constituent)_tpxo10_atlas_30_v2.nc"), "c") do atlas
+        defDim(atlas, "nx", length(λᶠ))
+        defDim(atlas, "ny", length(φᶠ))
+        defVar(atlas, "hRe", Int32, ("ny", "nx"))[:, :] .= round(Int32, 1e3 * amplitude)
+        defVar(atlas, "hIm", Int32, ("ny", "nx"))[:, :] .= Int32(0)
+    end
+
+    NCDataset(joinpath(dir, "u_$(constituent)_tpxo10_atlas_30_v2.nc"), "c") do atlas
+        defDim(atlas, "nx", length(λᶠ))
+        defDim(atlas, "ny", length(φᶠ))
+        defVar(atlas, "uRe", Int32, ("ny", "nx"))[:, :] .= Int32(0)
+        defVar(atlas, "vRe", Int32, ("ny", "nx"))[:, :] .= Int32(0)
+        defVar(atlas, "uIm", Int32, ("ny", "nx"))[:, :] =
+            [round(Int32, 1e4 * eastward(λ, φ + Δ)) for φ in φᶠ, λ in λᶠ]
+        defVar(atlas, "vIm", Int32, ("ny", "nx"))[:, :] =
+            [round(Int32, 1e4 * northward(λ + Δ, φ)) for φ in φᶠ, λ in λᶠ]
+    end
+
+    return dir
+end
+
+# Least-squares amplitude and phase lag of `constituent` in a time series, the analysis that a tide
+# gauge record gets, so that a modeled tide can be compared with the constants that forced it.
+function tidal_constants(times, series, harmonics)
+    ω, f, Θ = first(harmonics.frequencies), first(harmonics.nodal_factors), first(harmonics.phases)
+    design = [cos.(ω .* times .+ Θ) sin.(ω .* times .+ Θ) ones(length(times))]
+    cosine, sine, _ = design \ series
+    return (amplitude = sqrt(cosine^2 + sine^2) / f, phase_lag = mod(atan(-sine, cosine), 2π))
+end
+
+@testset "Tidal astronomy" begin
+    harmonics = TidalHarmonics(DateTime(2019, 4, 1))
+
+    speeds = rad2deg.(harmonics.frequencies) .* 3600
+    @test all(isapprox(speed, noaa_speeds[name]; rtol = 1e-7)
+              for (name, speed) in zip(harmonics.constituents, speeds))
+
+    # The phases are the equilibrium arguments at the reference date, so they must advance with the
+    # frequencies: this is what keeps the body force and the boundary tide in phase with each other.
+    later = TidalHarmonics(DateTime(2019, 4, 1, 6))
+    drift = @. mod(later.phases - harmonics.phases - harmonics.frequencies * 6hours, 2π)
+    @test all(@. min(drift, 2π - drift) < 1e-4)
+end
+
+@testset "Equilibrium tidal body force" begin
+    for arch in test_architectures
+        grid = LatitudeLongitudeGrid(arch;
+                                     size = (20, 12, 1),
+                                     longitude = (-78, -68),
+                                     latitude = (35, 41),
+                                     z = (-4000, 0),
+                                     topology = (Bounded, Bounded, Bounded))
+
+        period = 2π / first(TidalHarmonics(DateTime(2019, 4, 1); constituents = (:M2,)).frequencies)
+        harmonics = TidalHarmonics(DateTime(2019, 4, 1); constituents = (:M2,), ramp_time = period)
+
+        model = HydrostaticFreeSurfaceModel(grid;
+                                            forcing = tidal_forcing(harmonics),
+                                            free_surface = SplitExplicitFreeSurface(grid; substeps = 30),
+                                            coriolis = HydrostaticSphericalCoriolis(),
+                                            momentum_advection = nothing,
+                                            tracer_advection = nothing,
+                                            buoyancy = nothing,
+                                            tracers = (),
+                                            closure = nothing)
+
+        simulation = Simulation(model; Δt = 120, stop_time = 5period)
+
+        times = Float64[]
+        elevation = Matrix{Float64}[]
+        function sample!(sim)
+            push!(times, sim.model.clock.time)
+            push!(elevation, Array(interior(sim.model.free_surface.displacement, :, :, 1)))
+        end
+        add_callback!(simulation, sample!, TimeInterval(period / 24))
+
+        run!(simulation)
+
+        # The equilibrium tide of one semidiurnal constituent, written out from its own harmonic
+        # constants: η = f A cos²φ cos(ω t + Θ + 2λ).
+        ω, f, A, Θ = (first(harmonics.frequencies), first(harmonics.nodal_factors),
+                      first(harmonics.equilibrium_amplitudes), first(harmonics.phases))
+        λ, φ = λnodes(grid, Center()), φnodes(grid, Center())
+        equilibrium(t) = [f * A * cosd(φⱼ)^2 * cos(ω * t + Θ + 2 * deg2rad(λᵢ)) for λᵢ in λ, φⱼ in φ]
+
+        anomaly(field) = field .- mean(field)
+        analyzed = findall(t -> t > 3period, times)
+        modeled = [anomaly(elevation[n]) for n in analyzed]
+        expected = [anomaly(equilibrium(times[n])) for n in analyzed]
+
+        # A basin this small responds statically, so it fills to the equilibrium tide itself.
+        gain = sum(sum(m .* e) for (m, e) in zip(modeled, expected)) / sum(sum(abs2, e) for e in expected)
+        @test 0.9 < gain < 1.15
+    end
+end
+
+@testset "Tidal boundary conditions" begin
+    for arch in test_architectures
+        harmonics = TidalHarmonics(DateTime(2019, 4, 1); constituents = (:M2,))
+        period = 2π / first(harmonics.frequencies)
+        amplitude = 0.5
+        dir = write_synthetic_atlas(mktempdir(), harmonics; amplitude)
+
+        grid = LatitudeLongitudeGrid(arch;
+                                     size = (8, 8, 1),
+                                     longitude = (-74, -72),
+                                     latitude = (34, 36),
+                                     z = (-100, 0),
+                                     topology = (Bounded, Bounded, Bounded))
+
+        tide = tidal_boundary_conditions(grid, harmonics, TPXO10Atlas(); dir)
+
+        open_scheme = NormalRadiation(inflow_timescale = Inf, outflow_timescale = Inf)
+        open_flow = NormalFlowBoundaryCondition(0; scheme = open_scheme)
+        u = FieldBoundaryConditions(west = open_flow, east = open_flow)
+        v = FieldBoundaryConditions(south = open_flow, north = open_flow)
+
+        model = HydrostaticFreeSurfaceModel(grid;
+                                            boundary_conditions = merge(tide, (; u, v)),
+                                            free_surface = SplitExplicitFreeSurface(grid; substeps = 30),
+                                            coriolis = HydrostaticSphericalCoriolis(),
+                                            momentum_advection = nothing,
+                                            tracer_advection = nothing,
+                                            buoyancy = nothing,
+                                            tracers = (),
+                                            closure = nothing)
+
+        simulation = Simulation(model; Δt = 120, stop_time = 4period)
+
+        times = Float64[]
+        center = Float64[]
+        i, j = size(grid, 1) ÷ 2, size(grid, 2) ÷ 2
+        function sample!(sim)
+            push!(times, sim.model.clock.time)
+            push!(center, Array(interior(sim.model.free_surface.displacement, i:i, j:j, 1))[1])
+        end
+        add_callback!(simulation, sample!, TimeInterval(period / 24))
+
+        run!(simulation)
+
+        # A basin far shorter than the tidal wavelength co-oscillates with the tide imposed on its
+        # boundaries, so the interior carries the atlas's own amplitude and phase.
+        analyzed = findall(t -> t > 2period, times)
+        constants = tidal_constants(times[analyzed], center[analyzed], harmonics)
+        @test isapprox(constants.amplitude, amplitude; rtol = 0.1)
+        @test min(constants.phase_lag, 2π - constants.phase_lag) < 0.2
+    end
+end


### PR DESCRIPTION
## What this adds

Tidal forcing for regional ocean simulations, as the two halves a tidal run needs:

- `TidalHarmonics(reference_date; constituents, ramp_time)` resolves the astronomy — frequencies,
  equilibrium arguments and nodal corrections — for up to ten constituents.
- `tidal_forcing(harmonics)` is the astronomical body force on `u` and `v`, `+g∇η_eq`.
- `tidal_boundary_conditions(grid, harmonics, dataset)` drives the barotropic tide through the
  lateral boundaries from a tidal atlas: Flather conditions on `U` and `V`, radiation on `η`.
- `TPXO10Atlas()` reads the TPXO10-atlas-v2 harmonic constants.

```julia
harmonics = TidalHarmonics(DateTime(2019, 4, 1); ramp_time = 1day)
tide = tidal_boundary_conditions(grid, harmonics, TPXO10Atlas())

ocean = ocean_simulation(grid;
                        forcing = tidal_forcing(harmonics),
                        boundary_conditions = merge(tide, (u = u_bcs, v = v_bcs)))
```

The body force and the boundary forcing read one `TidalHarmonics`, so they cannot drift out of phase
with each other. If they used different nodal factors or equilibrium arguments, the astronomical tide
and the boundary tide would beat against one another at a rate no amplitude tuning can fix.

## How it works

- The constituent table carries each constituent's equilibrium amplitude and the multiples of the
  astronomical angles that make up its equilibrium argument. The frequencies are the time derivative
  of those same arguments rather than a second column of numbers, so a frequency and its phase cannot
  disagree. The ten constituents are the eight primary astronomical ones plus `Mf` and `Mm`; a shelf
  generates the compound and overtides internally, so forcing them at the boundary as well would
  double-count them.
- The body force is the discrete gradient of the equilibrium elevation, taken over the same cells as
  the model's pressure gradient (`∂xᶠᶜᶜ`, as `BarotropicPotentialForcing` does), so a resting ocean
  with `η = η_eq` stays at rest, and it works on any grid whose nodes carry longitude and latitude.
- The atlas window is read onto its own `LatitudeLongitudeGrid` — TPXO's C-grid maps onto an
  Oceananigans C-grid cell for cell, `lon_u` being the western faces of the elevation cells and
  `lat_v` their southern faces. Land, which the atlas encodes as zero, is filled with
  `inpaint_mask!`, and the boundary nodes are sampled with `Fields.interpolate`, so a model boundary
  point that the atlas puts on land takes the nearest wet constants.
- Harmonic constants stay complex through the whole path, which avoids interpolating a phase (the
  average of 359° and 1° is 180°, the opposite of the right answer). The boundary condition evaluates
  `real(f z e^{i(ωt + V + u)})`, with the constants on the architecture of the grid.
- Transports enter the Flather condition unconverted, preserving the tidal mass flux where the atlas
  and the model disagree about depth.

## TPXO is licensed

TPXO cannot be downloaded automatically: it is distributed under an academic license from
https://www.tpxo.net. `TPXO10Atlas` therefore has no `download` method, and reports in one sentence
where the files are expected if they are missing. The tests use synthetic files in the atlas's own
format instead, so none of this needs the real atlas.

## Tests

`test/test_tides.jl`, all on synthetic data:

1. The frequencies match the NOAA CO-OPS published angular speeds to 1e-7 relative — an independent
   source, and a check on the astronomical arguments the frequencies are derived from. The phases of
   harmonics built six hours apart differ by exactly the frequencies times six hours, which is what
   keeps the body force and the boundary tide on one clock.
2. A closed basin under the M2 body force fills to the equilibrium tide: least-squares gain 1.02 with
   correlation 0.9996 against `f A cos²φ cos(ωt + V + u + 2λ)` written out independently in the test.
3. A basin far shorter than the tidal wavelength, forced through all four boundaries from a synthetic
   atlas, co-oscillates with the atlas tide: interior amplitude 0.52 m against the atlas's 0.50 m,
   phase lag 0.5°. This exercises the file layout, the millimeter and centimeter²/second units, the
   phase convention and the Flather pair together — a unit error in the transports would show up as
   metres of error in the interior.

## Validation

A 140 × 92 × 24 Mid-Atlantic Bight configuration at 1/12°, CATKE with a constant bottom drag
coefficient of 3e-3 and no stratification, forced both at the open boundaries and as a body force.
Two runs, each repeated with this code:

**M2 alone, 10 days**, harmonically analyzed against TPXO over 9669 wet interior cells, with a
six-cell buffer next to the open boundaries excluded:

| depth class | cells | model A | TPXO A | cRMS | cRMS / A |
|---|---|---|---|---|---|
| deep > 1000 m | 7454 | 0.408 | 0.413 | 0.0100 | 0.02 |
| slope 200–1000 m | 318 | 0.426 | 0.419 | 0.0156 | 0.04 |
| shelf 50–200 m | 987 | 0.448 | 0.418 | 0.0549 | 0.13 |
| shelf < 50 m | 910 | 0.563 | 0.469 | 0.3424 | 0.73 |

Domain complex RMS 0.1069 m against a mean amplitude of 0.419 m, amplitude bias +0.008 m, phase bias
+0.46°, phase RMS 8.0°.

**All ten constituents, 15 days**, compared with the full TPXO prediction in the time domain, which
needs no constituent separation because the forcing is known. Over 9674 wet interior cells and a
12.9-day record, `rms(model − TPXO prediction) / rms(prediction)` has a median of 0.026 and a 90th
percentile of 0.114. At the two open-coast gauges the modeled elevation correlates with the TPXO
prediction at 0.996 (Atlantic City) and 0.986 (Duck), and with the NOAA prediction at 0.992 and 0.977,
against a signal of 0.44 m and 0.36 m rms.

Both runs were repeated with this code rather than quoted from the implementation they were first made
with, because the atlas sampling genuinely changed — inpainting and `Fields.interpolate` in place of a
masked bilinear interpolation with a nearest-wet fallback. The skill did not move: the M2 domain
complex RMS is 0.1069 m against 0.1070 m before, every depth class is unchanged, and the ten-constituent
median ratio and 90th percentile are identical to three decimals (0.026 and 0.114). The ported astronomy
agrees with the earlier one to 2.7e-6 in frequency, 0.02° in phase and exactly in amplitude, the
frequency difference being the port's own gain in accuracy, since `Mf` and `Mm` were tabulated to five
digits before.

The shelf figure is a resolution and bottom-boundary-layer question at 12 km, not a forcing one: a
uniform ν_z = 0.1 scores better there but is not a defensible setting, since it would also erode
surface stratification.

## Points for review

- The open boundary conditions on the baroclinic `u` and `v` are left to the caller: they are a
  choice about the interior flow, not about the tide. Without them the barotropic tide still enters,
  but the depth-mean flow and the 3-D flow disagree at the boundary.
- Self-attraction and loading is not included. The scalar approximation is a force `+gβ∇η` on the
  model's own elevation; the better route for a regional model is per-constituent SAL amplitude and
  phase maps added to the equilibrium tide, which the harmonic sum already accommodates. Either is
  additive to this, and for a domain whose tide arrives through the boundaries an assimilative atlas
  already carries the real SAL there.
- Every lateral boundary gets the tidal conditions, including a boundary that is all land; the MAB
  configuration above runs that way.
- The nodal factors are evaluated once, at the reference date. Over a run of a year or more they
  drift, and the harmonics should be rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



